### PR TITLE
Enable high zoom level

### DIFF
--- a/include/output_object.h
+++ b/include/output_object.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <iostream>
 #include "geomtypes.h"
 #include "coordinates.h"
 #include "osm_store.h"

--- a/include/read_shp.h
+++ b/include/read_shp.h
@@ -15,11 +15,11 @@
 void fillPointArrayFromShapefile(std::vector<Point> *points, SHPObject *shape, uint part);
 
 /// Add an OutputObject to all tiles between min/max lat/lon
-void addToTileIndexByBbox(OutputObject &oo, std::map< uint, std::vector<OutputObject> > &tileIndex, uint baseZoom,
+void addToTileIndexByBbox(OutputObject &oo, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, uint baseZoom,
                           double minLon, double minLatp, double maxLon, double maxLatp);
 
 /// Add an OutputObject to all tiles along a polyline
-void addToTileIndexPolyline(OutputObject &oo, std::map< uint, std::vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls);
+void addToTileIndexPolyline(OutputObject &oo, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls);
 
 /// Read requested attributes from a shapefile, and encode into an OutputObject
 void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, std::unordered_map<int,std::string> &columnMap, std::unordered_map<int,int> &columnTypeMap);
@@ -28,7 +28,7 @@ void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, std
 void readShapefile(std::string filename,
                    std::vector<std::string> &columns,
                    Box &clippingBox,
-                   std::map< uint, std::vector<OutputObject> > &tileIndex,
+                   std::map< uint64_t, std::vector<OutputObject> > &tileIndex,
                    std::vector<Geometry> &cachedGeometries,
                    OSMObject &osmObject,
                    uint baseZoom, uint layerNum, std::string &layerName,

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -23,8 +23,8 @@ double tiley2latp(uint y, uint z) { return 180.0 - scalbn(y, -(int)z) * 360.0; }
 double tiley2lat(uint y, uint z) { return latp2lat(tiley2latp(y, z)); }
 
 // Get a tile index
-uint32_t latpLon2index(LatpLon ll, uint baseZoom) {
-	return lon2tilex(ll.lon /10000000.0, baseZoom) * 65536 +
+uint64_t latpLon2index(LatpLon ll, uint baseZoom) {
+	return lon2tilex(ll.lon /10000000.0, baseZoom) * 4294967296 +
 	       latp2tiley(ll.latp/10000000.0, baseZoom);
 }
 
@@ -37,17 +37,17 @@ double meter2degp(double meter, double latp) {
 }
 
 // the range between smallest y and largest y is filled, for each x
-void fillCoveredTiles(unordered_set<uint32_t> &tileSet) {
-	vector<uint32_t> tileList(tileSet.begin(), tileSet.end());
+void fillCoveredTiles(unordered_set<uint64_t> &tileSet) {
+	vector<uint64_t> tileList(tileSet.begin(), tileSet.end());
 	sort(tileList.begin(), tileList.end());
 
-	uint prevX = 0, prevY = static_cast<uint>(-2);
-	for (uint32_t index: tileList) {
-		uint tileX = index >> 16, tileY = index & 65535;
+	uint64_t prevX = 0, prevY = static_cast<uint64_t>(-2);
+	for (uint64_t index: tileList) {
+		uint64_t tileX = index >> 32, tileY = index & 4294967296;
 		if (tileX == prevX) {
 			// this loop has no effect at the first iteration
-			for (uint fillY = prevY+1; fillY < tileY; fillY++) {
-				tileSet.insert((tileX << 16) + fillY);
+			for (uint64_t fillY = prevY+1; fillY < tileY; fillY++) {
+				tileSet.insert((tileX << 32) + fillY);
 			}
 		}
 		prevX = tileX, prevY = tileY;
@@ -58,10 +58,10 @@ void fillCoveredTiles(unordered_set<uint32_t> &tileSet) {
 // ------------------------------------------------------
 // Helper class for dealing with spherical Mercator tiles
 
-TileBbox::TileBbox(uint i, uint z) {
+TileBbox::TileBbox(uint64_t i, uint z) {
 	index = i; zoom = z;
-	tiley = index & 65535;
-	tilex = index >> 16;
+	tiley = index & 4294967295L;
+	tilex = index >> 32;
 	minLon = tilex2lon(tilex  ,zoom);
 	minLat = tiley2lat(tiley+1,zoom);
 	maxLon = tilex2lon(tilex+1,zoom);

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -104,7 +104,7 @@ std::string decompress_string(const std::string& str) {
     return outstring;
 }
 
-const double CLIPPER_SCALE = 1e6;
+const double CLIPPER_SCALE = 1e8;
 
 void ConvertToClipper(const Polygon &p, Path &outer, Paths &inners)
 {

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -20,7 +20,7 @@ public:
 	bool sqlite;
 	MBTiles mbtiles;
 	string outputFile;
-	map< uint, vector<OutputObject> > *tileIndexForZoom;
+	map< uint64_t, vector<OutputObject> > *tileIndexForZoom;
 
 	SharedData(kaguya::State *luaPtr, map< string, RTree> *idxPtr, map<uint,string> *namePtr, OSMStore *osmStore) :
 		osmObject(luaPtr, idxPtr, &this->cachedGeometries, namePtr, osmStore)
@@ -35,7 +35,7 @@ public:
 	// ----	Read all config details from JSON file
 
 	void readConfig(rapidjson::Document &jsonConfig, bool hasClippingBox, Box &clippingBox,
-	                map< uint, vector<OutputObject> > &tileIndex) {
+	                map< uint64_t, vector<OutputObject> > &tileIndex) {
 		baseZoom       = jsonConfig["settings"]["basezoom"].GetUint();
 		startZoom      = jsonConfig["settings"]["minzoom" ].GetUint();
 		endZoom        = jsonConfig["settings"]["maxzoom" ].GetUint();


### PR DESCRIPTION
When the zoom level is equal or greater than 17, the tiles were not generated.
This problem was mainly due to the uint_32 limitation of the tiles indices.

This pull request removes this limitation.