### PR TITLE
Fix mismatched signed types

### DIFF
--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -1,8 +1,8 @@
 struct LayerDef {
 	string name;
-	int minzoom;
-	int maxzoom;
-	int simplifyBelow;
+	uint minzoom;
+	uint maxzoom;
+	uint simplifyBelow;
 	double simplifyLevel;
 	double simplifyLength;
 	double simplifyRatio;
@@ -47,17 +47,17 @@ class OSMObject { public:
 
 	// Common tag storage
 	vector<string> stringTable;				// Tag table from the current PrimitiveGroup
-	map<string, int> tagMap;				// String->position map
+	map<string, uint> tagMap;				// String->position map
 
 	// Tag storage for denseNodes
-	int denseStart;							// Start of key/value table section (DenseNodes)
-	int denseEnd;							// End of key/value table section (DenseNodes)
+	uint denseStart;							// Start of key/value table section (DenseNodes)
+	uint denseEnd;							// End of key/value table section (DenseNodes)
 	DenseNodes *densePtr;					// DenseNodes object
 
 	// Tag storage for ways/relations
 	::google::protobuf::RepeatedField< ::google::protobuf::uint32 > *keysPtr;
 	::google::protobuf::RepeatedField< ::google::protobuf::uint32 > *valsPtr;
-	int tagLength;
+	uint tagLength;
 
 	// ----	initialization routines
 
@@ -70,8 +70,8 @@ class OSMObject { public:
 	}
 
 	// Define a layer (as read from the .json file)
-	uint addLayer(string name, int minzoom, int maxzoom,
-			int simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, string writeTo) {
+	uint addLayer(string name, uint minzoom, uint maxzoom,
+			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, string writeTo) {
 		LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio };
 		layers.push_back(layer);
 		uint layerNum = layers.size()-1;
@@ -96,16 +96,15 @@ class OSMObject { public:
 
 	// Read string dictionary from the .pbf
 	void readStringTable(PrimitiveBlock *pbPtr) {
-		uint i;
 		// Populate the string table
 		stringTable.clear();
 		stringTable.resize(pbPtr->stringtable().s_size());
-		for (i=0; i<pbPtr->stringtable().s_size(); i++) {
+		for (int i=0; i<pbPtr->stringtable().s_size(); i++) {
 			stringTable[i] = pbPtr->stringtable().s(i);
 		}
 		// Create a string->position map
 		tagMap.clear();
-		for (i=0; i<pbPtr->stringtable().s_size(); i++) {
+		for (int i=0; i<pbPtr->stringtable().s_size(); i++) {
 			tagMap.insert(pair<string, int> (pbPtr->stringtable().s(i), i));
 		}
 	}
@@ -207,7 +206,7 @@ class OSMObject { public:
 			}
 		} else {
 			for (uint n=denseStart; n<denseEnd; n+=2) {
-				if (densePtr->keys_vals(n)==keyNum) { return true; }
+				if (uint(densePtr->keys_vals(n))==keyNum) { return true; }
 			}
 		}
 		return false;
@@ -225,7 +224,7 @@ class OSMObject { public:
 			}
 		} else {
 			for (uint n=denseStart; n<denseEnd; n+=2) {
-				if (densePtr->keys_vals(n)==keyNum) { return stringTable[densePtr->keys_vals(n+1)]; }
+				if (uint(densePtr->keys_vals(n))==keyNum) { return stringTable[densePtr->keys_vals(n+1)]; }
 			}
 		}
 		return "";

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -151,7 +151,7 @@ class OutputObject { public:
 	// (we can't easily use find() because of the different value-type encoding - 
 	//  should be possible to improve this though)
 	int findValue(vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Value *value) const {
-		for (int i=0; i<valueList->size(); i++) {
+		for (size_t i=0; i<valueList->size(); i++) {
 			vector_tile::Tile_Value v = valueList->at(i);
 			if (v.has_string_value() && value->has_string_value() && v.string_value()==value->string_value()) { return i; }
 			if (v.has_float_value()  && value->has_float_value()  && v.float_value() ==value->float_value() ) { return i; }

--- a/src/pbf_blocks.cpp
+++ b/src/pbf_blocks.cpp
@@ -66,14 +66,14 @@ void writeBlock(google::protobuf::Message *messagePtr, fstream *outputPtr, strin
 // Populate an array with the contents of a StringTable
 void readStringTable(vector<string> *strPtr, PrimitiveBlock *pbPtr) {
 	strPtr->resize(pbPtr->stringtable().s_size());
-	for (uint i=0; i<pbPtr->stringtable().s_size(); i++) {
+	for (int i=0; i<pbPtr->stringtable().s_size(); i++) {
 		(*strPtr)[i] = pbPtr->stringtable().s(i);			// dereference strPtr to get strings
 	}
 }
 
 // Populate a map with the reverse contents of a StringTable (i.e. string->num)
 void readStringMap(map<string, int> *mapPtr, PrimitiveBlock *pbPtr) {
-	for (uint i=0; i<pbPtr->stringtable().s_size(); i++) {
+	for (int i=0; i<pbPtr->stringtable().s_size(); i++) {
 		mapPtr->insert(pair<string, int> (pbPtr->stringtable().s(i), i));
 	}
 }
@@ -82,7 +82,7 @@ void readStringMap(map<string, int> *mapPtr, PrimitiveBlock *pbPtr) {
 // requires strings array to have been populated by readStringTable
 map<string, string> getTags(vector<string> *strPtr, Way *wayPtr) {
 	map<string, string> tags;
-	for (uint n=0; n<wayPtr->keys_size(); n++) {
+	for (int n=0; n<wayPtr->keys_size(); n++) {
 		tags[(*strPtr)[wayPtr->keys(n)]] = (*strPtr)[wayPtr->vals(n)];
 	}
 	return tags;
@@ -100,7 +100,7 @@ uint findStringInTable(string *strPtr, map<string, int> *mapPtr, PrimitiveBlock 
 
 // Set a tag for a way to a new value
 void setTag(Way *wayPtr, uint keyIndex, uint valueIndex) {
-	for (uint i=0; i<wayPtr->keys_size(); i++) {
+	for (int i=0; i<wayPtr->keys_size(); i++) {
 		if (wayPtr->keys(i)==keyIndex) {
 			wayPtr->mutable_vals()->Set(i,valueIndex);
 			return;

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -3,15 +3,15 @@
 */
 
 void fillPointArrayFromShapefile(vector<Point> *points, SHPObject *shape, uint part) {
-	int start = shape->panPartStart[part];
-	int end   = (part==shape->nParts-1) ? shape->nVertices : shape->panPartStart[part+1];
+	uint start = shape->panPartStart[part];
+	uint end   = (int(part)==shape->nParts-1) ? shape->nVertices : shape->panPartStart[part+1];
     double* const x = shape->padfX;
     double* const y = shape->padfY;
 	points->clear(); if (points->capacity() < (end-start)+1) { points->reserve(end-start+1); }
 	double prevx = 1000;
 	double prevy = 1000;
 	for (uint i=start; i<end; i++) {
-		y[i] = fmin(fmax(y[i], MinLat), MaxLat);	// To avoid infinite latp
+		y[i] = fmin(fmax(y[i], MinLat),MaxLat);	// To avoid infinite latp
 		double latp = lat2latp(y[i]);
 		// skip duplicated point
 		if ((i == end - 1 && (x[i] != prevx || latp != prevy)) ||
@@ -49,8 +49,8 @@ void addToTileIndexPolyline(OutputObject &oo, map< uint, vector<OutputObject> > 
 		if (lastx==UINT_MAX) {
 			tileIndex[tilex*65536+tiley].push_back(oo);
 		} else if (lastx!=tilex || lasty!=tiley) {
-			for (int x=min(tilex,lastx); x<=max(tilex,lastx); x++) {
-				for (int y=min(tiley,lasty); y<=max(tiley,lasty); y++) {
+			for (uint x=min(tilex,lastx); x<=max(tilex,lastx); x++) {
+				for (uint y=min(tiley,lasty); y<=max(tiley,lasty); y++) {
 					tileIndex[x*65536+y].push_back(oo);
 				}
 			}
@@ -96,7 +96,7 @@ void readShapefile(string filename,
 	// prepare columns
 	unordered_map<int,string> columnMap;
 	unordered_map<int,int> columnTypeMap;
-	for (int i=0; i<columns.size(); i++) {
+	for (size_t i=0; i<columns.size(); i++) {
 		int dbfLoc = DBFGetFieldIndex(dbf,columns[i].c_str());
 		if (dbfLoc>-1) { 
 			columnMap[dbfLoc]=columns[i];
@@ -131,7 +131,7 @@ void readShapefile(string filename,
 			// (Multi)-polylines
 			// Due to https://svn.boost.org/trac/boost/ticket/11268, we can't clip a MultiLinestring with Boost 1.56-1.58, 
 			// so we need to create everything as polylines and clip individually :(
-			for (uint j=0; j<shape->nParts; j++) {
+			for (int j=0; j<shape->nParts; j++) {
 				Linestring ls;
 				fillPointArrayFromShapefile(&points, shape, j);
 				geom::assign_points(ls, points);
@@ -159,7 +159,7 @@ void readShapefile(string filename,
 
 			// To avoid expensive computations, we assume the shapefile has been pre-processed
 			// such that each polygon's exterior ring is immediately followed by its interior rings.
-			for (uint j=0; j<shape->nParts; j++) {
+			for (int j=0; j<shape->nParts; j++) {
 				fillPointArrayFromShapefile(&points, shape, j);
 				// Read points into a ring
 				ring.clear();

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -349,7 +349,7 @@ int main(int argc, char* argv[]) {
 		DenseNodes dense;
 		Way pbfWay;
 		vector<string> strings(0);
-		uint i,j,k,ct=0;
+		uint ct=0;
 		int64_t nodeId;
 		bool checkedRelations = false;
 		int wayPosition = -1;
@@ -376,7 +376,7 @@ int main(int argc, char* argv[]) {
 				nodeKeyPositions.insert(osmObject.findStringPosition(it));
 			}
 
-			for (i=0; i<pb.primitivegroup_size(); i++) {
+			for (int i=0; i<pb.primitivegroup_size(); i++) {
 				pg = pb.primitivegroup(i);
 				cout << "Block " << ct << " group " << i << " ways " << pg.ways_size() << " relations " << pg.relations_size() << "        \r";
 				cout.flush();
@@ -389,7 +389,7 @@ int main(int argc, char* argv[]) {
 					int lat = 0;
 					int kvPos = 0;
 					dense = pg.dense();
-					for (j=0; j<dense.id_size(); j++) {
+					for (int j=0; j<dense.id_size(); j++) {
 						nodeId += dense.id(j);
 						lon    += dense.lon(j);
 						lat    += dense.lat(j);
@@ -433,10 +433,10 @@ int main(int argc, char* argv[]) {
 				// ----	Remember all ways in any relation
 
 				if (!checkedRelations && pg.relations_size() > 0) {
-					for (j=0; j<pg.relations_size(); j++) {
+					for (int j=0; j<pg.relations_size(); j++) {
 						Relation pbfRelation = pg.relations(j);
 						int64_t lastID = 0;
-						for (uint n = 0; n < pbfRelation.memids_size(); n++) {
+						for (int n = 0; n < pbfRelation.memids_size(); n++) {
 							lastID += pbfRelation.memids(n);
 							if (pbfRelation.types(n) != Relation_MemberType_WAY) { continue; }
 							WayID wayId = static_cast<WayID>(lastID);
@@ -454,14 +454,14 @@ int main(int argc, char* argv[]) {
 				// ----	Read ways
 
 				if (pg.ways_size() > 0) {
-					for (j=0; j<pg.ways_size(); j++) {
+					for (int j=0; j<pg.ways_size(); j++) {
 						pbfWay = pg.ways(j);
 						WayID wayId = static_cast<WayID>(pbfWay.id());
 
 						// Assemble nodelist
 						nodeId = 0;
 						NodeVec nodeVec;
-						for (k=0; k<pbfWay.refs_size(); k++) {
+						for (int k=0; k<pbfWay.refs_size(); k++) {
 							nodeId += pbfWay.refs(k);
 							nodeVec.push_back(static_cast<NodeID>(nodeId));
 						}
@@ -517,7 +517,7 @@ int main(int argc, char* argv[]) {
 					int innerKey= osmObject.findStringPosition("inner");
 					//int outerKey= osmObject.findStringPosition("outer");
 					if (typeKey >-1 && mpKey>-1) {
-						for (j=0; j<pg.relations_size(); j++) {
+						for (int j=0; j<pg.relations_size(); j++) {
 							Relation pbfRelation = pg.relations(j);
 							if (find(pbfRelation.keys().begin(), pbfRelation.keys().end(), typeKey) == pbfRelation.keys().end()) { continue; }
 							if (find(pbfRelation.vals().begin(), pbfRelation.vals().end(), mpKey  ) == pbfRelation.vals().end()) { continue; }
@@ -525,7 +525,7 @@ int main(int argc, char* argv[]) {
 							// Read relation members
 							WayVec outerWayVec, innerWayVec;
 							int64_t lastID = 0;
-							for (uint n=0; n < pbfRelation.memids_size(); n++) {
+							for (int n=0; n < pbfRelation.memids_size(); n++) {
 								lastID += pbfRelation.memids(n);
 								if (pbfRelation.types(n) != Relation_MemberType_WAY) { continue; }
 								int32_t role = pbfRelation.roles_sid(n);


### PR DESCRIPTION
A lot of these would normally be `size_t` except the protobuf functions oddly return int for size.

The scopes of some loop counters have also been fixed.