### PR TITLE
Make the global data store, and make it available geometry data when processing relations

### DIFF
--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -17,20 +17,22 @@ struct LayerDef {
 class OSMObject { public:
 
 	lua_State *luaState;					// Lua reference
-	map< string, RTree> *indices;			// Spatial indices
+	map<string, RTree> *indices;			// Spatial indices
 	vector<Geometry> *cachedGeometries;		// Cached geometries
 	map<uint,string> *cachedGeometryNames;	// Cached geometry names
 	OSMStore *osmStore;						// Global OSM store
+
 	bool isWay, isRelation;					// Way, node, relation?
 	uint32_t osmID;							// ID of OSM object
 	uint32_t newWayID = 4294967295;			// Decrementing new ID for relations
+
 	int32_t lon1,latp1,lon2,latp2;			// Start/end co-ordinates of OSM object
 	NodeVec *nodeVec;						// node vector
 	WayVec *outerWayVec, *innerWayVec;		// way vectors
 
 	vector<LayerDef> layers;				// List of layers
 	map<string,uint> layerMap;				// Layer->position map
-	vector< vector<uint> > layerOrder;		// Order of (grouped) layers, e.g. [ [0], [1,2,3], [4] ]
+	vector<vector<uint>> layerOrder;		// Order of (grouped) layers, e.g. [ [0], [1,2,3], [4] ]
 
 	vector<OutputObject> outputs;			// All output objects
 
@@ -47,6 +49,8 @@ class OSMObject { public:
 	::google::protobuf::RepeatedField< ::google::protobuf::uint32 > *keysPtr;
 	::google::protobuf::RepeatedField< ::google::protobuf::uint32 > *valsPtr;
 	int tagLength;
+
+	// ----	initialization routines
 
 	OSMObject(lua_State *luaPtr, map< string, RTree> *idxPtr, vector<Geometry> *geomPtr, map<uint,string> *namePtr, OSMStore *storePtr) {
 		luaState = luaPtr;
@@ -76,7 +80,7 @@ class OSMObject { public:
 		}
 		return layerNum;
 	}
-	
+
 	// Read string dictionary from the .pbf
 	void readStringTable(PrimitiveBlock *pbPtr) {
 		uint i;
@@ -93,6 +97,8 @@ class OSMObject { public:
 		}
 	}
 
+	// ----	Helpers provided for main routine
+
 	// Has this object been assigned to any layers?
 	bool empty() {
 		return outputs.size()==0;
@@ -107,7 +113,21 @@ class OSMObject { public:
 			return distance(stringTable.begin(), p);
 		}
 	}
-	
+
+	// ----	Set an osm element to make it accessible from Lua
+
+	// We are now processing a node
+	inline void setNode(uint32_t id, DenseNodes *dPtr, int kvStart, int kvEnd, LatpLon node) {
+		outputs.clear();
+		osmID = id;
+		isWay = false;
+		isRelation = false;
+		denseStart = kvStart;
+		denseEnd = kvEnd;
+		densePtr = dPtr;
+		setLocation(node.lon, node.latp, node.lon, node.latp);
+	}
+
 	// We are now processing a way
 	inline void setWay(Way *way, NodeVec *nodeVecPtr) {
 		outputs.clear();
@@ -121,19 +141,7 @@ class OSMObject { public:
 		setLocation(osmStore->nodes.at(nodeVec->front()).lon, osmStore->nodes.at(nodeVec->front()).latp,
 				osmStore->nodes.at(nodeVec->back()).lon, osmStore->nodes.at(nodeVec->back()).latp);
 	}
-	
-	// We are now processing a node
-	inline void setNode(uint32_t id, DenseNodes *dPtr, int kvStart, int kvEnd, LatpLon node) {
-		outputs.clear();
-		osmID = id;
-		isWay = false;
-		isRelation = false;
-		denseStart = kvStart;
-		denseEnd = kvEnd;
-		densePtr = dPtr;
-		setLocation(node.lon, node.latp, node.lon, node.latp);
-	}
-	
+
 	// We are now processing a relation
 	// (note that we store relations as ways with artificial IDs, and that
 	//  we use decrementing positive IDs to give a bit more space for way IDs)
@@ -149,51 +157,56 @@ class OSMObject { public:
 		innerWayVec = innerWayVecPtr;
 	}
 
-	// Set start/end co-ordinates
+	// Internal: set start/end co-ordinates
 	inline void setLocation(int32_t a, int32_t b, int32_t c, int32_t d) {
 		lon1=a; latp1=b; lon2=c; latp2=d;
 	}
-	
-	// Write this way/node to a vector tile's Layer
-	// Called from Lua
-	void Layer(const string &layerName, bool area) {
-		OutputObject oo(isWay ? (area ? POLYGON : LINESTRING) : POINT,
-						layerMap[layerName],
-						osmID);
-		outputs.push_back(oo);
+
+	// ----	Metadata queries called from Lua
+
+	// Get the ID of the current object
+	string Id() const {
+		return to_string(osmID);
 	}
-	void LayerAsCentroid(const string &layerName) {
-		OutputObject oo(CENTROID,
-						layerMap[layerName],
-						osmID);
-		outputs.push_back(oo);
+
+	// Check if there's a value for a given key
+	bool Holds(const string& key) const {
+		if (tagMap.find(key) == tagMap.end()) { return false; }
+		uint keyNum = tagMap.at(key);
+		if (isWay) {
+			for (uint n=0; n > tagLength; n++) {
+				if (keysPtr->Get(n)==keyNum) { return true; }
+			}
+		} else {
+			for (uint n=denseStart; n<denseEnd; n+=2) {
+				if (densePtr->keys_vals(n)==keyNum) { return true; }
+			}
+		}
+		return false;
 	}
-	
-	// Set attributes in a vector tile's Attributes table
-	// Called from Lua
-	void Attribute(const string &key, const string &val) {
-		if (val.size()==0) { return; }		// don't set empty strings
-		if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
-		vector_tile::Tile_Value v;
-		v.set_string_value(val);
-		outputs[outputs.size()-1].addAttribute(key, v);
+
+	// Get an OSM tag for a given key (or return empty string if none)
+	string Find(const string& key) const {
+		// First, convert the string into a number
+		if (tagMap.find(key) == tagMap.end()) { return ""; }
+		uint keyNum = tagMap.at(key);
+		if (isWay) {
+			// Then see if this number is in the way tags, and return its value if so
+			for (uint n=0; n < tagLength; n++) {
+				if (keysPtr->Get(n)==keyNum) { return stringTable[valsPtr->Get(n)]; }
+			}
+		} else {
+			for (uint n=denseStart; n<denseEnd; n+=2) {
+				if (densePtr->keys_vals(n)==keyNum) { return stringTable[densePtr->keys_vals(n+1)]; }
+			}
+		}
+		return "";
 	}
-	void AttributeNumeric(const string &key, const float val) {
-		if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
-		vector_tile::Tile_Value v;
-		v.set_float_value(val);
-		outputs[outputs.size()-1].addAttribute(key, v);
-	}
-	void AttributeBoolean(const string &key, const bool val) {
-		if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
-		vector_tile::Tile_Value v;
-		v.set_bool_value(val);
-		outputs[outputs.size()-1].addAttribute(key, v);
-	}
-	
-	// Query spatial indexes
-	// Called from Lua
-	// Note - multipolygon relations not supported, will always return false (because we don't know the geometry yet)
+
+	// ----	Spatial queries called from Lua
+
+	// Find intersecting shapefile layer
+	// TODO: multipolygon relations not supported, will always return false
 	vector<string> FindIntersecting(const string &layerName) {
 		vector<uint> ids = findIntersectingGeometries(layerName);
 		return namesOfGeometries(ids);
@@ -240,46 +253,40 @@ class OSMObject { public:
 		return names;
 	}
 
-	// Get an OSM tag for a given key (or return empty string if none)
-	// Called from Lua
-	string Find(const string& key) const {
-		// First, convert the string into a number
-		if (tagMap.find(key) == tagMap.end()) { return ""; }
-		uint keyNum = tagMap.at(key);
-		if (isWay) {
-			// Then see if this number is in the way tags, and return its value if so
-			for (uint n=0; n < tagLength; n++) {
-				if (keysPtr->Get(n)==keyNum) { return stringTable[valsPtr->Get(n)]; }
-			}
-		} else {
-			for (uint n=denseStart; n<denseEnd; n+=2) {
-				if (densePtr->keys_vals(n)==keyNum) { return stringTable[densePtr->keys_vals(n+1)]; }
-			}
-		}
-		return "";
-	}
+	// ----	Requests from Lua to write this way/node to a vector tile's Layer
 
-	// Check if there's a value for a given key
-	// Called from Lua
-	bool Holds(const string& key) const {
-		if (tagMap.find(key) == tagMap.end()) { return false; }
-		uint keyNum = tagMap.at(key);
-		if (isWay) {
-			for (uint n=0; n > tagLength; n++) {
-				if (keysPtr->Get(n)==keyNum) { return true; }
-			}
-		} else {
-			for (uint n=denseStart; n<denseEnd; n+=2) {
-				if (densePtr->keys_vals(n)==keyNum) { return true; }
-			}
-		}
-		return false;
+	// Add layer
+	void Layer(const string &layerName, bool area) {
+		OutputObject oo(isWay ? (area ? POLYGON : LINESTRING) : POINT,
+						layerMap[layerName],
+						osmID);
+		outputs.push_back(oo);
+	}
+	void LayerAsCentroid(const string &layerName) {
+		OutputObject oo(CENTROID,
+						layerMap[layerName],
+						osmID);
+		outputs.push_back(oo);
 	}
 	
-	// Get the ID of the current object
-	// Called from Lua	
-	string Id() const {
-		return to_string(osmID);
+	// Set attributes in a vector tile's Attributes table
+	void Attribute(const string &key, const string &val) {
+		if (val.size()==0) { return; }		// don't set empty strings
+		if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
+		vector_tile::Tile_Value v;
+		v.set_string_value(val);
+		outputs[outputs.size()-1].addAttribute(key, v);
 	}
-	
+	void AttributeNumeric(const string &key, const float val) {
+		if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
+		vector_tile::Tile_Value v;
+		v.set_float_value(val);
+		outputs[outputs.size()-1].addAttribute(key, v);
+	}
+	void AttributeBoolean(const string &key, const bool val) {
+		if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
+		vector_tile::Tile_Value v;
+		v.set_bool_value(val);
+		outputs[outputs.size()-1].addAttribute(key, v);
+	}
 };

--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -286,7 +286,7 @@ class OSMObject { public:
 	}
 
 	// Returns area
-	double Area() const {
+	double Area() {
 		if (!IsClosed()) return 0;
 		if (isRelation) {
 			if (!multiPolygonInited) {

--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -286,15 +286,17 @@ class OSMObject { public:
 	}
 
 	// Returns area
-	double Area() {
+	double Area() const {
 		if (!IsClosed()) return 0;
 		if (isRelation) {
 			if (!multiPolygonInited) {
+				multiPolygonInited = true;
 				multiPolygon = osmStore->wayListMultiPolygon(*outerWayVec, *innerWayVec);
 			}
 			return geom::area(multiPolygon);
 		} else if (isWay) {
 			if (!polygonInited) {
+				polygonInited = true;
 				polygon = osmStore->nodeListPolygon(*nodeVec);
 			}
 			return geom::area(polygon);

--- a/src/osm_store.cpp
+++ b/src/osm_store.cpp
@@ -1,0 +1,254 @@
+/*
+	OSM Store
+
+	Store all of those to be output: latp/lon for nodes, node list for ways, and way list for relations.
+	Only one instance of OSMStore is ever used. It will serve as the global data store. All data determined
+	to be output will be set here, from tilemaker.cpp.
+
+	OSMStore will be mainly used for geometry generation. Geometry generation logic is implemented in this class.
+	These functions are used by osm_output, and can be used by osm_object to provide the geometry information to Lua.
+
+	Internal data structures are encapsulated in NodeStore, WayStore and RelationStore classes.
+	These store can be altered for efficient memory use without global code changes.
+	Such data structures have to return const ForwardInputIterators (only *, ++ and == should be supported).
+
+	Possible future improvements to save memory:
+	- pack WayStore (e.g. zigzag PBF encoding and varint)
+	- combine innerWays and outerWays into one vector, with a single-byte index marking the changeover
+	- use two arrays (sorted keys and elements) instead of map
+*/
+
+//
+// Views of data structures.
+//
+
+template<class NodeIt>
+struct NodeList {
+	NodeIt begin;
+	NodeIt end;
+};
+
+NodeList<NodeVec::const_iterator> makeNodeList(const NodeVec &nodeVec) {
+	return { nodeVec.cbegin(), nodeVec.cend() };
+}
+
+template<class WayIt>
+struct WayList {
+	WayIt outerBegin;
+	WayIt outerEnd;
+	WayIt innerBegin;
+	WayIt innerEnd;
+};
+
+WayList<WayVec::const_iterator> makeWayList( const WayVec &outerWayVec, const WayVec &innerWayVec) {
+	return { outerWayVec.cbegin(), outerWayVec.cend(), innerWayVec.cbegin(), innerWayVec.cend() };
+}
+
+//
+// Internal data structures.
+//
+
+// node store
+class NodeStore {
+	std::unordered_map<uint32_t, LatpLon> mLatpLons;
+
+public:
+	// @brief Lookup a latp/lon pair
+	// @param i OSM ID of a node
+	// @return Latp/lon pair
+	// @exception NotFound
+	LatpLon at(uint32_t i) const {
+		return mLatpLons.at(i);
+	}
+
+	// @brief Return whether a latp/lon pair is on the store.
+	// @param i Any possible OSM ID
+	// @return 1 if found, 0 otherwise
+	// @note This function is named as count for consistent naming with stl functions.
+	size_t count(uint32_t i) const {
+		return mLatpLons.count(i);
+	}
+
+	// @brief Insert a latp/lon pair.
+	// @param i OSM ID of a node
+	// @param coord a latp/lon pair to be inserted
+	// @invariant The OSM ID i must be larger than previously inserted OSM IDs of nodes
+	//            (though unnecessarily for current impl, future impl may impose that)
+	void insert_back(uint32_t i, LatpLon coord) {
+		mLatpLons.emplace(i, coord);
+	}
+
+	// @brief Make the store empty
+	void clear() {
+		mLatpLons.clear();
+	}
+};
+
+// way store
+typedef vector<uint32_t>::const_iterator WayStoreIterator;
+
+class WayStore {
+	std::unordered_map<uint32_t, const vector<uint32_t>> mNodeLists;
+
+public:
+	// @brief Lookup a node list
+	// @param i OSM ID of a way
+	// @return A node list
+	// @exception NotFound
+	NodeList<WayStoreIterator> at(uint32_t i) const {
+		const auto &way = mNodeLists.at(i);
+		return { way.cbegin(), way.cend() };
+	}
+
+	// @brief Return whether a node list is on the store.
+	// @param i Any possible OSM ID
+	// @return 1 if found, 0 otherwise
+	// @note This function is named as count for consistent naming with stl functions.
+	size_t count(uint32_t i) const {
+		return mNodeLists.count(i);
+	}
+
+	// @brief Insert a node list.
+	// @param i OSM ID of a way
+	// @param nodeVec a node vector to be inserted
+	// @invariant The OSM ID i must be larger than previously inserted OSM IDs of ways
+	//            (though unnecessarily for current impl, future impl may impose that)
+	void insert_back(int i, const NodeVec &nodeVec) {
+		mNodeLists.emplace(i, nodeVec);
+	}
+
+	// @brief Make the store empty
+	void clear() {
+		mNodeLists.clear();
+	}
+};
+
+// relation store
+typedef vector<uint32_t>::const_iterator RelationStoreIterator;
+
+class RelationStore {
+	std::unordered_map<uint32_t, const pair<const vector<uint32_t>, const vector<uint32_t>>> mOutInLists;
+
+public:
+	// @brief Lookup a way list
+	// @param i Pseudo OSM ID of a relational way
+	// @return A way list
+	// @exception NotFound
+	WayList<RelationStoreIterator> at(uint32_t i) const {
+		const auto &outInList = mOutInLists.at(i);
+		return { outInList.first.cbegin(), outInList.first.cend(),
+			outInList.second.cbegin(), outInList.second.cend() };
+	}
+
+	// @brief Return whether a way list is on the store.
+	// @param i Any possible OSM ID
+	// @return 1 if found, 0 otherwise
+	// @note This function is named as count for consistent naming with stl functions.
+	size_t count(uint32_t i) const {
+		return mOutInLists.count(i);
+	}
+
+	// @brief Insert a way list.
+	// @param i Pseudo OSM ID of a relation
+	// @param outerWayVec A outer way vector to be inserted
+	// @param innerWayVec A inner way vector to be inserted
+	// @invariant The pseudo OSM ID i must be smaller than previously inserted pseudo OSM IDs of relations
+	//            (though unnecessarily for current impl, future impl may impose that)
+	void insert_front(uint32_t i, const WayVec &outerWayVec, const WayVec &innerWayVec) {
+		mOutInLists.emplace(i, make_pair(outerWayVec, innerWayVec));
+	}
+
+	// @brief Make the store empty
+	void clear() {
+		mOutInLists.clear();
+	}
+};
+
+//
+// OSM store, containing all above.
+//
+struct OSMStore {
+	NodeStore nodes;
+	WayStore ways;
+	RelationStore relations;
+
+	// Relation -> MultiPolygon
+	template<class WayIt>
+	MultiPolygon wayListMultiPolygon(WayList<WayIt> wayList) const {
+		// polygon
+		MultiPolygon mp;
+		if (wayList.outerBegin != wayList.outerEnd) {
+			// main outer way and inners
+			Polygon poly;
+			fillPoints(poly.outer(), ways.at(*wayList.outerBegin++));
+			for (auto it = wayList.innerBegin; it != wayList.innerEnd; ++it) {
+				Ring inner;
+				fillPoints(inner, ways.at(*it));
+				poly.inners().emplace_back(move(inner));
+			}
+			mp.emplace_back(move(poly));
+
+			// additional outer ways - we don't match them up with inners, that shit is insane
+			for (auto it = wayList.outerBegin; it != wayList.outerEnd; ++it) {
+				Polygon outerPoly;
+				fillPoints(outerPoly.outer(), ways.at(*it));
+				mp.emplace_back(move(outerPoly));
+			}
+
+			// fix winding
+			geom::correct(mp);
+		}
+		return mp;
+	}
+
+	MultiPolygon wayListMultiPolygon(uint32_t relId) const {
+		return wayListMultiPolygon(relations.at(relId));
+	}
+
+	MultiPolygon wayListMultiPolygon(const WayVec &outerWayVec, const WayVec &innerWayVec) const {
+		return wayListMultiPolygon(makeWayList(outerWayVec, innerWayVec));
+	}
+
+	// Way -> Polygon
+	template<class NodeIt>
+	Polygon nodeListPolygon(NodeList<NodeIt> nodeList) const {
+		Polygon poly;
+		fillPoints(poly.outer(), nodeList);
+		geom::correct(poly);
+		return poly;
+	}
+
+	Polygon nodeListPolygon(uint32_t wayId) const {
+		return nodeListPolygon(ways.at(wayId));
+	}
+
+	Polygon nodeListPolygon(const NodeVec &nodeVec) const {
+		return nodeListPolygon(makeNodeList(nodeVec));
+	}
+
+	// Way -> Linestring
+	template<class NodeIt>
+	Linestring nodeListLinestring(NodeList<NodeIt> nodeList) const {
+		Linestring ls;
+		fillPoints(ls, nodeList);
+		return ls;
+	}
+
+	Linestring nodeListLinestring(uint32_t wayId) const {
+		return nodeListLinestring(ways.at(wayId));
+	}
+
+	Linestring nodeListLinestring(const NodeVec &nodeVec) const {
+		return nodeListLinestring(makeNodeList(nodeVec));
+	}
+
+private:
+	// helper
+	template<class PointRange, class NodeIt>
+	void fillPoints(PointRange &points, NodeList<NodeIt> nodeList) const {
+		for (auto it = nodeList.begin; it != nodeList.end; ++it) {
+			LatpLon ll = nodes.at(*it);
+			geom::range::push_back(points, geom::make<Point>(ll.lon/10000000.0, ll.latp/10000000.0));
+		}
+	}
+};

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -1,14 +1,8 @@
-struct WayStore {
-	vector <uint32_t> nodelist;
-};
-
 /*
 	OutputObject - any object (node, linestring, polygon) to be outputted to tiles
 
 	Possible future improvements to save memory:
-	- pack WayStore.nodelist (e.g. zigzag PBF encoding)
 	- use a global dictionary for attribute key/values
-	- combine innerWays and outerWays into one vector, with a single-byte index marking the changeover
 */
 
 enum OutputGeometryType { POINT, LINESTRING, POLYGON, CENTROID, CACHED_POINT, CACHED_LINESTRING, CACHED_POLYGON };
@@ -19,8 +13,6 @@ class OutputObject { public:
 	uint_least8_t layer;								// what layer is it in?
 	uint32_t objectID;									// id of way (linestring/polygon) or node (point)
 	map <string, vector_tile::Tile_Value> attributes;	// attributes
-	vector<uint32_t> innerWays;							// multipolygons - ways contained in this
-	vector<uint32_t> outerWays;							//  |
 
 	OutputObject(OutputGeometryType type, uint_least8_t l, uint32_t id) {
 		geomType = type;
@@ -32,50 +24,21 @@ class OutputObject { public:
 		attributes[key]=value;
 	}
 
-	void addRelationWay(uint32_t wayID, bool isInner) {
-		if (isInner) { innerWays.push_back(wayID); }
-		        else { outerWays.push_back(wayID); }
-	}
-
 	// Assemble a linestring or polygon into a Boost geometry, and clip to bounding box
-	// (the linestring code is the easiest way to understand this - the polygon code 
-	//  is greatly complicated by multipolygon support)
 	// Returns a boost::variant -
 	//   POLYGON->MultiPolygon, CENTROID->Point, LINESTRING->MultiLinestring
-	Geometry buildWayGeometry(const node_container_t &nodes,
-	                      map< uint32_t, WayStore > *waysPtr, 
+	Geometry buildWayGeometry(const OSMStore &osmStore,
 	                      TileBbox *bboxPtr, 
 	                      vector<Geometry> &cachedGeometries) const {
-		uint32_t objID = objectID;
-		if (outerWays.size()>0) { objID = outerWays[0]; }
-		vector<Point> points;
 		
 		if (geomType==POLYGON || geomType==CENTROID) {
 			// polygon
-			const vector <uint32_t> &nodelist = waysPtr->at(objID).nodelist;
 			MultiPolygon mp;
-
-			// main outer way and inners
-			Polygon poly;
-			fillPointArray(points, nodelist, nodes);
-			geom::assign_points(poly, points);
-			geom::interior_rings(poly).resize(innerWays.size());
-			for (uint i=0; i<innerWays.size(); i++) {
-				fillPointArray(points, waysPtr->at(innerWays[i]).nodelist, nodes);
-				geom::append(poly, points, i);
+			if (osmStore.ways.count(objectID)) {
+				mp.emplace_back(osmStore.nodeListPolygon(objectID));
+			} else {
+				mp = osmStore.wayListMultiPolygon(objectID);
 			}
-			mp.push_back(poly);
-
-			// additional outer ways - we don't match them up with inners, that shit is insane
-			for (uint i = 1; i < outerWays.size(); i++) {
-				Polygon outer;
-				fillPointArray(points, waysPtr->at(outerWays[i]).nodelist, nodes);
-				geom::assign_points(outer, points);
-				mp.push_back(outer);
-			}
-
-			// fix winding
-			geom::correct(mp);
 
 			// write out
 			if (geomType==CENTROID) {
@@ -94,9 +57,9 @@ class OutputObject { public:
 		} else if (geomType==LINESTRING) {
 			// linestring
 			Linestring ls;
-			const vector <uint32_t> &nodelist = waysPtr->at(objID).nodelist;
-			fillPointArray(points, nodelist, nodes);
-			geom::assign_points(ls, points);
+			if (osmStore.ways.count(objectID)) {
+				ls = osmStore.nodeListLinestring(objectID);
+			}
 			// clip
 			MultiLinestring out;
 			geom::intersection(ls, bboxPtr->clippingBox, out);
@@ -107,16 +70,6 @@ class OutputObject { public:
 		}
 
 		MultiLinestring out; return out; // return a blank geometry
-	}
-
-	// Helper to make a vector of Boost points from a vector of node IDs
-	void fillPointArray(vector<Point> &points, const vector<uint32_t> &nodelist, const node_container_t &nodes) const {
-		points.clear();
-		if (points.capacity() < nodelist.size()) { points.reserve(nodelist.size()); }
-		for (auto node_id : nodelist) {
-			LatpLon ll = nodes.at(node_id);
-			points.emplace_back(geom::make<Point>(ll.lon/10000000.0, ll.latp/10000000.0));
-		}
 	}
 	
 	// Add a node geometry

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -175,6 +175,8 @@ int main(int argc, char* argv[]) {
 		.def("Find", &OSMObject::Find)
 		.def("FindIntersecting", &OSMObject::FindIntersecting, luabind::return_stl_iterator)
 		.def("Intersects", &OSMObject::Intersects)
+		.def("IsClosed", &OSMObject::IsClosed)
+		.def("Area", &OSMObject::Area)
 		.def("Layer", &OSMObject::Layer)
 		.def("LayerAsCentroid", &OSMObject::LayerAsCentroid)
 		.def("Attribute", &OSMObject::Attribute)

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -102,12 +102,13 @@ int main(int argc, char* argv[]) {
 	WayStore &ways = osmStore.ways;
 	RelationStore &relations = osmStore.relations;
 
+	map<string, RTree> indices;						// boost::geometry::index objects for shapefile indices
+	vector<Geometry> cachedGeometries;					// prepared boost::geometry objects (from shapefiles)
+	map<uint, string> cachedGeometryNames;			//  | optional names for each one
+
 	map< uint, unordered_set<OutputObject> > tileIndex;	// objects to be output
 	map< uint32_t, unordered_set<OutputObject> > relationOutputObjects;	// outputObjects for multipolygons (saved for processing later as ways)
 	map< uint32_t, vector<uint32_t> > wayRelations;		// for each way, which relations it's in (therefore we need to keep them)
-	vector<Geometry> cachedGeometries;					// prepared boost::geometry objects (from shapefiles)
-	map< uint, string > cachedGeometryNames;			//  | optional names for each one
-	map< string, RTree > indices;						// boost::geometry::index objects for shapefile indices
 
 	// ----	Read command-line options
 	
@@ -169,16 +170,16 @@ int main(int argc, char* argv[]) {
 	luabind::set_pcall_callback(&lua_error_handler);
 	luabind::module(luaState) [
 	luabind::class_<OSMObject>("OSM")
-		.def("Find", &OSMObject::Find)
-		.def("Holds", &OSMObject::Holds)
 		.def("Id", &OSMObject::Id)
+		.def("Holds", &OSMObject::Holds)
+		.def("Find", &OSMObject::Find)
+		.def("FindIntersecting", &OSMObject::FindIntersecting, luabind::return_stl_iterator)
+		.def("Intersects", &OSMObject::Intersects)
 		.def("Layer", &OSMObject::Layer)
 		.def("LayerAsCentroid", &OSMObject::LayerAsCentroid)
 		.def("Attribute", &OSMObject::Attribute)
 		.def("AttributeNumeric", &OSMObject::AttributeNumeric)
 		.def("AttributeBoolean", &OSMObject::AttributeBoolean)
-		.def("Intersects", &OSMObject::Intersects)
-		.def("FindIntersecting", &OSMObject::FindIntersecting, luabind::return_stl_iterator)
 	];
 	OSMObject osmObject(luaState, &indices, &cachedGeometries, &cachedGeometryNames, &osmStore);
 


### PR DESCRIPTION
Currently OSM IDs for node, way and relations are handled in really ad-hoc manner. This patches fixed this by creating a globally used data structure. This change also make it easy, optimization of internal data structure for efficient memory use.

And the flow of reading .pbf is changed, to make the information about coordinates of nodes available when processing relations.

I added functions to be used by Lua: `IsClosed` and `Area`. `Area` function can be used for multipolygons.