### PR TITLE
Use vector for keeping output objects, and merge output polygons/linestrings with the identical attributes

### DIFF
--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -124,11 +124,44 @@ class OutputObject { public:
 	}
 };
 
-// Hashing function so we can use an unordered_set
+// Comparision functions
 
-bool operator==(const OutputObject& x, const OutputObject& y) {
-	return (x.layer == y.layer) && (x.objectID == y.objectID) && (x.geomType == y.geomType);
+bool operator==(const OutputObject &x, const OutputObject &y) {
+	return
+		x.layer == y.layer &&
+		x.geomType == y.geomType &&
+		x.attributes == y.attributes &&
+		x.objectID == y.objectID;
 }
+// Do lexicographic comparison, with the order of: layer, geomType, attributes, and objectID.
+// Note that attributes is preffered to objectID.
+// It is to arrange objects with the identical attributes continuously.
+// Such objects will be merged into one object, to reduce the size of output.
+bool operator<(const OutputObject &x, const OutputObject &y) {
+	if (x.layer < y.layer) return true;
+	if (x.layer > y.layer) return false;
+	if (x.geomType < y.geomType) return true;
+	if (x.geomType > y.geomType) return false;
+	if (x.attributes < y.attributes) return true;
+	if (x.attributes > y.attributes) return false;
+	if (x.objectID < y.objectID) return true;
+	return false;
+}
+
+namespace vector_tile {
+	bool operator==(const vector_tile::Tile_Value &x, const vector_tile::Tile_Value &y) {
+		std::string strx = x.SerializeAsString();
+		std::string stry = y.SerializeAsString();
+		return strx == stry;
+	}
+	bool operator<(const vector_tile::Tile_Value &x, const vector_tile::Tile_Value &y) {
+		std::string strx = x.SerializeAsString();
+		std::string stry = y.SerializeAsString();
+		return strx < stry;
+	}
+}
+
+// Hashing function so we can use an unordered_set
 
 namespace std {
 	template<>

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -14,7 +14,7 @@ void fillPointArrayFromShapefile(vector<Point> *points, SHPObject *shape, uint p
 }
 
 // Add an OutputObject to all tiles between min/max lat/lon
-void addToTileIndexByBbox(OutputObject &oo, map< uint, unordered_set<OutputObject> > &tileIndex, uint baseZoom,
+void addToTileIndexByBbox(OutputObject &oo, map< uint, vector<OutputObject> > &tileIndex, uint baseZoom,
                           double minLon, double minLatp, double maxLon, double maxLatp) {
 	uint minTileX =  lon2tilex(minLon, baseZoom);
 	uint maxTileX =  lon2tilex(maxLon, baseZoom);
@@ -23,24 +23,24 @@ void addToTileIndexByBbox(OutputObject &oo, map< uint, unordered_set<OutputObjec
 	for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
 		for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
 			uint32_t index = x*65536+y;
-			tileIndex[index].insert(oo);
+			tileIndex[index].push_back(oo);
 		}
 	}
 }
 
 // Add an OutputObject to all tiles along a polyline
-void addToTileIndexPolyline(OutputObject &oo, map< uint, unordered_set<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls) {
+void addToTileIndexPolyline(OutputObject &oo, map< uint, vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls) {
 	uint lastx = UINT_MAX;
 	uint lasty;
 	for (Linestring::const_iterator jt = ls.begin(); jt != ls.end(); ++jt) {
 		uint tilex =  lon2tilex(jt->get<0>(), baseZoom);
 		uint tiley = latp2tiley(jt->get<1>(), baseZoom);
 		if (lastx==UINT_MAX) {
-			tileIndex[tilex*65536+tiley].insert(oo);
+			tileIndex[tilex*65536+tiley].push_back(oo);
 		} else if (lastx!=tilex || lasty!=tiley) {
 			for (int x=min(tilex,lastx); x<=max(tilex,lastx); x++) {
 				for (int y=min(tiley,lasty); y<=max(tiley,lasty); y++) {
-					tileIndex[x*65536+y].insert(oo);
+					tileIndex[x*65536+y].push_back(oo);
 				}
 			}
 		}
@@ -68,7 +68,7 @@ void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, uno
 void readShapefile(string filename, 
                    vector<string> &columns,
                    Box &clippingBox, 
-                   map< uint, unordered_set<OutputObject> > &tileIndex, 
+                   map< uint, vector<OutputObject> > &tileIndex, 
                    vector<Geometry> &cachedGeometries, map< uint, string > &cachedGeometryNames,
                    uint baseZoom, uint layerNum, string &layerName,
                    bool isIndexed, map<string,RTree> &indices, string &indexName) {
@@ -108,7 +108,7 @@ void readShapefile(string filename,
 				cachedGeometries.push_back(p);
 				OutputObject oo(CACHED_POINT, layerNum, cachedGeometries.size()-1);
 				addShapefileAttributes(dbf,oo,i,columnMap,columnTypeMap);
-				tileIndex[tilex*65536+tiley].insert(oo);
+				tileIndex[tilex*65536+tiley].push_back(oo);
 				if (isIndexed) {
 					uint id = cachedGeometries.size()-1;
 					geom::envelope(p, box); indices[layerName].insert(std::make_pair(box, id));

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -716,9 +716,13 @@ int main(int argc, char* argv[]) {
 						simplifyLevel *= pow(ld.simplifyRatio, (ld.simplifyBelow-1) - zoom);
 					}
 
+					// compare only by `layer`
+					auto layerComp = [](const OutputObject &x, const OutputObject &y) -> bool { return x.layer < y.layer; };
+					// We get the range within ooList, where the layer of each object is `layerNum`.
+					// Note that ooList is sorted by a lexicographic order, `layer` being the most significant.
+					auto ooListSameLayer = equal_range(ooList.begin(), ooList.end(), OutputObject(POINT, layerNum, 0), layerComp);
 					// Loop through output objects
-					for (auto jt = ooList.begin(); jt != ooList.end(); ++jt) {
-						if (jt->layer != layerNum) { continue; }
+					for (auto jt = ooListSameLayer.first; jt != ooListSameLayer.second; ++jt) {
 						if (jt->geomType == POINT) {
 							vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();
 							jt->buildNodeGeometry(nodes.at(jt->objectID), &bbox, featurePtr);


### PR DESCRIPTION
Polygons with the identical attributes can be merged into one polygon, when outputting a vector tiles.
This PR does this optimization.

To do so, output objects with the same attributes should be made adjacent. So we can't use unordered_set.

I suppose this PR also solves Issue #41.