### PR TITLE
Support building on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(tilemaker)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+  message(FATAL_ERROR "In-source builds are not allowed, please use a separate build directory.")
+endif()
+
+include_directories(include)
+include_directories(${CMAKE_BINARY_DIR}) # for generated files
+
+find_package(Boost 1.56 REQUIRED COMPONENTS system filesystem program_options)
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+
+find_package(Protobuf REQUIRED)
+include_directories(${PROTOBUF_INCLUDE_DIR})
+
+find_package(SQLite3 REQUIRED)
+include_directories(${SQLITE3_INCLUDE_DIR})
+
+find_package(libshp REQUIRED)
+include_directories(${LIBSHP_INCLUDE_DIR})
+
+find_package(Lua REQUIRED)
+include_directories(${LUA_INCLUDE_DIR})
+
+find_package(Luabind REQUIRED)
+include_directories(${LUABIND_INCLUDE_DIR})
+
+find_package(ZLIB REQUIRED)
+include_directories(${ZLIB_INCLUDE_DIR})
+
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+else()
+  add_definitions(-std=c++11)
+endif()
+
+ADD_CUSTOM_COMMAND(OUTPUT vector_tile.pb.cc vector_tile.pb.h
+                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+		   ARGS --cpp_out ${CMAKE_BINARY_DIR} -I ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/include/vector_tile.proto)
+
+ADD_CUSTOM_COMMAND(OUTPUT osmformat.pb.cc osmformat.pb.h
+                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+		   ARGS --cpp_out ${CMAKE_BINARY_DIR} -I ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/include/osmformat.proto)
+
+add_executable(tilemaker vector_tile.pb.cc osmformat.pb.cc src/tilemaker.cpp)
+target_link_libraries(tilemaker ${Boost_LIBRARIES} ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUABIND_LIBRARIES} ${LUA_LIBRARIES} ${ZLIB_LIBRARY})
+
+install(TARGETS tilemaker RUNTIME DESTINATION bin)

--- a/cmake/FindLuabind.cmake
+++ b/cmake/FindLuabind.cmake
@@ -1,0 +1,75 @@
+# Locate Luabind library
+# This module defines
+#  LUABIND_FOUND, if false, do not try to link to Luabind
+#  LUABIND_LIBRARIES
+#  LUABIND_INCLUDE_DIR, where to find luabind.hpp
+#
+# Note that the expected include convention is
+#  #include <luabind/luabind.hpp>
+# and not
+#  #include <luabind.hpp>
+
+IF( NOT LUABIND_FIND_QUIETLY )
+    MESSAGE(STATUS "Looking for Luabind...")
+ENDIF()
+
+FIND_PATH(LUABIND_INCLUDE_DIR luabind.hpp
+  HINTS
+  $ENV{LUABIND_DIR}
+  PATH_SUFFIXES luabind include/luabind include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /usr
+  /opt/local # DarwinPorts
+  /opt
+)
+
+FIND_LIBRARY(LUABIND_LIBRARY
+  NAMES luabind luabind09
+  HINTS
+  $ENV{LUABIND_DIR}
+  PATH_SUFFIXES lib64 lib
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /usr
+  /opt/local
+  /opt
+)
+
+FIND_LIBRARY(LUABIND_LIBRARY_DBG
+  NAMES luabindd
+  HINTS
+  $ENV{LUABIND_DIR}
+  PATH_SUFFIXES lib64 lib
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /usr
+  /opt/local
+  /opt
+)
+
+IF(LUABIND_LIBRARY)
+    SET( LUABIND_LIBRARIES "${LUABIND_LIBRARY}" CACHE STRING "Luabind Libraries")
+ENDIF(LUABIND_LIBRARY)
+
+INCLUDE(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LUABIND_FOUND to TRUE if
+# all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Luabind  DEFAULT_MSG  LUABIND_LIBRARIES LUABIND_INCLUDE_DIR)
+
+IF( NOT LUABIND_FIND_QUIETLY )
+    IF( LUABIND_FOUND )
+        MESSAGE(STATUS "Found Luabind: ${LUABIND_LIBRARY}" )
+    ENDIF()
+    IF( LUABIND_LIBRARY_DBG )
+        MESSAGE(STATUS "Luabind debug library availible: ${LUABIND_LIBRARY_DBG}")
+    ENDIF()
+ENDIF()
+
+MARK_AS_ADVANCED(LUABIND_INCLUDE_DIR LUABIND_LIBRARIES LUABIND_LIBRARY LUABIND_LIBRARY_DBG)

--- a/cmake/FindSQLite3.cmake
+++ b/cmake/FindSQLite3.cmake
@@ -1,0 +1,87 @@
+# - Try to find Sqlite3
+# Once done this will define
+#
+#  SQLITE3_FOUND - system has Sqlite3
+#  SQLITE3_INCLUDE_DIRS - the Sqlite3 include directory
+#  SQLITE3_LIBRARIES - Link these to use Sqlite3
+#  SQLITE3_DEFINITIONS - Compiler switches required for using Sqlite3
+#
+#  Copyright (c) 2008 Andreas Schneider <mail@cynapses.org>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+
+if (SQLITE3_LIBRARIES AND SQLITE3_INCLUDE_DIRS)
+  # in cache already
+  set(SQLITE3_FOUND TRUE)
+else (SQLITE3_LIBRARIES AND SQLITE3_INCLUDE_DIRS)
+  # use pkg-config to get the directories and then use these values
+  # in the FIND_PATH() and FIND_LIBRARY() calls
+  if (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_MINOR_VERSION} EQUAL 4)
+    include(UsePkgConfig)
+    pkgconfig(sqlite3 _SQLITE3_INCLUDEDIR _SQLITE3_LIBDIR _SQLITE3_LDFLAGS _SQLITE3_CFLAGS)
+  else (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_MINOR_VERSION} EQUAL 4)
+    find_package(PkgConfig)
+    if (PKG_CONFIG_FOUND)
+      pkg_check_modules(_SQLITE3 sqlite3)
+    endif (PKG_CONFIG_FOUND)
+  endif (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_MINOR_VERSION} EQUAL 4)
+  find_path(SQLITE3_INCLUDE_DIR
+    NAMES
+      sqlite3.h
+    PATHS
+      ${_SQLITE3_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+  )
+
+  find_library(SQLITE3_LIBRARY
+    NAMES
+      sqlite3
+    PATHS
+      ${_SQLITE3_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  if (SQLITE3_LIBRARY)
+    set(SQLITE3_FOUND TRUE)
+  endif (SQLITE3_LIBRARY)
+
+  set(SQLITE3_INCLUDE_DIRS
+    ${SQLITE3_INCLUDE_DIR}
+  )
+
+  if (SQLITE3_FOUND)
+    set(SQLITE3_LIBRARIES
+      ${SQLITE3_LIBRARIES}
+      ${SQLITE3_LIBRARY}
+    )
+  endif (SQLITE3_FOUND)
+
+  if (SQLITE3_INCLUDE_DIRS AND SQLITE3_LIBRARIES)
+     set(SQLITE3_FOUND TRUE)
+  endif (SQLITE3_INCLUDE_DIRS AND SQLITE3_LIBRARIES)
+
+  if (SQLITE3_FOUND)
+    if (NOT Sqlite3_FIND_QUIETLY)
+      message(STATUS "Found Sqlite3: ${SQLITE3_LIBRARIES}")
+    endif (NOT Sqlite3_FIND_QUIETLY)
+  else (SQLITE3_FOUND)
+    if (Sqlite3_FIND_REQUIRED)
+      message(FATAL_ERROR "Could not find Sqlite3")
+    endif (Sqlite3_FIND_REQUIRED)
+  endif (SQLITE3_FOUND)
+
+  # show the SQLITE3_INCLUDE_DIRS and SQLITE3_LIBRARIES variables only in the advanced view
+  mark_as_advanced(SQLITE3_INCLUDE_DIRS SQLITE3_LIBRARIES)
+
+endif (SQLITE3_LIBRARIES AND SQLITE3_INCLUDE_DIRS)
+

--- a/cmake/Findlibshp.cmake
+++ b/cmake/Findlibshp.cmake
@@ -1,0 +1,16 @@
+# LIBSHP_FOUND - system has the LIBSHP library
+# LIBSHP_INCLUDE_DIR - the LIBSHP include directory
+# LIBSHP_LIBRARIES - The libraries needed to use LIBSHP
+
+if(LIBSHP_INCLUDE_DIR AND LIBSHP_LIBRARIES)
+  set(LIBSHP_FOUND TRUE)
+else(LIBSHP_INCLUDE_DIR AND LIBSHP_LIBRARIES)
+
+  find_path(LIBSHP_INCLUDE_DIR NAMES shapefil.h PATH_SUFFIXES libshp)
+  find_library(LIBSHP_LIBRARIES NAMES shp shapelib)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(libshp DEFAULT_MSG LIBSHP_INCLUDE_DIR LIBSHP_LIBRARIES)
+
+  mark_as_advanced(LIBSHP_INCLUDE_DIR LIBSHP_LIBRARIES)
+endif(LIBSHP_INCLUDE_DIR AND LIBSHP_LIBRARIES)

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -23,6 +23,9 @@
 #include "rapidjson/filereadstream.h"
 #include "sqlite_modern_cpp.h"
 
+#ifdef _MSC_VER
+typedef unsigned uint;
+#endif
 // Protobuf
 #include "osmformat.pb.h"
 #include "vector_tile.pb.h"


### PR DESCRIPTION
Thank you very much for this good tool!

Usage of C++11 allows simple cross-platform builds. I had to do only one small change (define uint type) to make it compile under Visual Studio 2015.

It would be useful to add cmake build scripts for systems that have libraries in different locations.
For example, osrm and libosmium have them.

cmake will not break the existing Makefile build (special check is included)

The script should also work on Linux/BSD/Macos but this needs additional checking. Commands to build are something like
```bash
git clone https://github.com/alex85k/tilemaker.git
#if merged, git clone https://github.com/systemed/tilemaker.git :)
cd tilemaker
mkdir build && cd build
cmake .. -G "Unix Makefiles"
make
```