### PR TITLE
Turn Lua variables into Sets

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -215,9 +215,9 @@ poiClassRanks   = { hospital=1, railway=2, bus=3, attraction=4, harbor=5, colleg
 					school=7, stadium=8, zoo=9, town_hall=10, campsite=11, cemetery=12,
 					park=13, library=14, police=15, post=16, golf=17, shop=18, grocery=19,
 					fast_food=20, clothing_store=21, bar=22 }
-poiKeys         = { "amenity", "sport", "tourism", "office", "historic", "leisure", "landuse", "information" }
-waterClasses    = { "river", "riverbank", "stream", "canal", "drain", "ditch", "dock" }
-waterwayClasses = { "stream", "river", "canal", "drain", "ditch" }
+poiKeys         = Set { "amenity", "sport", "tourism", "office", "historic", "leisure", "landuse", "information" }
+waterClasses    = Set { "river", "riverbank", "stream", "canal", "drain", "ditch", "dock" }
+waterwayClasses = Set { "stream", "river", "canal", "drain", "ditch" }
 
 
 function way_function(way)


### PR DESCRIPTION
When I tried out the recently updated waterways I noticed that rivers and streams didn't show up on the map.

After much head-scratching I traced it down to the waterway variables being plain Lua hashtables (lists).

Apparently, you need to use the `Set` constructor otherwise the `set[key]` lookup does not work. This make sense as all the other value lists use it.

https://stackoverflow.com/questions/33510736/check-if-array-contains-specific-value