### PR TITLE
Multi threads support for output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,10 @@ include_directories(${ZLIB_INCLUDE_DIR})
 
 if(MSVC)
   add_definitions(-D_USE_MATH_DEFINES)
+  set(THREAD_LIB "")
 else()
   add_definitions(-std=c++11)
+  set(THREAD_LIB pthread)
 endif()
 
 ADD_CUSTOM_COMMAND(OUTPUT vector_tile.pb.cc vector_tile.pb.h
@@ -47,6 +49,6 @@ ADD_CUSTOM_COMMAND(OUTPUT osmformat.pb.cc osmformat.pb.h
 		   ARGS --cpp_out ${CMAKE_BINARY_DIR} -I ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/include/osmformat.proto)
 
 add_executable(tilemaker vector_tile.pb.cc osmformat.pb.cc src/tilemaker.cpp)
-target_link_libraries(tilemaker ${Boost_LIBRARIES} ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUABIND_LIBRARIES} ${LUA_LIBRARIES} ${ZLIB_LIBRARY})
+target_link_libraries(tilemaker ${Boost_LIBRARIES} ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUABIND_LIBRARIES} ${LUA_LIBRARIES} ${ZLIB_LIBRARY} ${THREAD_LIB})
 
 install(TARGETS tilemaker RUNTIME DESTINATION bin)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LUA_CFLAGS := -I/usr/local/include/lua5.1 -I/usr/include/lua5.1
 LUA_LIBS := -llua5.1
-CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++11 $(CONFIG)
+CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++11 -pthread $(CONFIG)
 LIB := -L/usr/local/lib -lz $(LUA_LIBS) -lboost_program_options -lluabind -lsqlite3 -lboost_filesystem -lboost_system -lprotobuf -lshp
 INC := -I/usr/local/include -I./include -I./src $(LUA_CFLAGS)
 

--- a/src/mbtiles.cpp
+++ b/src/mbtiles.cpp
@@ -4,6 +4,7 @@
 class MBTiles { public:
 
 	database db;
+	mutex m;
 
 	MBTiles() {
 	}
@@ -21,11 +22,15 @@ class MBTiles { public:
 	}
 	
 	void writeMetadata(string key, string value) {
+		m.lock();
 		db << "REPLACE INTO metadata (name,value) VALUES (?,?);" << key << value;
+		m.unlock();
 	}
 	
 	void saveTile(int zoom, int x, int y, string *data) {
 		int tmsY = pow(2,zoom) - 1 - y;
+		m.lock();
 		db << "REPLACE INTO tiles (zoom_level, tile_column, tile_row, tile_data) VALUES (?,?,?,?);" << zoom << x << tmsY && *data;
+		m.unlock();
 	}
 };


### PR DESCRIPTION
Use std::thread and make output parallel. Tilemaker becomes 4x faster on ordinal machines.

By default, the number of core is automatically detected.
The number of threads can be explicitly specified by -threads option.
