### PR TITLE
Use Spherical Strategy to calculate length

### DIFF
--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -191,11 +191,13 @@ double OsmLuaProcessing::Area() {
 
 // Returns length
 double OsmLuaProcessing::Length() {
-	if (isRelation) {
-		return geom::length(multiPolygonCached());
-	} else if (isWay) {
-		return geom::length(linestringCached());
+	if (isWay) {
+		geom::model::linestring<DegPoint> l;
+		geom::assign(l, linestringCached());
+		geom::for_each_point(l, reverse_project);
+		return geom::length(l, geom::strategy::distance::haversine<float>(RadiusMeter));
 	}
+	// multi_polygon would be calculated as zero
 	return 0;
 }
 


### PR DESCRIPTION
continue #152

@systemed 
Successfully build on my machine with Boost 1.72.
Not sure it would be fail on automated build (Boost 1.65), please take a look.

Also, `boost.geometry.length` would calculate all multi_polygon as zero, so just return 0 if feature is a relation.

ref:
https://www.boost.org/doc/libs/1_72_0/libs/geometry/doc/html/geometry/reference/algorithms/length/length_2_with_strategy.html#geometry.reference.algorithms.length.length_2_with_strategy.behavior