### PR TITLE
Refine openmaptiles config with mountain_peak layer

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -133,10 +133,11 @@ function node_function(node)
 
 	-- Write 'mountain_peak' and 'water_name'
 	local natural = node:Find("natural")
-	if natural == "peak" then
+	if natural == "peak" or natural == "volcano" then
 		node:Layer("mountain_peak", false)
 		SetEleAttributes(node)
 		node:AttributeNumeric("rank", 1)
+		node:Attribute("class", natural)
 		SetNameAttributes(node)
 		return
 	end
@@ -458,7 +459,7 @@ end
 function SetEleAttributes(obj)
     local ele = obj:Find("ele")
 	if ele ~= "" then
-		local meter = tonumber(ele) or 0
+		local meter = math.floor(ele) or 0
 		local feet = math.floor(meter * 3.2808399)
 		obj:AttributeNumeric("ele", meter)
 		obj:AttributeNumeric("ele_ft", feet)

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -136,7 +136,7 @@ function node_function(node)
 	if natural == "peak" then
 		node:Layer("mountain_peak", false)
 		SetEleAttributes(node)
-		node:AttributeNumeric("rank", 5)
+		node:AttributeNumeric("rank", 1)
 		SetNameAttributes(node)
 		return
 	end

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -459,7 +459,7 @@ end
 function SetEleAttributes(obj)
     local ele = obj:Find("ele")
 	if ele ~= "" then
-		local meter = math.floor(ele) or 0
+		local meter = math.floor(tonumber(ele) or 0)
 		local feet = math.floor(meter * 3.2808399)
 		obj:AttributeNumeric("ele", meter)
 		obj:AttributeNumeric("ele_ft", feet)


### PR DESCRIPTION
@systemed 

e64a158
Set all features in mountain_peak as rank=1

Nearly all the styles from klokan(openmaptiles-topo, maptiler-terrain-gl-style, maptiler-topographique) only render mountain_peak feature with rank=1. Which means, if we set them as 5, none of them would not be rendered.

Though setting all features with rank=1 makes some non-important peaks also got rendered on those styles, it is better than nothing. The result would be like this:

**style [maptiles-topographique](https://www.maptiler.com/maps/#topographique//vector/13.78/121.61565/25.01444), left uses tiles from this PR, right uses openmaptiles**
![Screenshot from 2020-07-05 22-12-51](https://user-images.githubusercontent.com/19887090/86534683-c0993400-bf0c-11ea-84ad-7e470eec925d.png)


e2fac1f
- Add `class`, which is necessary in some style like [openmaptiles-topo](https://www.maptiler.com/maps/#topo//vector/14.13/121.54814/25.09374)
- Include natural=volcano into mountain_peak, see the result with [openmaptiles-topo](https://www.maptiler.com/maps/#topo//vector/14.13/121.54814/25.09374)(The red triangles are volcano outputs):
![Screenshot from 2020-07-05 22-04-58](https://user-images.githubusercontent.com/19887090/86534736-5cc33b00-bf0d-11ea-83de-8b4c2b2b45e0.png)

- Floor elevation as Integer, or some terrible thing would happen...like this:
![Screenshot_2020-07-05 Mapbox GL Inspect](https://user-images.githubusercontent.com/19887090/86534648-816ae300-bf0c-11ea-915e-c01a68f2d92a.png)


refs:
- What is rank in layer mountain_peak? How to calculate it when generating tiles?
  https://github.com/openmaptiles/openmaptiles/issues/687

- How a style render mountain_peak noramlly
  https://github.com/openmaptiles/maptiler-terrain-gl-style/blob/6c480e82af32f4df2ce49d85f59e625ef94337f4/style.json#L715
