### PR TITLE
Update config for OpenMapTiles

### DIFF
--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -21,10 +21,16 @@
 
 		"building":          { "minzoom": 13, "maxzoom": 14 },
 
-		"water":             { "minzoom": 9,  "maxzoom": 14, "simplify_below": 12, "simplify_length": 1, "simplify_ratio": 2},
+		"water":             { "minzoom": 12, "maxzoom": 14, "simplify_below": 12, "simplify_length": 1, "simplify_ratio": 2},
+		"water_z11":         { "minzoom": 11, "maxzoom": 14, "write_to": "water", "simplify_below": 12, "simplify_length": 1,  "simplify_ratio": 2},
+		"water_z10":         { "minzoom": 10, "maxzoom": 14, "write_to": "water", "simplify_below": 12, "simplify_length": 1,  "simplify_ratio": 2},
+		"water_z9":          { "minzoom": 9,  "maxzoom": 14, "write_to": "water", "simplify_below": 12, "simplify_length": 1,  "simplify_ratio": 2},
+		"water_z8":          { "minzoom": 8,  "maxzoom": 14, "write_to": "water", "simplify_below": 12, "simplify_length": 1,  "simplify_ratio": 2},
+		"water_z7":          { "minzoom": 7,  "maxzoom": 14, "write_to": "water", "simplify_below": 12, "simplify_length": 1,  "simplify_ratio": 2},
+		"water_z6":          { "minzoom": 6,  "maxzoom": 14, "write_to": "water", "simplify_below": 12, "simplify_length": 1,  "simplify_ratio": 2},
+		"ocean":             { "minzoom": 6,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "simplify_below": 13, "simplify_level": 0.0005, "write_to": "water" },
 		"water_name":        { "minzoom": 16, "maxzoom": 17 },
 		"water_name_detail": { "minzoom": 16, "maxzoom": 17, "write_to": "water_name" },
-		"ocean":             { "minzoom": 6,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "simplify_below": 13, "simplify_level": 0.0005, "write_to": "water" },
 
 		"aeroway":           { "minzoom": 11, "maxzoom": 14 },
 		"aerodrome_label":   { "minzoom": 10,  "maxzoom": 14 },

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -51,6 +51,17 @@ function Set(list)
 	return set
 end
 
+-- Meters per pixel if tile is 256x256
+ZRES5  = 4891.97
+ZRES6  = 2445.98
+ZRES7  = 1222.99
+ZRES8  = 611.5
+ZRES9  = 305.7
+ZRES10 = 152.9
+ZRES11 = 76.4
+ZRES12 = 38.2
+ZRES13 = 19.1
+
 -- Process node/way tags
 aerodromeValues = Set { "international", "public", "regional", "military", "private" }
 
@@ -346,7 +357,14 @@ function way_function(way)
 	if natural=="water" or natural=="bay" or leisure=="swimming_pool" or landuse=="reservoir" or landuse=="basin" or waterClasses[waterway] then
 		if way:Find("covered")=="yes" or not isClosed then return end
 		local class="lake"; if natural=="bay" then class="ocean" elseif waterway~="" then class="river" end
-		way:Layer("water", true)
+		local area=way:Area()
+		if     area>ZRES5^2  then way:Layer("water_z6",  true)
+        elseif area>ZRES6^2  then way:Layer("water_z7",  true)
+        elseif area>ZRES7^2  then way:Layer("water_z8",  true)
+		elseif area>ZRES8^2  then way:Layer("water_z9",  true)
+		elseif area>ZRES9^2  then way:Layer("water_z10", true)
+		elseif area>ZRES10^2 then way:Layer("water_z11", true)
+		else                      way:Layer("water",     true) end
 		way:Attribute("class",class)
 		if way:Find("intermittent")=="yes" then way:Attribute("intermittent",1) end
 		if way:Holds("name") then


### PR DESCRIPTION
Continue #148. Time to apply `way:Area()` in Lua script!

b0992cb
- Add more tags into waterway layer and water layer with OpenMapTiles spec.
- Explicitly only include linestrings into waterway, and polygons into water. This is because of some OSM features are not well tagged (For example: `waterway=riverbank` on a non-polygon way, see the case in Taipei below)
![Screenshot from 2020-05-25 01-34-32](https://user-images.githubusercontent.com/19887090/82760702-f33d1080-9e27-11ea-8a9b-1357e916070d.png)

6fe2cfc
- Filter out small water body in lower zoom levels, this should dramatically reduce tile size in lower zoom level