### PR TITLE
Fix up labels for lakes and rivers

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -346,7 +346,7 @@ function way_function(way)
 	-- Set 'waterway' and associated
 	if waterwayClasses[waterway] and not isClosed then
 		if waterway == "river" and way:Holds("name") then
-			way:Layer("water_name_detail", false)
+			way:Layer("waterway", false)
 		else
 			way:Layer("waterway_detail", false)
 		end
@@ -357,6 +357,17 @@ function way_function(way)
 	elseif waterway == "boatyard"  then way:Layer("landuse", isClosed); way:Attribute("class", "industrial")
 	elseif waterway == "dam"       then way:Layer("building",isClosed)
 	elseif waterway == "fuel"      then way:Layer("landuse", isClosed); way:Attribute("class", "industrial")
+	end
+	-- Set names on rivers
+	if waterwayClasses[waterway] and not isClosed then
+		if waterway == "river" and way:Holds("name") then
+			way:Layer("water_name", false)
+		else
+			way:Layer("water_name_detail", false)
+			way:MinZoom(14)
+		end
+		way:Attribute("class", waterway)
+		SetNameAttributes(way)
 	end
 
 	-- Set 'building' and associated

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -317,6 +317,7 @@ function way_function(way)
 
 		way:Layer("transportation_name", false)
 		SetNameAttributes(way)
+		way:MinZoom(14)
 		way:Attribute("class", "rail")
 	end
 
@@ -345,9 +346,9 @@ function way_function(way)
 	-- Set 'waterway' and associated
 	if waterwayClasses[waterway] and not isClosed then
 		if waterway == "river" and way:Holds("name") then
-		    way:Layer("waterway",false)
+			way:Layer("water_name_detail", false)
 		else
-		    way:Layer("waterway_detail",false)
+			way:Layer("waterway_detail", false)
 		end
 		if way:Find("intermittent")=="yes" then way:AttributeNumeric("intermittent", 1) else way:AttributeNumeric("intermittent", 0) end
 		way:Attribute("class", waterway)
@@ -359,8 +360,8 @@ function way_function(way)
 	end
 
 	-- Set 'building' and associated
-	if building~="" then 
-		way:Layer("building", true) 
+	if building~="" then
+		way:Layer("building", true)
 		SetMinZoomByArea(way)
 	end
 
@@ -377,12 +378,19 @@ function way_function(way)
 		way:Layer("water",true)
 		SetMinZoomByArea(way)
 		way:Attribute("class",class)
+
 		if way:Find("intermittent")=="yes" then way:Attribute("intermittent",1) end
-		if way:Holds("name") then
+		-- we only want to show the names of actual lakes not every man-made basin that probably doesn't even have a name other than "basin"
+		-- examples for which we don't want to show a name:
+		--  https://www.openstreetmap.org/way/2595868
+		--  https://www.openstreetmap.org/way/27201902
+		if way:Holds("name") and natural=="water" then
 			way:LayerAsCentroid("water_name_detail")
 			SetNameAttributes(way)
+			SetMinZoomByArea(way)
 			way:Attribute("class", class)
 		end
+
 		return -- in case we get any landuse processing
 	end
 


### PR DESCRIPTION
This PR improves the handling of labels for bodies of water.

## Lakes
I noticed on our map that sometimes the labels would show up earlier than the actual lakes, which has been fixed. Also, I've restricted the display of names to actual lakes and excluded things like basins and swimming pools as their nondescript names often are a distraction.

## Rivers

So far it appears that river names were not in the correct format, so I added them.

### Before 
![Screenshot from 2020-09-04 14-08-04](https://user-images.githubusercontent.com/151346/92238715-10b75700-eeba-11ea-988d-ad76031106dc.png)

### Before 
![Screenshot from 2020-09-04 14-02-24](https://user-images.githubusercontent.com/151346/92238722-1319b100-eeba-11ea-9f5e-dd5eec00f537.png)

~~However, this part probably needs a little careful review, as i'm not entirely sure why it works. After having changed the layer from `waterway` to `water_name_detail` I expected the rivers themselves to disappear but they are still there.~~

~~Can you help me understand?~~

I think I figured it out. It needed a second pass so that the layers for the water polygon and the name are created separately.