### PR TITLE
Use Ubuntu 20.04 as the base image of the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 LABEL Description="Tilemaker" Version="1.4.0"
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 # INSTALL DEPENDENCIES
 RUN apt-get update


### PR DESCRIPTION
This upgrades the base image to Ubuntu 20.04 LTS.

This of course means that the packages like `libboost-all-dev` also have been upgraded. Would it be problematic to use newer versions?