### PR TITLE
Update build config and README.md from c++11 to c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(tilemaker)
 
+set(CMAKE_CXX_STANDARD 14)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -33,7 +35,6 @@ if(MSVC)
   add_definitions(-D_USE_MATH_DEFINES)
   set(THREAD_LIB "")
 else()
-  add_definitions(-std=c++11)
   set(THREAD_LIB pthread)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LUA_CFLAGS := -I/usr/local/include/lua5.1 -I/usr/include/lua5.1
 LUA_LIBS := -llua5.1
-CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++11 -pthread $(CONFIG)
+CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++14 -pthread $(CONFIG)
 LIB := -L/usr/local/lib -lz $(LUA_LIBS) -lboost_program_options -lsqlite3 -lboost_filesystem -lboost_system -lprotobuf -lshp
 INC := -I/usr/local/include -isystem ./include -I./src $(LUA_CFLAGS)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tilemaker keeps nodes and ways in RAM. If you're processing a country extract or
 
 ## Installing
 
-Tilemaker is written in C++11. The chief dependencies are:
+Tilemaker is written in C++14. The chief dependencies are:
 
 * Google Protocol Buffers
 * Boost (latest version advised, 1.56 minimum: for boost::geometry, boost::program_options, boost::filesystem, boost::variant)
@@ -24,7 +24,7 @@ You can then simply install with:
 
     make
     sudo make install
-	
+
 For detailed installation instructions for your operating system, see INSTALL.md.
 
 ## Out-of-the-box setup


### PR DESCRIPTION
g++ needs C++14 configuration to successfully build latest tilemaker.
Otherwise it fails with internal compiler error (boost 1.68) or other boost errors (boost 1.73).