### PR TITLE
Improve GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,32 @@ env:
   AREA: liechtenstein
 
 jobs:
-  generate-tiles:
+  build:
+    name: Compile, install and build mbtiles
     runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev
+
+    - name: Build and install
+      run: |
+        make -j 2
+        sudo make install
+
+    - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
+      run: |
+        curl http://download.geofabrik.de/europe/${AREA}-latest.osm.pbf -o ${AREA}.osm.pbf
+        tilemaker ${AREA}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${AREA}.mbtiles --verbose
+
+  Github-Action:
+    name: Generate mbtiles with Github Action
+    runs-on: ubuntu-latest
+
     steps:
     - name: Check out repository
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,26 +5,21 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  AREA: liechtenstein
+
 jobs:
-  build:
-
-    name: Compile, install and build mbtiles
+  generate-tiles:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out repository
+      uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev
+    - name: Download PBF file
+      run: curl http://download.geofabrik.de/europe/${AREA}-latest.osm.pbf -o ${AREA}.osm.pbf
 
-    - name: Build and install
-      run: |
-        make -j 2
-        sudo make install
-
-    - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
-      run: |
-        curl http://download.geofabrik.de/europe/liechtenstein-latest.osm.pbf -o liechtenstein.osm.pbf
-        tilemaker liechtenstein.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=liechtenstein.mbtiles --verbose
+    - name: Build openmaptiles-compatible mbtiles files of given area
+      uses: ./
+      with:
+        input: ${{ env.AREA }}.osm.pbf 
+        output: ${{ env.AREA }}.mbtiles

--- a/README.md
+++ b/README.md
@@ -71,23 +71,24 @@ When running, you may see "couldn't find constituent way" messages. This happens
 See https://github.com/mapbox/awesome-vector-tiles for a list of renderers which support vector tiles.
 
 ## Github Action
-You can integrate tilemaker as Github Action into your [Github Workflow](https://help.github.com/en/actions).
+You can integrate tilemaker as Github Action into your [Github Workflow](https://help.github.com/en/actions).  
+Here is the example:
 ```yaml
 - uses: systemed/tilemaker@master
   with:
-    # Same to --input
-    input: ''
-    # Same to --config
+    # Required, same to --input
+    input: /path/to/osm.pbf
+    # Required, same to --output. Could be a directory or a .mbtiles files
+    output: /path/to/output
+    # Optional, same to --config
     # If not being set, default to resources/config-openmaptiles.config
-    config: ''
-    # Same to --process
+    config: /path/to/config
+    # Optional, same to --process
     # If not being set, default to resources/process-openmaptiles.lua
-    input: ''
-    # Same to --output
-    output: ''
-    # Other options
+    process: /path/to/lua
+    # Optional, other arguments
     # If not being set, default to '--verbose'
-    extra: ''
+    extra: --threads 0
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -70,6 +70,26 @@ When running, you may see "couldn't find constituent way" messages. This happens
 
 See https://github.com/mapbox/awesome-vector-tiles for a list of renderers which support vector tiles.
 
+## Github Action
+You can integrate tilemaker as Github Action into your [Github Workflow](https://help.github.com/en/actions).
+```yaml
+- uses: systemed/tilemaker@master
+  with:
+    # Same to --input
+    input: ''
+    # Same to --config
+    # If not being set, default to resources/config-openmaptiles.config
+    config: ''
+    # Same to --process
+    # If not being set, default to resources/process-openmaptiles.lua
+    input: ''
+    # Same to --output
+    output: ''
+    # Other options
+    # If not being set, default to '--verbose'
+    extra: ''
+```
+
 ## Contributing
 
 Bug reports, suggestions and (especially!) pull requests are very welcome on the Github issue tracker. Please check the tracker to see if your issue is already known, and be nice. For questions, please use IRC (irc.oftc.net or http://irc.osm.org, channel #osm-dev) and http://help.osm.org.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,30 @@
+name: 'tilemaker'
+description: 'Make OpenStreetMap vector tiles without the stack'
+inputs:
+  input:
+    description: 'An .osm.pbf file from planet extract, as typically downloaded from providers like Geofabrik'
+    required: true
+  config:
+    description: 'A JSON file listing each layer, and the zoom levels at which to apply it'
+    required: false
+    default: '/resources/config-openmaptiles.json'
+  process:
+    description: "A Lua program that looks at each node/way's tags, and places it into layers accordingly"
+    required: false
+    default: '/resources/process-openmaptiles.lua'
+  output:
+    description: 'Could be directory of tiles, or a .mbtiles files'
+    required: true
+  extra:
+    description: 'Other options for tilemaker'
+    required: false
+    default: '--verbose'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - --input=${{ inputs.input }}
+    - --config=${{ inputs.config }}
+    - --process=${{ inputs.process }}
+    - --output=${{ inputs.output }}
+    - ${{ inputs.extra }}


### PR DESCRIPTION
tilemaker is within Dockerfile, so for now it already could be used as Github Action.
This PR does the following things:
- Add `action.yml` to make the inputs more clear
- Add example of usage into README
- Refactor `ci.yml` with Github Action. So each time we change build steps or dependencies, just need to modify Dockerfile

The CI works same as how @leonardehrenfried  did in #158 , but takes more time to build(1min->2.5min). I guess it is because Github Action calls `docker` to make a new image and create a new container. And what `ci.yml` works now is just build `tilemaker` directly in the workflow runner. Anyway just check the log of CI below.

@systemed 
Also if this PR is merged, since `action.yml` is there, you'll see the hint at repo page:
![Screenshot_2020-05-27 OsmHackTW tilemaker](https://user-images.githubusercontent.com/19887090/83007034-a767b280-a045-11ea-8636-458d73c6687d.png)
It's up to you to make a new release to promote tilemaker on the marketplace (Or not).