### PR TITLE
Shapefile fix

### DIFF
--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -145,7 +145,7 @@ void readShapefile(string filename,
 			if (shape->nParts > 1) { geom::interior_rings(poly).resize(shape->nParts-1); }
 			for (uint j=0; j<shape->nParts; j++) {
 				fillPointArrayFromShapefile(&points, shape, j);
-				if (j==0) { geom::assign_points(poly, points); }
+				if (j==0) { geom::append(poly, points); }
 				     else { geom::append(poly, points, j-1); }
 			}
 			// clip to bounding box

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -148,6 +148,14 @@ void readShapefile(string filename,
 				if (j==0) { geom::append(poly, points); }
 				     else { geom::append(poly, points, j-1); }
 			}
+			if (!geom::is_valid(poly)) {
+				cerr << "Shapefile entity #" << i << " type " << shapeType << " is invalid";
+				geom::correct(poly);
+				if (geom::is_valid(poly)) {
+					cerr << "... corrected";
+				}
+				cerr << endl;
+			}
 			// clip to bounding box
 			MultiPolygon out;
 			geom::intersection(poly, clippingBox, out);


### PR DESCRIPTION
Fix the handling of shapefile.

Note that `assign_points` makes the size of interior_rings 0. Therefore subsequent appending into each interior_ring has have no effect.