### PR TITLE
Use Spherical Strategy to calculate area

### DIFF
--- a/include/geomtypes.h
+++ b/include/geomtypes.h
@@ -12,6 +12,7 @@
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/index/rtree.hpp>
 typedef boost::geometry::model::d2::point_xy<double> Point; 
+typedef boost::geometry::model::point<double, 2, boost::geometry::cs::spherical_equatorial<boost::geometry::degree> > DegPoint;
 typedef boost::geometry::model::linestring<Point> Linestring;
 typedef boost::geometry::model::polygon<Point> Polygon;
 typedef boost::geometry::model::multi_polygon<Polygon> MultiPolygon;


### PR DESCRIPTION
@systemed 
Looks like the original area calculation is meaningless with 2D points for tiles.

Here I use [for_each_point](https://www.boost.org/doc/libs/1_72_0/libs/geometry/doc/html/geometry/reference/algorithms/for_each/for_each_point.html) to get original latitude value and [area function](https://www.boost.org/doc/libs/1_72_0/libs/geometry/doc/html/geometry/reference/algorithms/area/area_2_with_strategy.html) with strategy of spherical earth. So the result is in square meters.

I am new to C++ and not familiar with its conventions. So if anything looks weird, please don't hesitate to ask me to fix.

--
Also, some problem confuse me: When I tried to use geographic strategy with WGS84 spheroid, the result is more inconsistent with the area calculate by `GDAL` tools. So here I picked strategy:
```C++
boost::geometry::strategy::area::spherical<> sph_strategy(6371008.8);
```
rather than
```C++
boost::geometry::srs::spheroid<double> spheroid(6378137.0, 6356752.3142451793);
boost::geometry::strategy::area::geographic<> geo_strategy(spheroid);
```
You may check the example of strategies above in [area function](https://www.boost.org/doc/libs/1_72_0/libs/geometry/doc/html/geometry/reference/algorithms/area/area_2_with_strategy.html)
