### PR TITLE
Refine OpenMapTiles config with building

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -359,7 +359,10 @@ function way_function(way)
 	end
 
 	-- Set 'building' and associated
-	if building~="" then way:Layer("building", true) end
+	if building~="" then 
+		way:Layer("building", true) 
+		SetMinZoomByArea(way)
+	end
 
 	-- Set 'housenumber'
 	if housenumber~="" then
@@ -482,7 +485,9 @@ function SetMinZoomByArea(way)
 	elseif area>ZRES8^2  then way:MinZoom(9)
 	elseif area>ZRES9^2  then way:MinZoom(10)
 	elseif area>ZRES10^2 then way:MinZoom(11)
-	else                      way:MinZoom(12) end
+	elseif area>ZRES11^2 then way:MinZoom(12)
+	elseif area>ZRES12^2 then way:MinZoom(13)
+	else                      way:MinZoom(14) end
 end
 
 -- Calculate POIs (typically rank 1-4 go to 'poi' z12-14, rank 5+ to 'poi_detail' z14)


### PR DESCRIPTION
1. Exclude small buildings from z13
2. Change `SetMinZoomByArea()`, now it affects to z14

Though `building` layer, `landcover` layer and `water` layer in OpenMapTiles filter lower zoom levels by area with "a little different"
rules, but I thinks it is fine to apply `SetMinZoomByArea()` on all of them.

## Comparison ([topographique](https://cloud.maptiler.com/maps/topographique/) style)
left for generated tiles, right for tiles from `api.maptiler.com`
### Before
![Screenshot from 2020-07-25 00-37-26](https://user-images.githubusercontent.com/19887090/88416609-1299ef00-ce13-11ea-8484-4c3401143239.png)

### After
![Screenshot from 2020-07-25 00-36-16](https://user-images.githubusercontent.com/19887090/88416662-2c3b3680-ce13-11ea-9b65-f8cb36f80184.png)

## Rules in OpenMapTiles v3.11
- landuse
  all                  -> z14
  area>power(ZRES11,2) -> z13
  area>power(ZRES10,2) -> z12
  ⋮
  area>power(ZRES6,2)  -> z7
  area>power(ZRES6,2)  -> z6

- building
  all                  -> z14
  area>power(ZRES12,2) -> z13

- water
  all                  -> z12 z13 z14
  area>power(ZRES10,2) -> z11
  area>power(ZRES9,2)  -> z10
  ⋮
  area>power(ZRES5,2)  -> z6