### PR TITLE
Fixed luabind error of AttributeNumeric().

### DIFF
--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -174,7 +174,7 @@ class OSMObject { public:
 		v.set_string_value(val);
 		outputs[outputs.size()-1].addAttribute(key, v);
 	}
-	void AttributeNumeric(const string &key, const float &val) {
+	void AttributeNumeric(const string &key, const float val) {
 		vector_tile::Tile_Value v;
 		v.set_float_value(val);
 		outputs[outputs.size()-1].addAttribute(key, v);


### PR DESCRIPTION
In my case processing hawaii-latest.osm.obf makes the following luabind error (Running on Ubuntsu 14.04 LTS).
This PR fixes the error.

------
Reading hawaii-latest.osm.pbf
lua runtime error: No matching overload found, candidates:
void AttributeNumeric(OSM&,std::string const&,custom [f] const&)
traceback: stack traceback:
	[C]: ?
	[C]: in function 'AttributeNumeric'
	process.lua:138: in function <process.lua:95>
