### PR TITLE
Fix build on Ubuntu 18.04

### DIFF
--- a/src/write_geometry.cpp
+++ b/src/write_geometry.cpp
@@ -1,4 +1,5 @@
 #include "write_geometry.h"
+#include <iostream>
 #include "helpers.h"
 using namespace std;
 namespace geom = boost::geometry;


### PR DESCRIPTION
Include `<iostream>` to fix missing declarations for `std::cout`.