### PR TITLE
Improve configuration for openmaptiles

### DIFF
--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -8,7 +8,8 @@
 
 		"housenumber":      { "minzoom": 14, "maxzoom": 14 },
 
-		"waterway":         { "minzoom": 8,  "maxzoom": 14 },
+		"waterway":         { "minzoom":  9,  "maxzoom": 14, "simpolify_below": 12, "simplify_length": 2, "simplify_ratio": 2},
+		"waterway_detail":  { "minzoom": 12,  "maxzoom": 14, "write_to": "waterway" },
 
 		"transportation":             { "minzoom": 8,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003 },
 		"transportation_main":        { "minzoom": 9,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "write_to": "transportation" },
@@ -20,9 +21,9 @@
 
 		"building":          { "minzoom": 13, "maxzoom": 14 },
 
-		"water":             { "minzoom": 8,  "maxzoom": 14 },
-		"water_name":        { "minzoom": 8,  "maxzoom": 14 },
-		"water_name_detail": { "minzoom": 14, "maxzoom": 14, "write_to": "water_name" },
+		"water":             { "minzoom": 9,  "maxzoom": 14, "simpolify_below": 12, "simplify_length": 1, "simplify_ratio": 2},
+		"water_name":        { "minzoom": 9,  "maxzoom": 14 },
+		"water_name_detail": { "minzoom": 12, "maxzoom": 14, "write_to": "water_name" },
 
 		"aeroway":           { "minzoom": 11, "maxzoom": 14 },
 		"park":              { "minzoom": 11, "maxzoom": 14 },

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -292,15 +292,19 @@ function way_function(way)
 
 	-- Set 'waterway' and associated
 	if waterway~="" then
-		if     waterway == "riverbank" then way:Layer("water",   isClosed); way:Attribute("class", "river");
+		if     waterway == "riverbank" then way:Layer("water", isClosed); way:Attribute("class", "river");
 		                                    if way:Find("intermittent")=="yes" then way:AttributeNumeric("intermittent",1) end
-		elseif waterway == "dock"      then way:Layer("water",   isClosed); way:Attribute("class", "lake"); 
+		elseif waterway == "dock"      then way:Layer("water", isClosed); way:Attribute("class", "lake"); 
 		                                    way:LayerAsCentroid("water_name_detail"); SetNameAttributes(way); write_name = true
 		elseif waterway == "boatyard"  then way:Layer("landuse", isClosed); way:Attribute("class", "industrial")
 		elseif waterway == "dam"       then way:Layer("building",isClosed)
 		elseif waterway == "fuel"      then way:Layer("landuse", isClosed); way:Attribute("class", "industrial")
 		else
-			way:Layer("waterway",false)
+			if waterway == "river" and way:Holds("name") then
+				way:Layer("waterway",false)
+			else
+				way:Layer("waterway_detail",false)
+			end
 			way:Attribute("class", waterway)
 			SetNameAttributes(way)
 			SetBrunnelAttributes(way)


### PR DESCRIPTION
Make layers of water* more consistent with openmaptiles v3.11

Of course it is not one-to-one mapping, openmaptiles uses area to filter
out small water-body in lower zoom levels, but we cannot.

@systemed Is it possible to introduce `way:Area` into Lua spatial queries? I don't write C++, but maybe there are some stacks can be applied to tilemaker inside [mapbox/earcut.hpp](https://github.com/mapbox/earcut.hpp)

### waterway
- Removed from z8
- Only include waterway=river with name in z9-z11
  Also, do simplification below z12

### water
- Removed from z8
- Do simplification below z12

### water_name
- Removed from z8
- Put waterway=dock, natural=water, natural=bay or landuse=reservoir
  into z12 and above(originally only appears in z14)

---
Comparison with [mbview](https://github.com/mapbox/mbview) in z9

openmaptiles
![omt](https://user-images.githubusercontent.com/19887090/75132218-1d8c0e80-5711-11ea-8138-c073ea55f371.png)

before
![before](https://user-images.githubusercontent.com/19887090/75132259-40b6be00-5711-11ea-9ad6-38af176c4dbb.png)

after
![Screenshot from 2020-02-24 14-21-23](https://user-images.githubusercontent.com/19887090/75132262-457b7200-5711-11ea-8118-9867c841f95e.png)


