### PR TITLE
Reorganize SharedData and OSMObject classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,6 @@ install:
 	install -m 0755 tilemaker /usr/local/bin
 
 clean:
-	rm -f tilemaker src/tilemaker.o
+	rm -f tilemaker src/*.o
 
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ or with luajit:
 
 To save memory (on any platform), you can choose 32-bit storage for node and way IDs rather than 64-bit. You will need to run `osmium renumber` or a similar tool over your .osm.pbf first. Then compile Tilemaker with an additional flag:
 
-    make CONFIG="-DCOMPACT_NODES -DCOMPACT_WAYS"
+    make CONFIG="-DCOMPACT_NODES -DCOMPACT_WAYS -DCOMPACT_TILE_INDEX"
     make install
 
 ### Docker

--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -5,7 +5,11 @@
 #include <utility>
 #include <unordered_set>
 
+#ifdef COMPACT_TILE_INDEX
+typedef uint16_t TileCoordinate;
+#else
 typedef uint32_t TileCoordinate;
+#endif
 class TileCoordinates_
 {
 public:
@@ -92,7 +96,7 @@ void insertIntermediateTiles(const T &points, uint baseZoom, std::unordered_set<
 		p2 = *it;
 
 		double tileXf2 = lon2tilexf(p2.x(), baseZoom), tileYf2 = latp2tileyf(p2.y(), baseZoom);
-		uint64_t tileX2 = static_cast<uint64_t>(tileXf2), tileY2 = static_cast<uint64_t>(tileYf2);
+		TileCoordinate tileX2 = static_cast<TileCoordinate>(tileXf2), tileY2 = static_cast<TileCoordinate>(tileYf2);
 
 		// insert vertex
 		tileSet.insert(TileCoordinates(tileX2, tileY2));
@@ -100,16 +104,16 @@ void insertIntermediateTiles(const T &points, uint baseZoom, std::unordered_set<
 		if (it == points.begin()) continue;
 
 		double tileXf1 = lon2tilexf(p1.x(), baseZoom), tileYf1 = latp2tileyf(p1.y(), baseZoom);
-		uint64_t tileX1 = static_cast<uint64_t>(tileXf1), tileY1 = static_cast<uint64_t>(tileYf1);
+		TileCoordinate tileX1 = static_cast<TileCoordinate>(tileXf1), tileY1 = static_cast<TileCoordinate>(tileYf1);
 		double dx = tileXf2 - tileXf1, dy = tileYf2 - tileYf1;
 
 		// insert all X border
 		if (tileX1 != tileX2) {
 			double slope = dy / dx;
-			uint64_t tileXmin = std::min(tileX1, tileX2);
-			uint64_t tileXmax = std::max(tileX1, tileX2);
-			for (uint64_t tileXcur = tileXmin+1; tileXcur <= tileXmax; tileXcur++) {
-				uint64_t tileYcur = static_cast<uint64_t>(tileYf1 + (static_cast<double>(tileXcur) - tileXf1) * slope);
+			TileCoordinate tileXmin = std::min(tileX1, tileX2);
+			TileCoordinate tileXmax = std::max(tileX1, tileX2);
+			for (TileCoordinate tileXcur = tileXmin+1; tileXcur <= tileXmax; tileXcur++) {
+				TileCoordinate tileYcur = static_cast<TileCoordinate>(tileYf1 + (static_cast<double>(tileXcur) - tileXf1) * slope);
 				tileSet.insert(TileCoordinates(tileXcur, tileYcur));
 			}
 		}
@@ -117,10 +121,10 @@ void insertIntermediateTiles(const T &points, uint baseZoom, std::unordered_set<
 		// insert all Y border
 		if (tileY1 != tileY2) {
 			double slope = dx / dy;
-			uint64_t tileYmin = std::min(tileY1, tileY2);
-			uint64_t tileYmax = std::max(tileY1, tileY2);
-			for (uint64_t tileYcur = tileYmin+1; tileYcur <= tileYmax; tileYcur++) {
-				uint64_t tileXcur = static_cast<uint64_t>(tileXf1 + (static_cast<double>(tileYcur) - tileYf1) * slope);
+			TileCoordinate tileYmin = std::min(tileY1, tileY2);
+			TileCoordinate tileYmax = std::max(tileY1, tileY2);
+			for (TileCoordinate tileYcur = tileYmin+1; tileYcur <= tileYmax; tileYcur++) {
+				TileCoordinate tileXcur = static_cast<TileCoordinate>(tileXf1 + (static_cast<double>(tileYcur) - tileYf1) * slope);
 				tileSet.insert(TileCoordinates(tileXcur, tileYcur));
 			}
 		}
@@ -139,7 +143,6 @@ public:
 	double minLon, maxLon, minLat, maxLat, minLatp, maxLatp;
 	double xmargin, ymargin, xscale, yscale;
 	TileCoordinates index;
-	TileCoordinate tiley, tilex; //FIXME This duplicates the index variable
 	uint zoom;
 	Box clippingBox;
 

--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -34,7 +34,7 @@ double tiley2latp(uint y, uint z);
 double tiley2lat(uint y, uint z);
 
 // Get a tile index
-uint32_t latpLon2index(LatpLon ll, uint baseZoom);
+uint64_t latpLon2index(LatpLon ll, uint baseZoom);
 
 // Earth's (mean) radius
 // http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
@@ -47,50 +47,50 @@ double degp2meter(double degp, double latp);
 double meter2degp(double meter, double latp);
 
 template<typename T>
-void insertIntermediateTiles(const T &points, uint baseZoom, std::unordered_set<uint32_t> &tileSet) {
+void insertIntermediateTiles(const T &points, uint baseZoom, std::unordered_set<uint64_t> &tileSet) {
 	Point p2(0, 0);
 	for (auto it = points.begin(); it != points.end(); ++it) {
 		Point p1 = p2;
 		p2 = *it;
 
 		double tileXf2 = lon2tilexf(p2.x(), baseZoom), tileYf2 = latp2tileyf(p2.y(), baseZoom);
-		uint tileX2 = static_cast<uint>(tileXf2), tileY2 = static_cast<uint>(tileYf2);
+		uint64_t tileX2 = static_cast<uint64_t>(tileXf2), tileY2 = static_cast<uint64_t>(tileYf2);
 
 		// insert vertex
-		tileSet.insert((tileX2 << 16) + tileY2);
+		tileSet.insert((tileX2 << 32) + tileY2);
 		// p1 is not available at the first iteration
 		if (it == points.begin()) continue;
 
 		double tileXf1 = lon2tilexf(p1.x(), baseZoom), tileYf1 = latp2tileyf(p1.y(), baseZoom);
-		uint tileX1 = static_cast<uint>(tileXf1), tileY1 = static_cast<uint>(tileYf1);
+		uint64_t tileX1 = static_cast<uint64_t>(tileXf1), tileY1 = static_cast<uint64_t>(tileYf1);
 		double dx = tileXf2 - tileXf1, dy = tileYf2 - tileYf1;
 
 		// insert all X border
 		if (tileX1 != tileX2) {
 			double slope = dy / dx;
-			uint tileXmin = std::min(tileX1, tileX2);
-			uint tileXmax = std::max(tileX1, tileX2);
-			for (uint tileXcur = tileXmin+1; tileXcur <= tileXmax; tileXcur++) {
-				uint tileYcur = static_cast<uint>(tileYf1 + (static_cast<double>(tileXcur) - tileXf1) * slope);
-				tileSet.insert((tileXcur << 16) + tileYcur);
+			uint64_t tileXmin = std::min(tileX1, tileX2);
+			uint64_t tileXmax = std::max(tileX1, tileX2);
+			for (uint64_t tileXcur = tileXmin+1; tileXcur <= tileXmax; tileXcur++) {
+				uint64_t tileYcur = static_cast<uint64_t>(tileYf1 + (static_cast<double>(tileXcur) - tileXf1) * slope);
+				tileSet.insert((tileXcur << 32) + tileYcur);
 			}
 		}
 
 		// insert all Y border
 		if (tileY1 != tileY2) {
 			double slope = dx / dy;
-			uint tileYmin = std::min(tileY1, tileY2);
-			uint tileYmax = std::max(tileY1, tileY2);
-			for (uint tileYcur = tileYmin+1; tileYcur <= tileYmax; tileYcur++) {
-				uint tileXcur = static_cast<uint>(tileXf1 + (static_cast<double>(tileYcur) - tileYf1) * slope);
-				tileSet.insert((tileXcur << 16) + tileYcur);
+			uint64_t tileYmin = std::min(tileY1, tileY2);
+			uint64_t tileYmax = std::max(tileY1, tileY2);
+			for (uint64_t tileYcur = tileYmin+1; tileYcur <= tileYmax; tileYcur++) {
+				uint64_t tileXcur = static_cast<uint64_t>(tileXf1 + (static_cast<double>(tileYcur) - tileYf1) * slope);
+				tileSet.insert((tileXcur << 32) + tileYcur);
 			}
 		}
 	}
 }
 
 // the range between smallest y and largest y is filled, for each x
-void fillCoveredTiles(std::unordered_set<uint32_t> &tileSet);
+void fillCoveredTiles(std::unordered_set<uint64_t> &tileSet);
 
 // ------------------------------------------------------
 // Helper class for dealing with spherical Mercator tiles
@@ -100,10 +100,11 @@ class TileBbox {
 public:
 	double minLon, maxLon, minLat, maxLat, minLatp, maxLatp;
 	double xmargin, ymargin, xscale, yscale;
-	uint index, zoom, tiley, tilex;
+	uint64_t index, tiley, tilex;
+	uint zoom;
 	Box clippingBox;
 
-	TileBbox(uint i, uint z);
+	TileBbox(uint64_t i, uint z);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
 };

--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -105,7 +105,7 @@ public:
 
 	TileBbox(uint i, uint z);
 
-	std::pair<int,int> scaleLatpLon(double latp, double lon);
+	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
 };
 
 #endif //_COORDINATES_H

--- a/include/osm_object.h
+++ b/include/osm_object.h
@@ -8,6 +8,7 @@
 #include "kaguya.hpp"
 #include "geomtypes.h"
 #include "osm_store.h"
+#include "shared_data.h"
 #include "output_object.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -16,21 +17,6 @@
 // Protobuf
 #include "osmformat.pb.h"
 #include "vector_tile.pb.h"
-
-struct LayerDef {
-	std::string name;
-	uint minzoom;
-	uint maxzoom;
-	uint simplifyBelow;
-	double simplifyLevel;
-	double simplifyLength;
-	double simplifyRatio;
-	std::string source;
-	std::vector<std::string> sourceColumns;
-	bool indexed;
-	std::string indexName;
-	std::map<std::string, uint> attributeMap;
-};
 
 /*
 	OSMObject - represents the object (from the .osm.pbf) currently being processed
@@ -65,11 +51,7 @@ public:
 	MultiPolygon multiPolygonCache;
 	bool multiPolygonInited;
 
-	std::vector<LayerDef> layers;				// List of layers
-	std::map<std::string,uint> layerMap;				// Layer->position map
-	std::vector<std::vector<uint> > layerOrder;		// Order of (grouped) layers, e.g. [ [0], [1,2,3], [4] ]
-	uint baseZoom;
-
+	class Config &config;
 	std::vector<OutputObject> outputs;			// All output objects
 
 	// Common tag storage
@@ -88,7 +70,7 @@ public:
 
 	// ----	initialization routines
 
-	OSMObject(kaguya::State &luaObj, std::map< std::string, RTree> *idxPtr, std::vector<Geometry> *geomPtr, 
+	OSMObject(class Config &configIn, kaguya::State &luaObj, std::map< std::string, RTree> *idxPtr, std::vector<Geometry> *geomPtr, 
 		std::map<uint,std::string> *namePtr, OSMStore *storePtr);
 
 	// Read string dictionary from the .pbf

--- a/include/osm_object.h
+++ b/include/osm_object.h
@@ -25,6 +25,10 @@ struct LayerDef {
 	double simplifyLevel;
 	double simplifyLength;
 	double simplifyRatio;
+	std::string source;
+	std::vector<std::string> sourceColumns;
+	bool indexed;
+	std::string indexName;
 	std::map<std::string, uint> attributeMap;
 };
 

--- a/include/osm_object.h
+++ b/include/osm_object.h
@@ -87,10 +87,6 @@ public:
 	OSMObject(kaguya::State &luaObj, std::map< std::string, RTree> *idxPtr, std::vector<Geometry> *geomPtr, 
 		std::map<uint,std::string> *namePtr, OSMStore *storePtr);
 
-	// Define a layer (as read from the .json file)
-	uint addLayer(std::string name, uint minzoom, uint maxzoom,
-			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, std::string writeTo);
-
 	// Read string dictionary from the .pbf
 	void readStringTable(PrimitiveBlock *pbPtr);
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -58,11 +58,11 @@ public:
 	// Returns a boost::variant -
 	//   POLYGON->MultiPolygon, CENTROID->Point, LINESTRING->MultiLinestring
 	Geometry buildWayGeometry(const OSMStore &osmStore,
-	                      TileBbox *bboxPtr, 
+	                      const TileBbox *bboxPtr, 
 	                      const std::vector<Geometry> &cachedGeometries) const;
 	
 	// Add a node geometry
-	void buildNodeGeometry(LatpLon ll, TileBbox *bboxPtr, vector_tile::Tile_Feature *featurePtr) const;
+	void buildNodeGeometry(LatpLon ll, const TileBbox *bboxPtr, vector_tile::Tile_Feature *featurePtr) const;
 	
 	// Write attribute key/value pairs (dictionary-encoded)
 	void writeAttributes(std::vector<std::string> *keyList, std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Feature *featurePtr) const;

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -8,7 +8,8 @@
 #include "shared_data.h"
 
 int ReadPbfFile(const std::string &inputFile, std::unordered_set<std::string> &nodeKeys, 
-	std::map< uint64_t, std::vector<OutputObject> > &tileIndex, OSMObject &osmObject);
+	std::map< TileCoordinates, std::vector<OutputObject>, TileCoordinatesCompare > &tileIndex, 
+	OSMObject &osmObject);
 
 int ReadPbfBoundingBox(const std::string &inputFile, double &minLon, double &maxLon, 
 	double &minLat, double &maxLat, bool &hasClippingBox);

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -8,7 +8,7 @@
 #include "shared_data.h"
 
 int ReadPbfFile(const std::string &inputFile, std::unordered_set<std::string> &nodeKeys, 
-	std::map< uint, std::vector<OutputObject> > &tileIndex, OSMObject &osmObject);
+	std::map< uint64_t, std::vector<OutputObject> > &tileIndex, OSMObject &osmObject);
 
 int ReadPbfBoundingBox(const std::string &inputFile, double &minLon, double &maxLon, 
 	double &minLat, double &maxLat, bool &hasClippingBox);

--- a/include/read_shp.h
+++ b/include/read_shp.h
@@ -27,13 +27,13 @@ void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, std
 /// Read shapefile, and create OutputObjects for all objects within the specified bounding box
 void readShapefile(std::string filename,
                    std::vector<std::string> &columns,
-                   Box &clippingBox,
+                   const Box &clippingBox,
                    std::map< uint, std::vector<OutputObject> > &tileIndex,
                    std::vector<Geometry> &cachedGeometries,
                    OSMObject &osmObject,
-                   uint baseZoom, uint layerNum, std::string &layerName,
+                   uint baseZoom, uint layerNum, const std::string &layerName,
                    bool isIndexed,
-                   std::string &indexName);
+                   const std::string &indexName);
 
 #endif //_READ_SHP_H
 

--- a/include/read_shp.h
+++ b/include/read_shp.h
@@ -15,11 +15,11 @@
 void fillPointArrayFromShapefile(std::vector<Point> *points, SHPObject *shape, uint part);
 
 /// Add an OutputObject to all tiles between min/max lat/lon
-void addToTileIndexByBbox(OutputObject &oo, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, uint baseZoom,
+void addToTileIndexByBbox(OutputObject &oo, std::map< TileCoordinates, std::vector<OutputObject>, TileCoordinatesCompare > &tileIndex, uint baseZoom,
                           double minLon, double minLatp, double maxLon, double maxLatp);
 
 /// Add an OutputObject to all tiles along a polyline
-void addToTileIndexPolyline(OutputObject &oo, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls);
+void addToTileIndexPolyline(OutputObject &oo, std::map< TileCoordinates, std::vector<OutputObject>, TileCoordinatesCompare > &tileIndex, uint baseZoom, const Linestring &ls);
 
 /// Read requested attributes from a shapefile, and encode into an OutputObject
 void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, std::unordered_map<int,std::string> &columnMap, std::unordered_map<int,int> &columnTypeMap);
@@ -28,7 +28,7 @@ void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, std
 void readShapefile(std::string filename,
                    std::vector<std::string> &columns,
                    const Box &clippingBox,
-                   std::map< uint64_t, std::vector<OutputObject> > &tileIndex,
+                   std::map< TileCoordinates, std::vector<OutputObject>, TileCoordinatesCompare > &tileIndex,
                    std::vector<Geometry> &cachedGeometries,
                    OSMObject &osmObject,
                    uint baseZoom, uint layerNum, const std::string &layerName,

--- a/include/read_shp.h
+++ b/include/read_shp.h
@@ -15,11 +15,11 @@
 void fillPointArrayFromShapefile(std::vector<Point> *points, SHPObject *shape, uint part);
 
 /// Add an OutputObject to all tiles between min/max lat/lon
-void addToTileIndexByBbox(OutputObject &oo, std::map< uint, std::vector<OutputObject> > &tileIndex, uint baseZoom,
+void addToTileIndexByBbox(OutputObject &oo, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, uint baseZoom,
                           double minLon, double minLatp, double maxLon, double maxLatp);
 
 /// Add an OutputObject to all tiles along a polyline
-void addToTileIndexPolyline(OutputObject &oo, std::map< uint, std::vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls);
+void addToTileIndexPolyline(OutputObject &oo, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls);
 
 /// Read requested attributes from a shapefile, and encode into an OutputObject
 void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, std::unordered_map<int,std::string> &columnMap, std::unordered_map<int,int> &columnTypeMap);
@@ -28,7 +28,7 @@ void addShapefileAttributes(DBFHandle &dbf, OutputObject &oo, int recordNum, std
 void readShapefile(std::string filename,
                    std::vector<std::string> &columns,
                    const Box &clippingBox,
-                   std::map< uint, std::vector<OutputObject> > &tileIndex,
+                   std::map< uint64_t, std::vector<OutputObject> > &tileIndex,
                    std::vector<Geometry> &cachedGeometries,
                    OSMObject &osmObject,
                    uint baseZoom, uint layerNum, const std::string &layerName,

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -32,6 +32,11 @@ public:
 
 	void readConfig(rapidjson::Document &jsonConfig, bool hasClippingBox, Box &clippingBox,
 		            std::map< uint, std::vector<OutputObject> > &tileIndex, OSMObject &osmObject);
+
+	// Define a layer (as read from the .json file)
+	uint addLayer(std::string name, uint minzoom, uint maxzoom,
+			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, std::string writeTo);
+
 };
 
 class SharedData

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -61,16 +61,18 @@ class SharedData
 {
 public:
 	uint zoom;
+
+	///Number of worker threads to create
 	int threadNum;
-	OSMStore *osmStore;
+	const OSMStore *osmStore;
 	bool verbose;
 	bool sqlite;
 	MBTiles mbtiles;
 	std::string outputFile;
-	std::map< uint, std::vector<OutputObject> > *tileIndexForZoom;
-	std::vector<Geometry> *cachedGeometries;
+	const std::map< uint, std::vector<OutputObject> > *tileIndexForZoom;
+	const std::vector<Geometry> *cachedGeometries;
 
-	class Config &config;
+	const class Config &config;
 
 	SharedData(class Config &configIn, OSMStore *osmStore);
 	virtual ~SharedData();

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -35,7 +35,12 @@ public:
 
 	// Define a layer (as read from the .json file)
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,
-			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, std::string writeTo);
+			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
+			const std::string &source,
+			const std::vector<std::string> &sourceColumns,
+			bool indexed,
+			const std::string &indexName,	
+			const std::string &writeTo);
 
 };
 

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -30,8 +30,10 @@ public:
 	Config();
 	virtual ~Config();
 
-	void readConfig(rapidjson::Document &jsonConfig, bool hasClippingBox, Box &clippingBox,
-		            std::map< uint, std::vector<OutputObject> > &tileIndex, OSMObject &osmObject);
+	void readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, Box &clippingBox);
+
+	void loadExternal(bool hasClippingBox, Box &clippingBox,
+	                std::map< uint, std::vector<OutputObject> > &tileIndex, OSMObject &osmObject);
 
 	// Define a layer (as read from the .json file)
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -69,7 +69,7 @@ public:
 	bool sqlite;
 	MBTiles mbtiles;
 	std::string outputFile;
-	const std::map< uint, std::vector<OutputObject> > *tileIndexForZoom;
+	const std::map< uint64_t, std::vector<OutputObject> > *tileIndexForZoom;
 	const std::vector<Geometry> *cachedGeometries;
 
 	const class Config &config;

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -69,7 +69,7 @@ public:
 	bool sqlite;
 	MBTiles mbtiles;
 	std::string outputFile;
-	const std::map< uint64_t, std::vector<OutputObject> > *tileIndexForZoom;
+	const std::map<TileCoordinates, std::vector<OutputObject>, TileCoordinatesCompare > *tileIndexForZoom;
 	const std::vector<Geometry> *cachedGeometries;
 
 	const class Config &config;

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -11,6 +11,21 @@
 #include "osm_object.h"
 #include "mbtiles.h"
 
+struct LayerDef {
+	std::string name;
+	uint minzoom;
+	uint maxzoom;
+	uint simplifyBelow;
+	double simplifyLevel;
+	double simplifyLength;
+	double simplifyRatio;
+	std::string source;
+	std::vector<std::string> sourceColumns;
+	bool indexed;
+	std::string indexName;
+	std::map<std::string, uint> attributeMap;
+};
+
 class Config
 {
 public:
@@ -25,15 +40,11 @@ public:
 	double minLon, minLat, maxLon, maxLat;
 	std::string projectName, projectVersion, projectDesc;
 	std::string defaultView;
-	std::vector<Geometry> cachedGeometries;					// prepared boost::geometry objects (from shapefiles)
 
 	Config();
 	virtual ~Config();
 
 	void readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, Box &clippingBox);
-
-	void loadExternal(bool hasClippingBox, Box &clippingBox,
-	                std::map< uint, std::vector<OutputObject> > &tileIndex, OSMObject &osmObject);
 
 	// Define a layer (as read from the .json file)
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,
@@ -57,10 +68,11 @@ public:
 	MBTiles mbtiles;
 	std::string outputFile;
 	std::map< uint, std::vector<OutputObject> > *tileIndexForZoom;
+	std::vector<Geometry> *cachedGeometries;
 
-	class Config config;
+	class Config &config;
 
-	SharedData(OSMStore *osmStore);
+	SharedData(class Config &configIn, OSMStore *osmStore);
 	virtual ~SharedData();
 };
 

--- a/include/write_geometry.h
+++ b/include/write_geometry.h
@@ -20,23 +20,23 @@ typedef std::vector<std::pair<int,int> > XYString;
 class WriteGeometryVisitor : public boost::static_visitor<> { 
 
 public:
-	TileBbox *bboxPtr;
+	const TileBbox *bboxPtr;
 	vector_tile::Tile_Feature *featurePtr;
 	double simplifyLevel;
 
-	WriteGeometryVisitor(TileBbox *bp, vector_tile::Tile_Feature *fp, double sl);
+	WriteGeometryVisitor(const TileBbox *bp, vector_tile::Tile_Feature *fp, double sl);
 
 	// Point
-	void operator()(Point &p) const;
+	void operator()(const Point &p) const;
 
 	// Multipolygon
-	void operator()(MultiPolygon &mp) const;
+	void operator()(const MultiPolygon &mp) const;
 
 	// Multilinestring
-	void operator()(MultiLinestring &mls) const;
+	void operator()(const MultiLinestring &mls) const;
 
 	// Linestring
-	void operator()(Linestring &ls) const;
+	void operator()(const Linestring &ls) const;
 
 	// Encode a series of pixel co-ordinates into the feature, using delta and zigzag encoding
 	void writeDeltaString(XYString *scaledString, vector_tile::Tile_Feature *featurePtr, std::pair<int,int> *lastPos, bool closePath) const;

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -33,7 +33,7 @@
 		"name": "Tilemaker to OpenTileMaps schema",
 		"version": "0.1",
 		"description": "Tile config based on opentilemap schema",
-		"compress": "gzip",
+		"compress": "none",
 		"metadata": {
 			"json": { "vector_layers": [
 						{ "id": "transportation",     "description": "transportation",     "fields": {"class":"String"}},

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -20,7 +20,7 @@
 		"mountain_peak": { "minzoom": 11, "maxzoom": 14 },
 		"sea": {
 			"minzoom": 4, "maxzoom": 14,
-			"source": "fixed_water_polygons.shp",
+			"source": "water-polygons-split-4326/fixed_water_polygons.shp",
 			"simplify_below": 13, "simplify_level": 0.0003,
 			"write_to": "water"
 		}

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -20,7 +20,7 @@
 		"mountain_peak": { "minzoom": 11, "maxzoom": 14 },
 		"sea": {
 			"minzoom": 4, "maxzoom": 14,
-			"source": "water-polygons-split-4326/fixed_water_polygons.shp",
+			"source": "fixed_water_polygons.shp",
 			"simplify_below": 13, "simplify_level": 0.0003,
 			"write_to": "water"
 		}

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -20,7 +20,7 @@
 		"mountain_peak": { "minzoom": 11, "maxzoom": 14 },
 		"sea": {
 			"minzoom": 4, "maxzoom": 14,
-			"source": "../mappatches/coast.shp",
+			"source": "water-polygons-split-4326/fixed_water_polygons.shp",
 			"simplify_below": 13, "simplify_level": 0.0003,
 			"write_to": "water"
 		}

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -23,8 +23,8 @@ double tiley2latp(uint y, uint z) { return 180.0 - scalbn(y, -(int)z) * 360.0; }
 double tiley2lat(uint y, uint z) { return latp2lat(tiley2latp(y, z)); }
 
 // Get a tile index
-uint32_t latpLon2index(LatpLon ll, uint baseZoom) {
-	return lon2tilex(ll.lon /10000000.0, baseZoom) * 65536 +
+uint64_t latpLon2index(LatpLon ll, uint baseZoom) {
+	return lon2tilex(ll.lon /10000000.0, baseZoom) * 4294967296 +
 	       latp2tiley(ll.latp/10000000.0, baseZoom);
 }
 
@@ -37,17 +37,17 @@ double meter2degp(double meter, double latp) {
 }
 
 // the range between smallest y and largest y is filled, for each x
-void fillCoveredTiles(unordered_set<uint32_t> &tileSet) {
-	vector<uint32_t> tileList(tileSet.begin(), tileSet.end());
+void fillCoveredTiles(unordered_set<uint64_t> &tileSet) {
+	vector<uint64_t> tileList(tileSet.begin(), tileSet.end());
 	sort(tileList.begin(), tileList.end());
 
-	uint prevX = 0, prevY = static_cast<uint>(-2);
-	for (uint32_t index: tileList) {
-		uint tileX = index >> 16, tileY = index & 65535;
+	uint64_t prevX = 0, prevY = static_cast<uint64_t>(-2);
+	for (uint64_t index: tileList) {
+		uint64_t tileX = index >> 32, tileY = index & 4294967296;
 		if (tileX == prevX) {
 			// this loop has no effect at the first iteration
-			for (uint fillY = prevY+1; fillY < tileY; fillY++) {
-				tileSet.insert((tileX << 16) + fillY);
+			for (uint64_t fillY = prevY+1; fillY < tileY; fillY++) {
+				tileSet.insert((tileX << 32) + fillY);
 			}
 		}
 		prevX = tileX, prevY = tileY;
@@ -58,10 +58,10 @@ void fillCoveredTiles(unordered_set<uint32_t> &tileSet) {
 // ------------------------------------------------------
 // Helper class for dealing with spherical Mercator tiles
 
-TileBbox::TileBbox(uint i, uint z) {
+TileBbox::TileBbox(uint64_t i, uint z) {
 	index = i; zoom = z;
-	tiley = index & 65535;
-	tilex = index >> 16;
+	tiley = index & 4294967295L;
+	tilex = index >> 32;
 	minLon = tilex2lon(tilex  ,zoom);
 	minLat = tiley2lat(tiley+1,zoom);
 	maxLon = tilex2lon(tilex+1,zoom);

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -53,12 +53,12 @@ void fillCoveredTiles(unordered_set<TileCoordinates> &tileSet) {
 	vector<TileCoordinates> tileList(tileSet.begin(), tileSet.end());
 	sort(tileList.begin(), tileList.end(), TileCoordinatesCompare());
 
-	uint64_t prevX = 0, prevY = static_cast<uint64_t>(-2);
+	TileCoordinate prevX = 0, prevY = static_cast<TileCoordinate>(-2);
 	for (TileCoordinates index: tileList) {
-		uint64_t tileX = index.x, tileY = index.y;
+		TileCoordinate tileX = index.x, tileY = index.y;
 		if (tileX == prevX) {
 			// this loop has no effect at the first iteration
-			for (uint64_t fillY = prevY+1; fillY < tileY; fillY++) {
+			for (TileCoordinate fillY = prevY+1; fillY < tileY; fillY++) {
 				tileSet.insert(TileCoordinates(tileX, fillY));
 			}
 		}
@@ -73,12 +73,10 @@ void fillCoveredTiles(unordered_set<TileCoordinates> &tileSet) {
 TileBbox::TileBbox(TileCoordinates i, uint z) {
 	zoom = z;
 	index = i;
-        tilex = i.x;
-        tiley = i.y;
-	minLon = tilex2lon(tilex  ,zoom);
-	minLat = tiley2lat(tiley+1,zoom);
-	maxLon = tilex2lon(tilex+1,zoom);
-	maxLat = tiley2lat(tiley  ,zoom);
+	minLon = tilex2lon(i.x  ,zoom);
+	minLat = tiley2lat(i.y+1,zoom);
+	maxLon = tilex2lon(i.x+1,zoom);
+	maxLat = tiley2lat(i.y  ,zoom);
 	minLatp = lat2latp(minLat);
 	maxLatp = lat2latp(maxLat);
 	xmargin = (maxLon -minLon )/200.0;

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -76,7 +76,7 @@ TileBbox::TileBbox(uint i, uint z) {
 		              geom::make<Point>(maxLon+xmargin, maxLatp+ymargin));
 }
 
-pair<int,int> TileBbox::scaleLatpLon(double latp, double lon) {
+pair<int,int> TileBbox::scaleLatpLon(double latp, double lon) const {
 	int x = (lon -   minLon) / xscale;
 	int y = (maxLatp - latp) / yscale;
 	return pair<int,int>(x,y);

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -113,12 +113,14 @@ void ConvertToClipper(const Polygon &p, Path &outer, Paths &inners)
 	const Polygon::ring_type &out = p.outer();
 	const Polygon::inner_container_type &inns = p.inners();
 
-	for(size_t i=0; i<out.size(); i++) {
+	for(size_t i=0; i<out.size(); i++)
+	{
 		const Point &pt = out[i];
 		outer.push_back(IntPoint(std::round(pt.x() * CLIPPER_SCALE), std::round(pt.y() * CLIPPER_SCALE)));
 	}
 
-	for(size_t i=0; i<inns.size(); i++) {
+	for(size_t i=0; i<inns.size(); i++)
+	{
 		Path in;
 		const Polygon::ring_type &inner = inns[i];
 		for(size_t j=0; j<inner.size(); j++)
@@ -130,19 +132,22 @@ void ConvertToClipper(const Polygon &p, Path &outer, Paths &inners)
 	}
 }
 
-void ConvertToClipper(const MultiPolygon &mp, Paths &out) {
+void ConvertToClipper(const MultiPolygon &mp, Paths &out)
+{
 	// Convert boost geometries to clipper paths 
 	out.clear();
 	Clipper c;
 	c.StrictlySimple(true);
-	for(size_t i=0; i<mp.size(); i++) {
+	for(size_t i=0; i<mp.size(); i++)
+	{
 		const Polygon &p = mp[i];
 		Path outer;
 		Paths inners;
 		ConvertToClipper(p, outer, inners);
 
 		// For polygons with holes,
-		if(inners.size()>0) {
+		if(inners.size()>0)
+		{
 			// Find polygon shapes without needing holes
 			Paths simp;
 			c.AddPath(outer, ptSubject, true);
@@ -151,36 +156,43 @@ void ConvertToClipper(const MultiPolygon &mp, Paths &out) {
 			c.Clear();
 
 			out.insert(out.end(), simp.begin(), simp.end());
-		} else {
+		}
+		else
+		{
 			out.push_back(outer);				
 		}
 	}
 }
 
-void ConvertFromClipper(const Path &outer, const Paths &inners, Polygon &p) {
+void ConvertFromClipper(const Path &outer, const Paths &inners, Polygon &p)
+{
 	p.clear();
 	Polygon::ring_type &out = p.outer();
 	Polygon::inner_container_type &inns = p.inners();
 	
-	for(size_t i=0; i<outer.size(); i++) {
+	for(size_t i=0; i<outer.size(); i++)
+	{
 		const IntPoint &pt = outer[i];
 		out.push_back(Point(pt.X / CLIPPER_SCALE, pt.Y / CLIPPER_SCALE));
 	}
-
-	if(outer.size()>0) {
+	if(outer.size()>0)
+	{
 		//Start point in ring is repeated
 		const IntPoint &pt = outer[0];
 		out.push_back(Point(pt.X / CLIPPER_SCALE, pt.Y / CLIPPER_SCALE));
 	}
 
-	for(size_t i=0; i<inners.size(); i++) {
+	for(size_t i=0; i<inners.size(); i++)
+	{
 		const Path &inn = inners[i];
 		Polygon::ring_type inn2;
-		for(size_t j=0; j<inn.size(); j++) {
+		for(size_t j=0; j<inn.size(); j++)
+		{
 			const IntPoint &pt = inn[j];
 			inn2.push_back(Point(pt.X / CLIPPER_SCALE, pt.Y / CLIPPER_SCALE));
 		}
-		if(inn.size()>0) {
+		if(inn.size()>0)
+		{
 			//Start point in ring is repeated
 			const IntPoint &pt = inn[0];
 			inn2.push_back(Point(pt.X / CLIPPER_SCALE, pt.Y / CLIPPER_SCALE));
@@ -191,19 +203,23 @@ void ConvertFromClipper(const Path &outer, const Paths &inners, Polygon &p) {
 	geom::correct(p);
 }
 
-void ConvertFromClipper(const Paths &polys, MultiPolygon &mp) {
+void ConvertFromClipper(const Paths &polys, MultiPolygon &mp)
+{
 	mp.clear();
 
-	for(size_t pn=0; pn < polys.size(); pn++) {
+	for(size_t pn=0; pn < polys.size(); pn++)
+	{
 		const Path &pth = polys[pn];
 		Polygon p;
 		Polygon::ring_type &otr = p.outer();
 
-		for(size_t i=0; i<pth.size(); i++) {
+		for(size_t i=0; i<pth.size(); i++)
+		{
 			const IntPoint &pt = pth[i];
 			otr.push_back(Point(pt.X / CLIPPER_SCALE, pt.Y / CLIPPER_SCALE));
 		}
-		if(pth.size()>0) {
+		if(pth.size()>0)
+		{
 			//Start point in ring is repeated
 			const IntPoint &pt = pth[0];
 			otr.push_back(Point(pt.X / CLIPPER_SCALE, pt.Y / CLIPPER_SCALE));
@@ -214,3 +230,4 @@ void ConvertFromClipper(const Paths &polys, MultiPolygon &mp) {
 	}
 	assert(polys.size() == mp.size());
 }
+

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -104,7 +104,7 @@ std::string decompress_string(const std::string& str) {
     return outstring;
 }
 
-const double CLIPPER_SCALE = 1e6;
+const double CLIPPER_SCALE = 1e8;
 
 void ConvertToClipper(const Polygon &p, Path &outer, Paths &inners)
 {

--- a/src/osm_object.cpp
+++ b/src/osm_object.cpp
@@ -16,31 +16,6 @@ OSMObject::OSMObject(kaguya::State &luaObj, map< string, RTree> *idxPtr,
 	osmStore = storePtr;
 }
 
-// Define a layer (as read from the .json file)
-uint OSMObject::addLayer(string name, uint minzoom, uint maxzoom,
-		uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, string writeTo) {
-	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, std::map<std::string,uint>() };
-	layers.push_back(layer);
-	uint layerNum = layers.size()-1;
-	layerMap[name] = layerNum;
-
-	if (writeTo.empty()) {
-		vector<uint> r = { layerNum };
-		layerOrder.push_back(r);
-	} else {
-		if (layerMap.count(writeTo) == 0) {
-			throw out_of_range("ERROR: addLayer(): the layer to write, named as \"" + writeTo + "\", doesn't exist.");
-		}
-		uint lookingFor = layerMap[writeTo];
-		for (auto it = layerOrder.begin(); it!= layerOrder.end(); ++it) {
-			if (it->at(0)==lookingFor) {
-				it->push_back(layerNum);
-			}
-		}
-	}
-	return layerNum;
-}
-
 // Read string dictionary from the .pbf
 void OSMObject::readStringTable(PrimitiveBlock *pbPtr) {
 	// Populate the string table

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -93,7 +93,7 @@ bool OutputObject::hasAttribute(const string &key) const {
 // Returns a boost::variant -
 //   POLYGON->MultiPolygon, CENTROID->Point, LINESTRING->MultiLinestring
 Geometry OutputObject::buildWayGeometry(const OSMStore &osmStore,
-                      TileBbox *bboxPtr, 
+                      const TileBbox *bboxPtr, 
                       const vector<Geometry> &cachedGeometries) const {
 
 	ClipGeometryVisitor clip(bboxPtr->clippingBox);
@@ -140,7 +140,7 @@ Geometry OutputObject::buildWayGeometry(const OSMStore &osmStore,
 }
 
 // Add a node geometry
-void OutputObject::buildNodeGeometry(LatpLon ll, TileBbox *bboxPtr, vector_tile::Tile_Feature *featurePtr) const {
+void OutputObject::buildNodeGeometry(LatpLon ll, const TileBbox *bboxPtr, vector_tile::Tile_Feature *featurePtr) const {
 	featurePtr->add_geometry(9);					// moveTo, repeat x1
 	pair<int,int> xy = bboxPtr->scaleLatpLon(ll.latp/10000000.0, ll.lon/10000000.0);
 	featurePtr->add_geometry((xy.first  << 1) ^ (xy.first  >> 31));

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -47,6 +47,10 @@ Geometry ClipGeometryVisitor::operator()(const MultiLinestring &mls) const {
 }
 
 Geometry ClipGeometryVisitor::operator()(const MultiPolygon &mp) const {
+	Polygon clippingPolygon;
+	geom::convert(clippingBox,clippingPolygon);
+	if (geom::within(mp, clippingPolygon)) { return mp; }
+
 	MultiPolygon out;
 	string reason;
 

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -47,10 +47,6 @@ Geometry ClipGeometryVisitor::operator()(const MultiLinestring &mls) const {
 }
 
 Geometry ClipGeometryVisitor::operator()(const MultiPolygon &mp) const {
-	Polygon clippingPolygon;
-	geom::convert(clippingBox,clippingPolygon);
-	if (geom::within(mp, clippingPolygon)) { return mp; }
-
 	MultiPolygon out;
 	string reason;
 

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -37,7 +37,7 @@ bool ReadNodes(PrimitiveGroup &pg, const unordered_set<int> &nodeKeyPositions, s
 				osmObject.setNode(nodeId, &dense, kvStart, kvPos-1, node);
 				osmObject.luaState["node_function"](&osmObject);
 				if (!osmObject.empty()) {
-					uint32_t index = latpLon2index(node, osmObject.baseZoom);
+					uint32_t index = latpLon2index(node, osmObject.config.baseZoom);
 					for (auto jt = osmObject.outputs.begin(); jt != osmObject.outputs.end(); ++jt) {
 						tileIndex[index].push_back(*jt);
 					}
@@ -98,7 +98,7 @@ bool ReadWays(PrimitiveGroup &pg, unordered_set<WayID> &waysInRelation, std::map
 				// create a list of tiles this way passes through (tileSet)
 				unordered_set<uint32_t> tileSet;
 				try {
-					insertIntermediateTiles(osmStore->nodeListLinestring(nodeVec), osmObject.baseZoom, tileSet);
+					insertIntermediateTiles(osmStore->nodeListLinestring(nodeVec), osmObject.config.baseZoom, tileSet);
 
 					// then, for each tile, store the OutputObject for each layer
 					bool polygonExists = false;
@@ -201,12 +201,12 @@ bool ReadRelations(PrimitiveGroup &pg, std::map< uint, std::vector<OutputObject>
 
 					unordered_set<uint32_t> tileSet;
 					if (mp.size() == 1) {
-						insertIntermediateTiles(mp[0].outer(), osmObject.baseZoom, tileSet);
+						insertIntermediateTiles(mp[0].outer(), osmObject.config.baseZoom, tileSet);
 						fillCoveredTiles(tileSet);
 					} else {
 						for (Polygon poly: mp) {
 							unordered_set<uint32_t> tileSetTmp;
-							insertIntermediateTiles(poly.outer(), osmObject.baseZoom, tileSetTmp);
+							insertIntermediateTiles(poly.outer(), osmObject.config.baseZoom, tileSetTmp);
 							fillCoveredTiles(tileSetTmp);
 							tileSet.insert(tileSetTmp.begin(), tileSetTmp.end());
 						}

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -3,7 +3,7 @@
 #include "pbf_blocks.h"
 using namespace std;
 
-bool ReadNodes(PrimitiveGroup &pg, const unordered_set<int> &nodeKeyPositions, std::map< uint, std::vector<OutputObject> > &tileIndex, 
+bool ReadNodes(PrimitiveGroup &pg, const unordered_set<int> &nodeKeyPositions, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, 
 	class OSMStore *osmStore, OSMObject &osmObject)
 {
 	// ----	Read nodes
@@ -49,7 +49,7 @@ bool ReadNodes(PrimitiveGroup &pg, const unordered_set<int> &nodeKeyPositions, s
 	return false;
 }
 
-bool ReadWays(PrimitiveGroup &pg, unordered_set<WayID> &waysInRelation, std::map< uint, 
+bool ReadWays(PrimitiveGroup &pg, unordered_set<WayID> &waysInRelation, std::map< uint64_t, 
 	std::vector<OutputObject> > &tileIndex, class OSMStore *osmStore, OSMObject &osmObject)
 {
 	// ----	Read ways
@@ -96,14 +96,14 @@ bool ReadWays(PrimitiveGroup &pg, unordered_set<WayID> &waysInRelation, std::map
 
 			if (!osmObject.empty()) {
 				// create a list of tiles this way passes through (tileSet)
-				unordered_set<uint32_t> tileSet;
+				unordered_set<uint64_t> tileSet;
 				try {
 					insertIntermediateTiles(osmStore->nodeListLinestring(nodeVec), osmObject.config.baseZoom, tileSet);
 
 					// then, for each tile, store the OutputObject for each layer
 					bool polygonExists = false;
 					for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
-						uint32_t index = *it;
+						uint64_t index = *it;
 						for (auto jt = osmObject.outputs.begin(); jt != osmObject.outputs.end(); ++jt) {
 							if (jt->geomType == POLYGON) {
 								polygonExists = true;
@@ -117,7 +117,7 @@ bool ReadWays(PrimitiveGroup &pg, unordered_set<WayID> &waysInRelation, std::map
 					if (polygonExists) {
 						fillCoveredTiles(tileSet);
 						for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
-							uint32_t index = *it;
+							uint64_t index = *it;
 							for (auto jt = osmObject.outputs.begin(); jt != osmObject.outputs.end(); ++jt) {
 								if (jt->geomType != POLYGON) continue;
 								tileIndex[index].push_back(*jt);
@@ -135,7 +135,7 @@ bool ReadWays(PrimitiveGroup &pg, unordered_set<WayID> &waysInRelation, std::map
 	return false;
 }
 
-bool ReadRelations(PrimitiveGroup &pg, std::map< uint, std::vector<OutputObject> > &tileIndex, 
+bool ReadRelations(PrimitiveGroup &pg, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, 
 	class OSMStore *osmStore, OSMObject &osmObject)
 {
 	// ----	Read relations
@@ -199,13 +199,13 @@ bool ReadRelations(PrimitiveGroup &pg, std::map< uint, std::vector<OutputObject>
 						continue;
 					}		
 
-					unordered_set<uint32_t> tileSet;
+					unordered_set<uint64_t> tileSet;
 					if (mp.size() == 1) {
 						insertIntermediateTiles(mp[0].outer(), osmObject.config.baseZoom, tileSet);
 						fillCoveredTiles(tileSet);
 					} else {
 						for (Polygon poly: mp) {
-							unordered_set<uint32_t> tileSetTmp;
+							unordered_set<uint64_t> tileSetTmp;
 							insertIntermediateTiles(poly.outer(), osmObject.config.baseZoom, tileSetTmp);
 							fillCoveredTiles(tileSetTmp);
 							tileSet.insert(tileSetTmp.begin(), tileSetTmp.end());
@@ -226,7 +226,7 @@ bool ReadRelations(PrimitiveGroup &pg, std::map< uint, std::vector<OutputObject>
 	return false;
 }
 
-int ReadPbfFile(const string &inputFile, unordered_set<string> &nodeKeys, std::map< uint, std::vector<OutputObject> > &tileIndex, 
+int ReadPbfFile(const string &inputFile, unordered_set<string> &nodeKeys, std::map< uint64_t, std::vector<OutputObject> > &tileIndex, 
 	OSMObject &osmObject)
 {
 	// ----	Read PBF

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -37,7 +37,7 @@ bool ReadNodes(PrimitiveGroup &pg, const unordered_set<int> &nodeKeyPositions, s
 				osmObject.setNode(nodeId, &dense, kvStart, kvPos-1, node);
 				osmObject.luaState["node_function"](&osmObject);
 				if (!osmObject.empty()) {
-					uint32_t index = latpLon2index(node, osmObject.config.baseZoom);
+					uint64_t index = latpLon2index(node, osmObject.config.baseZoom);
 					for (auto jt = osmObject.outputs.begin(); jt != osmObject.outputs.end(); ++jt) {
 						tileIndex[index].push_back(*jt);
 					}
@@ -213,7 +213,7 @@ bool ReadRelations(PrimitiveGroup &pg, std::map< uint64_t, std::vector<OutputObj
 					}
 
 					for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
-						uint32_t index = *it;
+						uint64_t index = *it;
 						for (auto jt = osmObject.outputs.begin(); jt != osmObject.outputs.end(); ++jt) {
 							tileIndex[index].push_back(*jt);
 						}

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -29,7 +29,7 @@ void fillPointArrayFromShapefile(vector<Point> *points, SHPObject *shape, uint p
 }
 
 // Add an OutputObject to all tiles between min/max lat/lon
-void addToTileIndexByBbox(OutputObject &oo, map< uint64_t, vector<OutputObject> > &tileIndex, uint baseZoom,
+void addToTileIndexByBbox(OutputObject &oo, map< TileCoordinates, vector<OutputObject>, TileCoordinatesCompare > &tileIndex, uint baseZoom,
                           double minLon, double minLatp, double maxLon, double maxLatp) {
 	uint minTileX =  lon2tilex(minLon, baseZoom);
 	uint maxTileX =  lon2tilex(maxLon, baseZoom);
@@ -37,25 +37,25 @@ void addToTileIndexByBbox(OutputObject &oo, map< uint64_t, vector<OutputObject> 
 	uint maxTileY = latp2tiley(maxLatp, baseZoom);
 	for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
 		for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
-			uint64_t index = x*4294967296+y;
+			TileCoordinates index(x, y);
 			tileIndex[index].push_back(oo);
 		}
 	}
 }
 
 // Add an OutputObject to all tiles along a polyline
-void addToTileIndexPolyline(OutputObject &oo, map< uint64_t, vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls) {
+void addToTileIndexPolyline(OutputObject &oo, map< TileCoordinates, vector<OutputObject>, TileCoordinatesCompare > &tileIndex, uint baseZoom, const Linestring &ls) {
 	uint lastx = UINT_MAX;
 	uint lasty;
 	for (Linestring::const_iterator jt = ls.begin(); jt != ls.end(); ++jt) {
 		uint tilex =  lon2tilex(jt->get<0>(), baseZoom);
 		uint tiley = latp2tiley(jt->get<1>(), baseZoom);
 		if (lastx==UINT_MAX) {
-			tileIndex[tilex*4294967296+tiley].push_back(oo);
+			tileIndex[TileCoordinates(tilex, tiley)].push_back(oo);
 		} else if (lastx!=tilex || lasty!=tiley) {
 			for (uint x=min(tilex,lastx); x<=max(tilex,lastx); x++) {
 				for (uint y=min(tiley,lasty); y<=max(tiley,lasty); y++) {
-					tileIndex[x*4294967296+y].push_back(oo);
+					tileIndex[TileCoordinates(x, y)].push_back(oo);
 				}
 			}
 		}
@@ -94,7 +94,7 @@ void addShapefileAttributes(
 void readShapefile(string filename, 
                    vector<string> &columns,
                    const Box &clippingBox, 
-                   map< uint64_t, vector<OutputObject> > &tileIndex, 
+                   map< TileCoordinates, vector<OutputObject>, TileCoordinatesCompare > &tileIndex, 
                    vector<Geometry> &cachedGeometries,
 				   OSMObject &osmObject,
                    uint baseZoom, uint layerNum, const string &layerName,
@@ -138,7 +138,7 @@ void readShapefile(string filename,
 				cachedGeometries.push_back(p);
 				OutputObject oo(CACHED_POINT, layerNum, cachedGeometries.size()-1);
 				addShapefileAttributes(dbf,oo,i,columnMap,columnTypeMap,osmObject);
-				tileIndex[tilex*65536+tiley].push_back(oo);
+				tileIndex[TileCoordinates(tilex, tiley)].push_back(oo);
 				if (isIndexed) {
 					uint64_t id = cachedGeometries.size()-1;
 					geom::envelope(p, box); osmObject.indices->at(layerName).insert(std::make_pair(box, id));

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -93,13 +93,13 @@ void addShapefileAttributes(
 // Read shapefile, and create OutputObjects for all objects within the specified bounding box
 void readShapefile(string filename, 
                    vector<string> &columns,
-                   Box &clippingBox, 
+                   const Box &clippingBox, 
                    map< uint, vector<OutputObject> > &tileIndex, 
                    vector<Geometry> &cachedGeometries,
 				   OSMObject &osmObject,
-                   uint baseZoom, uint layerNum, string &layerName,
+                   uint baseZoom, uint layerNum, const string &layerName,
                    bool isIndexed,
-				   string &indexName) {
+				   const string &indexName) {
 
 	// open shapefile
 	SHPHandle shp = SHPOpen(filename.c_str(), "rb");

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -29,7 +29,7 @@ void fillPointArrayFromShapefile(vector<Point> *points, SHPObject *shape, uint p
 }
 
 // Add an OutputObject to all tiles between min/max lat/lon
-void addToTileIndexByBbox(OutputObject &oo, map< uint, vector<OutputObject> > &tileIndex, uint baseZoom,
+void addToTileIndexByBbox(OutputObject &oo, map< uint64_t, vector<OutputObject> > &tileIndex, uint baseZoom,
                           double minLon, double minLatp, double maxLon, double maxLatp) {
 	uint minTileX =  lon2tilex(minLon, baseZoom);
 	uint maxTileX =  lon2tilex(maxLon, baseZoom);
@@ -37,25 +37,25 @@ void addToTileIndexByBbox(OutputObject &oo, map< uint, vector<OutputObject> > &t
 	uint maxTileY = latp2tiley(maxLatp, baseZoom);
 	for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
 		for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
-			uint32_t index = x*65536+y;
+			uint64_t index = x*4294967296+y;
 			tileIndex[index].push_back(oo);
 		}
 	}
 }
 
 // Add an OutputObject to all tiles along a polyline
-void addToTileIndexPolyline(OutputObject &oo, map< uint, vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls) {
+void addToTileIndexPolyline(OutputObject &oo, map< uint64_t, vector<OutputObject> > &tileIndex, uint baseZoom, const Linestring &ls) {
 	uint lastx = UINT_MAX;
 	uint lasty;
 	for (Linestring::const_iterator jt = ls.begin(); jt != ls.end(); ++jt) {
 		uint tilex =  lon2tilex(jt->get<0>(), baseZoom);
 		uint tiley = latp2tiley(jt->get<1>(), baseZoom);
 		if (lastx==UINT_MAX) {
-			tileIndex[tilex*65536+tiley].push_back(oo);
+			tileIndex[tilex*4294967296+tiley].push_back(oo);
 		} else if (lastx!=tilex || lasty!=tiley) {
 			for (uint x=min(tilex,lastx); x<=max(tilex,lastx); x++) {
 				for (uint y=min(tiley,lasty); y<=max(tiley,lasty); y++) {
-					tileIndex[x*65536+y].push_back(oo);
+					tileIndex[x*4294967296+y].push_back(oo);
 				}
 			}
 		}
@@ -94,7 +94,7 @@ void addShapefileAttributes(
 void readShapefile(string filename, 
                    vector<string> &columns,
                    const Box &clippingBox, 
-                   map< uint, vector<OutputObject> > &tileIndex, 
+                   map< uint64_t, vector<OutputObject> > &tileIndex, 
                    vector<Geometry> &cachedGeometries,
 				   OSMObject &osmObject,
                    uint baseZoom, uint layerNum, const string &layerName,
@@ -140,7 +140,7 @@ void readShapefile(string filename,
 				addShapefileAttributes(dbf,oo,i,columnMap,columnTypeMap,osmObject);
 				tileIndex[tilex*65536+tiley].push_back(oo);
 				if (isIndexed) {
-					uint id = cachedGeometries.size()-1;
+					uint64_t id = cachedGeometries.size()-1;
 					geom::envelope(p, box); osmObject.indices->at(layerName).insert(std::make_pair(box, id));
 					if (indexField>-1) { osmObject.cachedGeometryNames->operator[](id)=DBFReadStringAttribute(dbf, i, indexField); }
 				}

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -216,13 +216,13 @@ int outputProc(uint threadId, class SharedData *sharedData)
 			// Write to sqlite
 			tile.SerializeToString(&data);
 			if (sharedData->config.compress) { compressed = compress_string(data, Z_DEFAULT_COMPRESSION, sharedData->config.gzip); }
-			sharedData->mbtiles.saveTile(zoom, bbox.tilex, bbox.tiley, sharedData->config.compress ? &compressed : &data);
+			sharedData->mbtiles.saveTile(zoom, bbox.index.x, bbox.index.y, sharedData->config.compress ? &compressed : &data);
 
 		} else {
 			// Write to file
 			stringstream dirname, filename;
-			dirname  << sharedData->outputFile << "/" << zoom << "/" << bbox.tilex;
-			filename << sharedData->outputFile << "/" << zoom << "/" << bbox.tilex << "/" << bbox.tiley << ".pbf";
+			dirname  << sharedData->outputFile << "/" << zoom << "/" << bbox.index.x;
+			filename << sharedData->outputFile << "/" << zoom << "/" << bbox.index.x << "/" << bbox.index.y << ".pbf";
 			boost::filesystem::create_directories(dirname.str());
 			fstream outfile(filename.str(), ios::out | ios::trunc | ios::binary);
 			if (sharedData->config.compress) {

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -10,7 +10,7 @@ typedef vector<OutputObject>::const_iterator OutputObjectsConstIt;
 typedef pair<OutputObjectsConstIt,OutputObjectsConstIt> OutputObjectsConstItPair;
 
 void CheckNextObjectAndMerge(OutputObjectsConstIt &jt, const OutputObjectsConstIt &ooSameLayerEnd, 
-	class SharedData *sharedData, TileBbox &bbox, Geometry &g)
+	class SharedData *sharedData, const TileBbox &bbox, Geometry &g)
 {
 	// If a object is a polygon or a linestring that is followed by
 	// other objects with the same geometry type and the same attributes,
@@ -89,10 +89,10 @@ void CheckNextObjectAndMerge(OutputObjectsConstIt &jt, const OutputObjectsConstI
 }
 
 void ProcessObjects(const OutputObjectsConstIt &ooSameLayerBegin, const OutputObjectsConstIt &ooSameLayerEnd, 
-	class SharedData *sharedData, double simplifyLevel, TileBbox &bbox,
+	class SharedData *sharedData, double simplifyLevel, const TileBbox &bbox,
 	vector_tile::Tile_Layer *vtLayer, vector<string> &keyList, vector<vector_tile::Tile_Value> &valueList)
 {
-	NodeStore &nodes = sharedData->osmStore->nodes;
+	const NodeStore &nodes = sharedData->osmStore->nodes;
 
 	for (OutputObjectsConstIt jt = ooSameLayerBegin; jt != ooSameLayerEnd; ++jt) {
 			
@@ -128,7 +128,7 @@ void ProcessObjects(const OutputObjectsConstIt &ooSameLayerBegin, const OutputOb
 }
 
 void ProcessLayer(uint zoom, uint index, const vector<OutputObject> &ooList, vector_tile::Tile &tile, 
-	TileBbox &bbox, std::vector<uint> &ltx, class SharedData *sharedData)
+	const TileBbox &bbox, const std::vector<uint> &ltx, class SharedData *sharedData)
 {
 	vector<string> keyList;
 	vector<vector_tile::Tile_Value> valueList;
@@ -140,7 +140,7 @@ void ProcessLayer(uint zoom, uint index, const vector<OutputObject> &ooList, vec
 	// Loop through sub-layers
 	for (auto mt = ltx.begin(); mt != ltx.end(); ++mt) {
 		uint layerNum = *mt;
-		LayerDef ld = sharedData->config.layers[layerNum];
+		const LayerDef &ld = sharedData->config.layers[layerNum];
 		if (zoom<ld.minzoom || zoom>ld.maxzoom) { continue; }
 		double simplifyLevel = 0.0;
 		if (zoom < ld.simplifyBelow) {

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -35,7 +35,7 @@ void CheckNextObjectAndMerge(OutputObjectsConstIt &jt, const OutputObjectsConstI
 
 			try {
 
-				MultiPolygon gNew = boost::get<MultiPolygon>(jt->buildWayGeometry(*sharedData->osmStore, &bbox, sharedData->config.cachedGeometries));
+				MultiPolygon gNew = boost::get<MultiPolygon>(jt->buildWayGeometry(*sharedData->osmStore, &bbox, *sharedData->cachedGeometries));
 				Paths newPaths;
 				ConvertToClipper(gNew, newPaths);
 
@@ -70,7 +70,7 @@ void CheckNextObjectAndMerge(OutputObjectsConstIt &jt, const OutputObjectsConstI
 			jt++;
 			try
 			{
-				MultiLinestring gNew = boost::get<MultiLinestring>(jt->buildWayGeometry(*sharedData->osmStore, &bbox, sharedData->config.cachedGeometries));
+				MultiLinestring gNew = boost::get<MultiLinestring>(jt->buildWayGeometry(*sharedData->osmStore, &bbox, *sharedData->cachedGeometries));
 				MultiLinestring gTmp;
 				geom::union_(*gAcc, gNew, gTmp);
 				*gAcc = move(gTmp);
@@ -104,7 +104,7 @@ void ProcessObjects(const OutputObjectsConstIt &ooSameLayerBegin, const OutputOb
 		} else {
 			Geometry g;
 			try {
-				g = jt->buildWayGeometry(*sharedData->osmStore, &bbox, sharedData->config.cachedGeometries);
+				g = jt->buildWayGeometry(*sharedData->osmStore, &bbox, *sharedData->cachedGeometries);
 			}
 			catch (std::out_of_range &err)
 			{

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -127,15 +127,15 @@ void ProcessObjects(const OutputObjectsConstIt &ooSameLayerBegin, const OutputOb
 	}
 }
 
-void ProcessLayer(uint zoom, uint index, const vector<OutputObject> &ooList, vector_tile::Tile &tile, 
+void ProcessLayer(uint zoom, uint64_t index, const vector<OutputObject> &ooList, vector_tile::Tile &tile, 
 	const TileBbox &bbox, const std::vector<uint> &ltx, class SharedData *sharedData)
 {
 	vector<string> keyList;
 	vector<vector_tile::Tile_Value> valueList;
 	vector_tile::Tile_Layer *vtLayer = tile.add_layers();
 
-	//uint tileX = index >> 16;
-	uint tileY = index & 65535;
+	//uint tileX = index >> 32;
+	uint tileY = index & 4294967296;
 
 	// Loop through sub-layers
 	for (auto mt = ltx.begin(); mt != ltx.end(); ++mt) {
@@ -184,7 +184,7 @@ int outputProc(uint threadId, class SharedData *sharedData)
 
 	// Loop through tiles
 	uint tc = 0;
-	uint index = 0;
+	uint64_t index = 0;
 	uint zoom = sharedData->zoom;
 	for (auto it = sharedData->tileIndexForZoom->begin(); it != sharedData->tileIndexForZoom->end(); ++it) {
 		uint interval = 100;
@@ -198,7 +198,7 @@ int outputProc(uint threadId, class SharedData *sharedData)
 		// Create tile
 		vector_tile::Tile tile;
 		index = it->first;
-		TileBbox bbox(index,zoom);
+		TileBbox bbox(index, zoom);
 		const vector<OutputObject> &ooList = it->second;
 		if (sharedData->config.clippingBoxFromJSON && (sharedData->config.maxLon<=bbox.minLon 
 			|| sharedData->config.minLon>=bbox.maxLon || sharedData->config.maxLat<=bbox.minLat 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -127,15 +127,15 @@ void ProcessObjects(const OutputObjectsConstIt &ooSameLayerBegin, const OutputOb
 	}
 }
 
-void ProcessLayer(uint zoom, uint64_t index, const vector<OutputObject> &ooList, vector_tile::Tile &tile, 
+void ProcessLayer(uint zoom, TileCoordinates index, const vector<OutputObject> &ooList, vector_tile::Tile &tile, 
 	const TileBbox &bbox, const std::vector<uint> &ltx, class SharedData *sharedData)
 {
 	vector<string> keyList;
 	vector<vector_tile::Tile_Value> valueList;
 	vector_tile::Tile_Layer *vtLayer = tile.add_layers();
 
-	//uint tileX = index >> 32;
-	uint tileY = index & 4294967296;
+	//TileCoordinate tileX = index.x;
+	TileCoordinate tileY = index.y;
 
 	// Loop through sub-layers
 	for (auto mt = ltx.begin(); mt != ltx.end(); ++mt) {
@@ -184,7 +184,7 @@ int outputProc(uint threadId, class SharedData *sharedData)
 
 	// Loop through tiles
 	uint tc = 0;
-	uint64_t index = 0;
+	TileCoordinates index(0, 0);
 	uint zoom = sharedData->zoom;
 	for (auto it = sharedData->tileIndexForZoom->begin(); it != sharedData->tileIndexForZoom->end(); ++it) {
 		uint interval = 100;

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -69,7 +69,7 @@ int lua_error_handler(int errCode, const char *errMessage)
 	exit(0);
 }
 
-void loadExternalShpFiles(class Config &config, bool hasClippingBox, Box &clippingBox,
+void loadExternalShpFiles(class Config &config, bool hasClippingBox, const Box &clippingBox,
                 map< uint, vector<OutputObject> > &tileIndex, 
 				std::vector<Geometry> &cachedGeometries,
 				OSMObject &osmObject)
@@ -214,6 +214,14 @@ int main(int argc, char* argv[]) {
 		return -1;
 	}
 
+	if(hasClippingBox)
+	{
+		config.minLon = minLon;
+		config.maxLon = maxLon;
+		config.minLat = minLat;
+		config.maxLat = maxLat;
+	}
+
 	// ----	Initialise SharedData
 
 	class SharedData sharedData(config, &osmStore);
@@ -222,13 +230,6 @@ int main(int argc, char* argv[]) {
 	sharedData.verbose = verbose;
 	sharedData.sqlite = sqlite;
 	sharedData.cachedGeometries = &cachedGeometries;
-	if(hasClippingBox)
-	{
-		sharedData.config.minLon = minLon;
-		sharedData.config.maxLon = maxLon;
-		sharedData.config.minLat = minLat;
-		sharedData.config.maxLat = maxLat;
-	}
 
 	OSMObject osmObject(config, luaState, &indices, &cachedGeometries, &cachedGeometryNames, &osmStore);
 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -154,6 +154,9 @@ int main(int argc, char* argv[]) {
 	#ifdef COMPACT_WAYS
 	cout << "tilemaker compiled without 64-bit way support, use 'osmium renumber' first if working with OpenStreetMap-sourced data" << endl;
 	#endif
+	#ifdef COMPACT_TILE_INDEX
+	cout << "tilemaker compiled without 64-bit tile index support, this limits accuracy at very high zoom levels" << endl;
+	#endif
 
 	// ---- Check config
 	

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -221,6 +221,10 @@ int main(int argc, char* argv[]) {
 	}
 
 	// ----	Read all PBFs
+
+	osmObject.layers = sharedData.config.layers;
+	osmObject.layerMap = sharedData.config.layerMap;
+	osmObject.layerOrder = sharedData.config.layerOrder;
 	
 	for (auto inputFile : inputFiles) {
 	
@@ -231,10 +235,6 @@ int main(int argc, char* argv[]) {
 			return ret;
 	}
 	osmStore.reportSize();
-
-	sharedData.config.layers = osmObject.layers;
-	sharedData.config.layerMap = osmObject.layerMap;
-	sharedData.config.layerOrder = osmObject.layerOrder;
 
 	// ----	Write out each tile
 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -70,7 +70,7 @@ int lua_error_handler(int errCode, const char *errMessage)
 }
 
 void loadExternalShpFiles(class Config &config, bool hasClippingBox, const Box &clippingBox,
-                map< uint64_t, vector<OutputObject> > &tileIndex, 
+                map< TileCoordinates, vector<OutputObject>, TileCoordinatesCompare > &tileIndex, 
 				std::vector<Geometry> &cachedGeometries,
 				OSMObject &osmObject)
 {
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
 	std::vector<Geometry> cachedGeometries;					// prepared boost::geometry objects (from shapefiles)
 	map<uint, string> cachedGeometryNames;			//  | optional names for each one
 
-	map< uint64_t, vector<OutputObject> > tileIndex;				// objects to be output
+	map< TileCoordinates, vector<OutputObject>, TileCoordinatesCompare > tileIndex;				// objects to be output
 
 	// ----	Read command-line options
 	
@@ -280,7 +280,7 @@ int main(int argc, char* argv[]) {
 	// Loop through zoom levels
 	for (uint zoom=sharedData.config.startZoom; zoom<=sharedData.config.endZoom; zoom++) {
 		// Create list of tiles, and the data in them
-		map< uint64_t, vector<OutputObject> > generatedIndex;
+		map< TileCoordinates, vector<OutputObject>, TileCoordinatesCompare > generatedIndex;
 		if (zoom==sharedData.config.baseZoom) {
 			// ----	Sort each tile
 			for (auto it = tileIndex.begin(); it != tileIndex.end(); ++it) {
@@ -294,10 +294,10 @@ int main(int argc, char* argv[]) {
 			// otherwise, we need to run through the z14 list, and assign each way
 			// to a tile at our zoom level
 			for (auto it = tileIndex.begin(); it!= tileIndex.end(); ++it) {
-				uint64_t index = it->first;
-				uint64_t tilex = (index >> 32  ) / pow(2, sharedData.config.baseZoom-zoom);
-				uint64_t tiley = (index & 4294967295) / pow(2, sharedData.config.baseZoom-zoom);
-				uint64_t newIndex = (tilex << 32) + tiley;
+				TileCoordinates index = it->first;
+				TileCoordinate tilex = index.x / pow(2, sharedData.config.baseZoom-zoom);
+				TileCoordinate tiley = index.y / pow(2, sharedData.config.baseZoom-zoom);
+				TileCoordinates newIndex(tilex, tiley);
 				const vector<OutputObject> &ooset = it->second;
 				for (auto jt = ooset.begin(); jt != ooset.end(); ++jt) {
 					generatedIndex[newIndex].push_back(*jt);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -70,7 +70,7 @@ int lua_error_handler(int errCode, const char *errMessage)
 }
 
 void loadExternalShpFiles(class Config &config, bool hasClippingBox, const Box &clippingBox,
-                map< uint, vector<OutputObject> > &tileIndex, 
+                map< uint64_t, vector<OutputObject> > &tileIndex, 
 				std::vector<Geometry> &cachedGeometries,
 				OSMObject &osmObject)
 {
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
 	std::vector<Geometry> cachedGeometries;					// prepared boost::geometry objects (from shapefiles)
 	map<uint, string> cachedGeometryNames;			//  | optional names for each one
 
-	map< uint, vector<OutputObject> > tileIndex;				// objects to be output
+	map< uint64_t, vector<OutputObject> > tileIndex;				// objects to be output
 
 	// ----	Read command-line options
 	
@@ -280,7 +280,7 @@ int main(int argc, char* argv[]) {
 	// Loop through zoom levels
 	for (uint zoom=sharedData.config.startZoom; zoom<=sharedData.config.endZoom; zoom++) {
 		// Create list of tiles, and the data in them
-		map< uint, vector<OutputObject> > generatedIndex;
+		map< uint64_t, vector<OutputObject> > generatedIndex;
 		if (zoom==sharedData.config.baseZoom) {
 			// ----	Sort each tile
 			for (auto it = tileIndex.begin(); it != tileIndex.end(); ++it) {
@@ -294,10 +294,10 @@ int main(int argc, char* argv[]) {
 			// otherwise, we need to run through the z14 list, and assign each way
 			// to a tile at our zoom level
 			for (auto it = tileIndex.begin(); it!= tileIndex.end(); ++it) {
-				uint index = it->first;
-				uint tilex = (index >> 16  ) / pow(2, sharedData.config.baseZoom-zoom);
-				uint tiley = (index & 65535) / pow(2, sharedData.config.baseZoom-zoom);
-				uint newIndex = (tilex << 16) + tiley;
+				uint64_t index = it->first;
+				uint64_t tilex = (index >> 32  ) / pow(2, sharedData.config.baseZoom-zoom);
+				uint64_t tiley = (index & 4294967295) / pow(2, sharedData.config.baseZoom-zoom);
+				uint64_t newIndex = (tilex << 32) + tiley;
 				const vector<OutputObject> &ooset = it->second;
 				for (auto jt = ooset.begin(); jt != ooset.end(); ++jt) {
 					generatedIndex[newIndex].push_back(*jt);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -187,12 +187,15 @@ int main(int argc, char* argv[]) {
 		if (jsonConfig.HasParseError()) { cerr << "Invalid JSON file." << endl; return -1; }
 		fclose(fp);
 
-		sharedData.config.readConfig(jsonConfig, hasClippingBox, clippingBox, tileIndex, osmObject);
+		sharedData.config.readConfig(jsonConfig, hasClippingBox, clippingBox);
+		sharedData.config.loadExternal(hasClippingBox, clippingBox, tileIndex, osmObject);
 
 	} catch (...) {
 		cerr << "Couldn't find expected details in JSON file." << endl;
 		return -1;
 	}
+
+	osmObject.baseZoom = sharedData.config.baseZoom;
 
 	// ---- Call init_function of Lua logic
 


### PR DESCRIPTION
I've tried to make the OSMObject object only available to the data loading phase.

The SharedData object is only used in the multi-threaded output phase.

class Config keeps the config settings together and are read in a more organized way. The shp file loading has been spilt out.

I don't fully understand hasClippingBox and clippingBox in tilemaker.cpp and if the config file or the first pbf should take precidence?