### PR TITLE
Improve configuration for openmaptiles

### DIFF
--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -10,10 +10,12 @@
 
 		"waterway":         { "minzoom": 8,  "maxzoom": 14 },
 
-		"transportation":             { "minzoom": 8, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003 },
+		"transportation":             { "minzoom": 8,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003 },
+		"transportation_main":        { "minzoom": 9,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "write_to": "transportation" },
 		"transportation_mid":         { "minzoom": 11, "maxzoom": 14, "write_to": "transportation" },
 		"transportation_detail":      { "minzoom": 13, "maxzoom": 14, "write_to": "transportation" },
-		"transportation_name":        { "minzoom": 8, "maxzoom": 14 },
+		"transportation_name":        { "minzoom": 8,  "maxzoom": 14 },
+		"transportation_name_mid":    { "minzoom": 12, "maxzoom": 14, "write_to": "transportation_name" },
 		"transportation_name_detail": { "minzoom": 14, "maxzoom": 14, "write_to": "transportation_name" },
 
 		"building":          { "minzoom": 13, "maxzoom": 14 },

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -124,6 +124,9 @@ end
 
 -- Process way tags
 
+majorRoadValues = Set { "motorway", "trunk", "primary" }
+mainRoadValues  = Set { "secondary", "motorway_link", "trunk_link", "primary_link", "secondary_link" }
+midRoadValues   = Set { "tertiary", "tertiary_link" }
 minorRoadValues = Set { "unclassified", "residential", "road" }
 trackValues     = Set { "cycleway", "byway", "bridleway", "track" }
 pathValues      = Set { "footway", "path" }
@@ -218,11 +221,14 @@ function way_function(way)
 	-- Roads ('transportation' and 'transportation_name', plus 'transportation_name_detail')
 	if highway~="" then
 		local h = highway
-		local layer = "transportation"
+		local layer = "transportation_detail"
+		if majorRoadValues[highway] then              layer="transportation" end
+		if mainRoadValues[highway]  then              layer="transportation_main" end
+		if midRoadValues[highway]   then              layer="transportation_mid" end
 		if minorRoadValues[highway] then h = "minor"; layer="transportation_mid" end
 		if trackValues[highway]     then h = "track"; layer="transportation_detail" end
 		if pathValues[highway]      then h = "path" ; layer="transportation_detail" end
-		if h=="service" then layer="transportation_detail" end
+		if h=="service"             then              layer="transportation_detail" end
 		way:Layer(layer, false)
 		way:Attribute("class", h)
 		SetBrunnelAttributes(way)
@@ -247,10 +253,12 @@ function way_function(way)
 		end
 
 		-- Write names
-		if h == "minor" or h == "track" or h == "path" or h == "service" then
+		if layer == "motorway" or layer == "trunk" then
+			way:Layer("transportation_name", false)
+		elseif h == "minor" or h == "track" or h == "path" or h == "service" then
 			way:Layer("transportation_name_detail", false)
 		else
-			way:Layer("transportation_name", false)
+			way:Layer("transportation_name_mid", false)
 		end
 		SetNameAttributes(way)
 		way:Attribute("class",h)


### PR DESCRIPTION
Make layers of transportation more consistent with openmaptiles v3.11.
Because I found current configuration causes z8 tiles up to 800KB(In Taiwan, a well-mapped country). It is ridiculous!

This PR does the following things:

transportation:
- Only include highway=`motorway`, `trunk`, `primary` in z8 
see [osm_transportation_merge_linestring_gen3](https://github.com/openmaptiles/openmaptiles/blob/f3667170f68c4c3574a1c5bfd2d7830781ca8c4f/layers/transportation/update_transportation_merge.sql#L51-L57)
- Only include highway=`secondary`, above and `*_link` in z9-z10
see [osm_highway_linestring_gen2](https://github.com/openmaptiles/openmaptiles/blob/f3667170f68c4c3574a1c5bfd2d7830781ca8c4f/layers/transportation/mapping.yaml#L45-L49)
- Only include highway=`tertiary`, above and `*_link` in z11-z12
see [osm_highway_linestring_gen1](https://github.com/openmaptiles/openmaptiles/blob/f3667170f68c4c3574a1c5bfd2d7830781ca8c4f/layers/transportation/mapping.yaml#L51-L55)

transportation_name:
- Only include highway=`motorway`, `trunk` in z8-z11
see
[osm_transportation_name_linestring_gen1](https://github.com/openmaptiles/openmaptiles/blob/f3667170f68c4c3574a1c5bfd2d7830781ca8c4f/layers/transportation_name/update_transportation_name.sql#L92-L97) for z9-z11 and [osm_transportation_name_linestring_gen1](https://github.com/openmaptiles/openmaptiles/blob/f3667170f68c4c3574a1c5bfd2d7830781ca8c4f/layers/transportation_name/update_transportation_name.sql#L105-L109) for z8
- Put other features(which are not in z14) in z12-z13

---
## Comparison with [mbview](https://github.com/mapbox/mbview) in z8
### openmaptiles (from openmaptiles.com)
Max z8 tile size: 32KB
![Screenshot from 2020-02-23 00-08-14](https://user-images.githubusercontent.com/19887090/75095595-8f5d3e80-55d1-11ea-9ea8-dd533b3ec014.png)

### Before
Max z8 tile size: 803 KB
![Screenshot from 2020-02-23 00-14-13](https://user-images.githubusercontent.com/19887090/75095650-15798500-55d2-11ea-8176-298b071d6367.png)

### After
Max z8 tile size: 333KB
![Screenshot from 2020-02-23 00-06-00](https://user-images.githubusercontent.com/19887090/75095744-3393b500-55d3-11ea-9d66-fb31cf9582c2.png)

As you see, still need to do more optimization. I think next step is to exclude waterway in lower zoom levels.