### PR TITLE
Actual length and adaptive simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [] - 2016-02-XX
+
+### Added
+- Add cmake scripts and support MSVC on Windows (@alex85k)
+- Support `way:IsClosed()`, `way:Area()`, `way:Length()`, and `way:ScaleToKm()` (@grafi-tt)
+- Optionally call lua functions `init_function()` and `exit_function()` (@tinoue)
+- Support `simplify_ratio`, and calculate the actual simplify level by
+  the formula `simplify_level * pow(simplify_ratio, (simplify_below-1) - <current zoom>)` (@tinoue)
+- Support `simplify_length`, that is simplify threshold in meters, instead of in degrees (its length changes corresponding to the latitude) (@grafi-tt)
+
+### Changed
+- Optimized SQLite output (@grafi-tt)
+- Refactored OSM object implementation (@grafi-tt)
+
+### Fixed
+- Add initialization to database class (avoid crash on shutdown) (@alex85k)
+- Documentation issues (@AndreMiras, @rory)
+
 ## [1.2.0] - 2015-10-08
 
 ### Added

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -63,7 +63,8 @@ You can add optional parameters to layers:
 
 * `write_to` - write way/nodes to a previously named layer
 * `simplify_below` - simplify ways below this zoom level
-* `simplify_level` - how much to simplify ways (in degrees of longitude)
+* `simplify_level` - how much to simplify ways (in degrees of longitude) on the zoom level `simplify_below-1`
+* `simplify_ratio` - (optional: the default value is 1.0) the actual simplify level will be `simplify_level * pow(simplify_ratio, (simplify_below-1) - <current zoom>)`
 
 Use these options to combine different layer specs within one outputted layer. For example:
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -64,6 +64,7 @@ You can add optional parameters to layers:
 * `write_to` - write way/nodes to a previously named layer
 * `simplify_below` - simplify ways below this zoom level
 * `simplify_level` - how much to simplify ways (in degrees of longitude) on the zoom level `simplify_below-1`
+* `simplify_length` - how much to simplify ways (in kilometers) on the zoom level `simplify_below-1`, preceding `simplify_level`
 * `simplify_ratio` - (optional: the default value is 1.0) the actual simplify level will be `simplify_level * pow(simplify_ratio, (simplify_below-1) - <current zoom>)`
 
 Use these options to combine different layer specs within one outputted layer. For example:

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"layers": {
 		"water": { "minzoom": 11, "maxzoom": 14 },
-		"roads": { "minzoom": 12, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0001 },
+		"roads": { "minzoom": 12, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0001, "simplify_ratio": 2.0 },
 		"buildings": { "minzoom": 14, "maxzoom": 14 },
 		"pois": { "minzoom": 13, "maxzoom": 14 }
 	},

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -27,6 +27,19 @@ uint32_t latpLon2index(LatpLon ll, uint baseZoom) {
 	       latp2tiley(ll.latp/10000000.0, baseZoom);
 }
 
+// Earth's (mean) radius
+// http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
+// http://mathworks.com/help/map/ref/earthradius.html
+constexpr double RadiusMeter = 6371000;
+
+// Convert to actual length
+double degp2meter(double degp, double latp) {
+	return RadiusMeter * deg2rad(degp) * cos(deg2rad(latp2lat(latp)));
+}
+double meter2degp(double meter, double latp) {
+	return rad2deg((1/RadiusMeter) * (meter / cos(deg2rad(latp2lat(latp)))));
+}
+
 // Add intermediate points so we don't skip tiles on long segments
 void insertIntermediateTiles(unordered_set <uint32_t> *tlPtr, int numPoints, LatpLon startLL, LatpLon endLL, uint baseZoom) {
 	numPoints *= 3;	// perhaps overkill, but why not

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -5,21 +5,25 @@ struct LatpLon {
 	int32_t lon;
 };
 
+double deg2rad(double deg) { return (M_PI/180.0) * deg; }
+double rad2deg(double rad) { return (180.0/M_PI) * rad; }
+
 // Project latitude (spherical Mercator)
 // (if calling with raw coords, remember to divide/multiply by 10000000.0)
-inline double lat2latp(double lat) { return 180.0/M_PI * log(tan(M_PI/4.0+lat*(M_PI/180.0)/2.0)); }
-inline double latp2lat(double latp) { return 180.0/M_PI * (2.0 * atan(exp(latp*M_PI/180.0)) - M_PI/2.0); }
+double lat2latp(double lat) { return rad2deg(log(tan(deg2rad(lat+90.0)/2.0))); }
+double latp2lat(double latp) { return rad2deg(atan(exp(deg2rad(latp)))*2.0)-90.0; }
 
 // Tile conversions
-int lon2tilex(double lon, uint z) { return (int)(floor((lon + 180.0) / 360.0 * pow(2.0, z)));  }
-int lat2tiley(double lat, uint z) { return (int)(floor((1.0 - log( tan(lat * M_PI/180.0) + 1.0 / cos(lat * M_PI/180.0)) / M_PI) / 2.0 * pow(2.0, z))); }
-int latp2tiley(double latp, uint z) { return (int)(floor( (180.0 - latp) / 360.0 * pow(2.0,z) )); }
-double tilex2lon(int x, uint z) { return x / pow(2.0, z) * 360.0 - 180; }
-double tiley2lat(int y, uint z) { double n = M_PI - 2.0 * M_PI * y / pow(2.0, z); return 180.0 / M_PI * atan(0.5 * (exp(n) - exp(-n))); }
+uint lon2tilex(double lon, uint z) { return scalbn((lon+180.0) * (1/360.0), (int)z); }
+uint latp2tiley(double latp, uint z) { return scalbn((180.0-latp) * (1/360.0), (int)z); }
+uint lat2tiley(double lat, uint z) { return latp2tiley(lat2latp(lat), z); }
+double tilex2lon(uint x, uint z) { return scalbn(x, -(int)z) * 360.0 - 180.0; }
+double tiley2latp(uint y, uint z) { return 180.0 - scalbn(y, -(int)z) * 360.0; }
+double tiley2lat(uint y, uint z) { return latp2lat(tiley2latp(y, z)); }
 
 // Get a tile index
-inline uint32_t latpLon2index(LatpLon ll, uint baseZoom) {
-	return lon2tilex(ll.lon /10000000.0, baseZoom) * 65536 + 
+uint32_t latpLon2index(LatpLon ll, uint baseZoom) {
+	return lon2tilex(ll.lon /10000000.0, baseZoom) * 65536 +
 	       latp2tiley(ll.latp/10000000.0, baseZoom);
 }
 

--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -285,6 +285,15 @@ class OSMObject { public:
 		}
 	}
 
+	// Scale to (kilo)meter
+	double ScaleToMeter() {
+		return degp2meter(1.0, (latp1/2+latp2/2)/10000000.0);
+	}
+
+	double ScaleToKiloMeter() {
+		return (1/1000.0) * ScaleToMeter();
+	}
+
 	// Returns area
 	double Area() {
 		if (!IsClosed()) return 0;

--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -4,6 +4,7 @@ struct LayerDef {
 	int maxzoom;
 	int simplifyBelow;
 	double simplifyLevel;
+	double simplifyLength;
 	double simplifyRatio;
 };
 
@@ -69,8 +70,9 @@ class OSMObject { public:
 	}
 
 	// Define a layer (as read from the .json file)
-	uint addLayer(string name, int minzoom, int maxzoom, int simplifyBelow, double simplifyLevel, double simplifyRatio, string writeTo) {
-		LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyRatio };
+	uint addLayer(string name, int minzoom, int maxzoom,
+			int simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, string writeTo) {
+		LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio };
 		layers.push_back(layer);
 		uint layerNum = layers.size()-1;
 		layerMap[name] = layerNum;

--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -4,6 +4,7 @@ struct LayerDef {
 	int maxzoom;
 	int simplifyBelow;
 	double simplifyLevel;
+	double simplifyRatio;
 };
 
 /*
@@ -68,8 +69,8 @@ class OSMObject { public:
 	}
 
 	// Define a layer (as read from the .json file)
-	uint addLayer(string name, int minzoom, int maxzoom, int simplifyBelow, double simplifyLevel, string writeTo) {
-		LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel };
+	uint addLayer(string name, int minzoom, int maxzoom, int simplifyBelow, double simplifyLevel, double simplifyRatio, string writeTo) {
+		LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyRatio };
 		layers.push_back(layer);
 		uint layerNum = layers.size()-1;
 		layerMap[name] = layerNum;

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -16,12 +16,12 @@ void fillPointArrayFromShapefile(vector<Point> *points, SHPObject *shape, uint p
 // Add an OutputObject to all tiles between min/max lat/lon
 void addToTileIndexByBbox(OutputObject &oo, map< uint, unordered_set<OutputObject> > &tileIndex, uint baseZoom,
                           double minLon, double minLatp, double maxLon, double maxLatp) {
-	int minTileX =  lon2tilex(minLon, baseZoom);
-	int maxTileX =  lon2tilex(maxLon, baseZoom);
-	int minTileY = latp2tiley(minLatp, baseZoom);
-	int maxTileY = latp2tiley(maxLatp, baseZoom);
-	for (int x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
-		for (int y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
+	uint minTileX =  lon2tilex(minLon, baseZoom);
+	uint maxTileX =  lon2tilex(maxLon, baseZoom);
+	uint minTileY = latp2tiley(minLatp, baseZoom);
+	uint maxTileY = latp2tiley(maxLatp, baseZoom);
+	for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
+		for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
 			uint32_t index = x*65536+y;
 			tileIndex[index].insert(oo);
 		}
@@ -30,12 +30,12 @@ void addToTileIndexByBbox(OutputObject &oo, map< uint, unordered_set<OutputObjec
 
 // Add an OutputObject to all tiles along a polyline
 void addToTileIndexPolyline(OutputObject &oo, map< uint, unordered_set<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls) {
-	int lastx = -1;
-	int lasty;
+	uint lastx = UINT_MAX;
+	uint lasty;
 	for (Linestring::const_iterator jt = ls.begin(); jt != ls.end(); ++jt) {
-		int tilex =  lon2tilex(jt->get<0>(), baseZoom);
-		int tiley = latp2tiley(jt->get<1>(), baseZoom);
-		if (lastx==-1) {
+		uint tilex =  lon2tilex(jt->get<0>(), baseZoom);
+		uint tiley = latp2tiley(jt->get<1>(), baseZoom);
+		if (lastx==UINT_MAX) {
 			tileIndex[tilex*65536+tiley].insert(oo);
 		} else if (lastx!=tilex || lasty!=tiley) {
 			for (int x=min(tilex,lastx); x<=max(tilex,lastx); x++) {
@@ -103,8 +103,8 @@ void readShapefile(string filename,
 			// Points
 			Point p( shape->padfX[0], lat2latp(shape->padfY[0]) );
 			if (geom::within(p, clippingBox)) {
-				int tilex =  lon2tilex(p.x(), baseZoom);
-				int tiley = latp2tiley(p.y(), baseZoom);
+				uint tilex =  lon2tilex(p.x(), baseZoom);
+				uint tiley = latp2tiley(p.y(), baseZoom);
 				cachedGeometries.push_back(p);
 				OutputObject oo(CACHED_POINT, layerNum, cachedGeometries.size()-1);
 				addShapefileAttributes(dbf,oo,i,columnMap,columnTypeMap);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -176,6 +176,8 @@ int main(int argc, char* argv[]) {
 		.def("FindIntersecting", &OSMObject::FindIntersecting, luabind::return_stl_iterator)
 		.def("Intersects", &OSMObject::Intersects)
 		.def("IsClosed", &OSMObject::IsClosed)
+		.def("ScaleToMeter", &OSMObject::ScaleToMeter)
+		.def("ScaleToKiloMeter", &OSMObject::ScaleToKiloMeter)
 		.def("Area", &OSMObject::Area)
 		.def("Length", &OSMObject::Length)
 		.def("Layer", &OSMObject::Layer)

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -177,6 +177,7 @@ int main(int argc, char* argv[]) {
 		.def("Intersects", &OSMObject::Intersects)
 		.def("IsClosed", &OSMObject::IsClosed)
 		.def("Area", &OSMObject::Area)
+		.def("Length", &OSMObject::Length)
 		.def("Layer", &OSMObject::Layer)
 		.def("LayerAsCentroid", &OSMObject::LayerAsCentroid)
 		.def("Attribute", &OSMObject::Attribute)

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -582,13 +582,13 @@ int main(int argc, char* argv[]) {
 							unordered_set <uint32_t> tilelist;
 							uint lastX, lastY;
 							for (k=0; k<pbfWay.refs_size(); k++) {
-								int tileX =  lon2tilex(nodes.at(nodeVec[k]).lon  / 10000000.0, baseZoom);
-								int tileY = latp2tiley(nodes.at(nodeVec[k]).latp / 10000000.0, baseZoom);
+								uint tileX =  lon2tilex(nodes.at(nodeVec[k]).lon  / 10000000.0, baseZoom);
+								uint tileY = latp2tiley(nodes.at(nodeVec[k]).latp / 10000000.0, baseZoom);
 								if (k>0) {
 									// Check we're not skipping any tiles, and insert intermediate nodes if so
 									// (we should have a simple fill algorithm for polygons, too)
-									int dx = abs((int)(tileX-lastX));
-									int dy = abs((int)(tileY-lastY));
+									int dx = abs((int)tileX-(int)lastX);
+									int dy = abs((int)tileY-(int)lastY);
 									if (dx>1 || dy>1 || (dx==1 && dy==1)) {
 										insertIntermediateTiles(&tilelist, max(dx,dy), nodes.at(nodeVec[k-1]), nodes.at(nodeVec[k]), baseZoom);
 									}

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -250,7 +250,8 @@ int main(int argc, char* argv[]) {
 			string writeTo = it->value.HasMember("write_to") ? it->value["write_to"].GetString() : "";
 			int   simplifyBelow = it->value.HasMember("simplify_below") ? it->value["simplify_below"].GetInt()    : 0;
 			float simplifyLevel = it->value.HasMember("simplify_level") ? it->value["simplify_level"].GetDouble() : 0.01;
-			uint layerNum = osmObject.addLayer(layerName, minZoom, maxZoom, simplifyBelow, simplifyLevel, writeTo);
+			float simplifyRatio = it->value.HasMember("simplify_ratio") ? it->value["simplify_ratio"].GetDouble() : 1.0;
+			uint layerNum = osmObject.addLayer(layerName, minZoom, maxZoom, simplifyBelow, simplifyLevel, simplifyRatio, writeTo);
 			cout << "Layer " << layerName << " (z" << minZoom << "-" << maxZoom << ")";
 			if (it->value.HasMember("write_to")) { cout << " -> " << it->value["write_to"].GetString(); }
 			cout << endl;
@@ -689,7 +690,7 @@ int main(int argc, char* argv[]) {
 					uint layerNum = *mt;
 					LayerDef ld = osmObject.layers[layerNum];
 					if (zoom<ld.minzoom || zoom>ld.maxzoom) { continue; }
-					double simplifyLevel = zoom < ld.simplifyBelow ? ld.simplifyLevel : 0;
+					double simplifyLevel = zoom < ld.simplifyBelow ? ld.simplifyLevel * pow(ld.simplifyRatio, (ld.simplifyBelow-1) - zoom) : 0;
 
 					// Loop through output objects
 					for (auto jt = ooList.begin(); jt != ooList.end(); ++jt) {

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -249,8 +249,8 @@ int main(int argc, char* argv[]) {
 			int maxZoom = it->value["maxzoom"].GetInt();
 			string writeTo = it->value.HasMember("write_to") ? it->value["write_to"].GetString() : "";
 			int   simplifyBelow = it->value.HasMember("simplify_below") ? it->value["simplify_below"].GetInt()    : 0;
-			float simplifyLevel = it->value.HasMember("simplify_level") ? it->value["simplify_level"].GetDouble() : 0.01;
-			float simplifyRatio = it->value.HasMember("simplify_ratio") ? it->value["simplify_ratio"].GetDouble() : 1.0;
+			double simplifyLevel = it->value.HasMember("simplify_level") ? it->value["simplify_level"].GetDouble() : 0.01;
+			double simplifyRatio = it->value.HasMember("simplify_ratio") ? it->value["simplify_ratio"].GetDouble() : 1.0;
 			uint layerNum = osmObject.addLayer(layerName, minZoom, maxZoom, simplifyBelow, simplifyLevel, simplifyRatio, writeTo);
 			cout << "Layer " << layerName << " (z" << minZoom << "-" << maxZoom << ")";
 			if (it->value.HasMember("write_to")) { cout << " -> " << it->value["write_to"].GetString(); }


### PR DESCRIPTION
We implemented adaptive simplify level, that is proposed in the issue #25.
The ratio can be specified by the `"simplify_ratio"` key in the config json file.
Its default is `1.0`, so the existing behavior would not change.

We also implemented `"simplify_length"`, that specifies simplify level by actual length (in meters).
It is useful because  `"simplify_level"` produces inconsistent output when
a country ranging over broad latitudes is processed.

In addition, `Length()`, `ScaleToMeter()`, and `ScaleToKiloMeter()` are added to Lua.
They are easily implemented.

Here we propose version change. So `CHANGELOG.md` is updated in the last commit.