### PR TITLE
Modified to be able to set compress option (gzip/deflate) in config.json

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -27,7 +27,7 @@ It also includes these global settings:
 * `maxzoom` - the maximum zoom level at which any tiles will be generated
 * `basezoom` - the zoom level for which Tilemaker will generate tiles internally (should usually be the same as `maxzoom`)
 * `include_ids` - whether you want to store the OpenStreetMap IDs for each way/node within your vector tiles
-* `compress` - whether to compress (deflate) vector tiles
+* `compress` - whether to compress vector tiles (Any of "gzip","deflate" or "none"(default))
 * `name`, `version` and `description` - about your project (these are written into the MBTiles file)
 
 A typical config file would look like this:

--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
 		"name": "Tilemaker example",
 		"version": "0.1",
 		"description": "Sample vector tiles for Tilemaker",
-		"compress": true,
+		"compress": "gzip",
 		"metadata": {
 			"json": { "vector_layers": [
 						{ "id": "roads",     "description": "roads",     "fields": {"name":"String","type":"String"}},

--- a/resources/mbx_compatible_config.json
+++ b/resources/mbx_compatible_config.json
@@ -34,7 +34,7 @@
 		"name": "OSM Vector Tiles",
 		"version": "0.1",
 		"description": "Vector Tiles from OSM data, created with tilemaker",
-		"compress": true,
+		"compress": "gzip",
 		"metadata": {
 			"json": { "vector_layers": [
 						{ "id": "road",     "description": "road",     "fields": {"name":"String","type":"String"}},


### PR DESCRIPTION
Modified to specify type of compression in config.json.
Because mapbox vector tile renderer (https://github.com/mapbox/mapbox-gl-native/) 
handles deflated compression only.

NOTE: "compression" value in config.json has been changed from boolean to string.
