### PR TITLE
Add initialization to database class (avoid crash on shutdown)

### DIFF
--- a/include/sqlite_modern_cpp.h
+++ b/include/sqlite_modern_cpp.h
@@ -234,9 +234,9 @@ namespace sqlite {
 
 	class database {
 	private:
-		sqlite3 * _db;
-		bool _connected;
-		bool _ownes_db;
+		sqlite3 * _db = nullptr;
+		bool _connected = false;
+		bool _ownes_db = false;
 	public:
 
 		database() {};


### PR DESCRIPTION
When compiling and debugging on Windows I had some crashes: when no sqlite database output was activated, shutting down non-existent sqlite database caused access violations in this line:
https://github.com/systemed/tilemaker/blob/master/include/sqlite_modern_cpp.h#L264
```c++
		~database() {
			if (_db && _ownes_db) { // <-- _db and _ownes_db happen to be non-zero
				sqlite3_close_v2(_db); // <-- and it crashes here
				_db = nullptr;
			}
		}
```
The suggested fix is trivial :)