### PR TITLE
Allow tilemaker to run in compact (32bit) nodeid mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ env:
 jobs:
   build:
     name: Compile, install and build mbtiles
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev 
+        sudo apt-get install -y --no-install-recommends build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-all-dev
 
     - name: Build and install
       env:
@@ -29,7 +29,7 @@ jobs:
         mkdir build
         cd build  
         export CFLAGS=${S_CFLAGS} && export CXXFLAGS=${S_CXXFLAGS} && export LDFLAGS=${S_LDFLAGS}
-        BOOST_ROOT=$BOOST_ROOT_1_72_0 cmake -DTILEMAKER_USE_STATIC_BOOST=true ..
+        cmake -DTILEMAKER_USE_STATIC_BOOST=true ..
         make -j 
         sudo make install
 
@@ -46,7 +46,7 @@ jobs:
 
   Github-Action:
     name: Generate mbtiles with Github Action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")

--- a/include/geomtypes.h
+++ b/include/geomtypes.h
@@ -132,16 +132,9 @@ BOOST_GEOMETRY_REGISTER_LINESTRING(mmap::linestring_t)
 BOOST_GEOMETRY_REGISTER_RING(mmap::ring_t)
 BOOST_GEOMETRY_REGISTER_MULTI_POLYGON(mmap::multi_polygon_t)
 
-#ifdef COMPACT_NODES
-typedef uint32_t NodeID;
-#else
 typedef uint64_t NodeID;
-#endif
-#ifdef FAT_WAYS
 typedef uint64_t WayID;
-#else
-typedef uint32_t WayID;
-#endif
+
 #define MAX_WAY_ID std::numeric_limits<WayID>::max()
 typedef std::vector<NodeID> NodeVec;
 typedef std::vector<WayID> WayVec;

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -180,8 +180,8 @@ private:
 	bool isWay, isRelation;					///< Way, node, relation?
 
 	int32_t lon1,latp1,lon2,latp2;			///< Start/end co-ordinates of OSM object
-	NodeVec *nodeVec;						///< node vector
-	WayVec *outerWayVec, *innerWayVec;		///< way vectors
+	OSMStore::handle_t nodeVec;				///< node vector
+  	WayVec *outerWayVec, *innerWayVec;      ///< way vectors
 
 	Linestring linestringCache;
 	bool linestringInited;

--- a/src/osm_store.cpp
+++ b/src/osm_store.cpp
@@ -1,7 +1,6 @@
 
 #include "osm_store.h"
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 using namespace std;
 namespace bg = boost::geometry;
@@ -15,88 +14,6 @@ NodeList<NodeVec::const_iterator> makeNodeList(const NodeVec &nodeVec) {
 WayList<WayVec::const_iterator> makeWayList( const WayVec &outerWayVec, const WayVec &innerWayVec) {
 	return { outerWayVec.cbegin(), outerWayVec.cend(), innerWayVec.cbegin(), innerWayVec.cend() };
 }
-
-//
-// Internal data structures.
-//
-
-LatpLon const &NodeStore::at(NodeID i) const {
-	try {
-		return mLatpLons->at(i);
-	}
-	catch (std::out_of_range &err){
-		stringstream ss;
-		ss << "Could not find node " << i;
-		throw std::out_of_range(ss.str());
-	}
-}
-
-// @brief Return whether a latp/lon pair is on the store.
-// @param i Any possible OSM ID
-// @return 1 if found, 0 otherwise
-// @note This function is named as count for consistent naming with stl functions.
-size_t NodeStore::count(NodeID i) const {
-	return mLatpLons->count(i);
-}
-
-// @brief Insert a latp/lon pair.
-// @param i OSM ID of a node
-// @param coord a latp/lon pair to be inserted
-// @invariant The OSM ID i must be larger than previously inserted OSM IDs of nodes
-//			  (though unnecessarily for current impl, future impl may impose that)
-void NodeStore::insert_back(NodeID i, LatpLon coord) {
-	//std::cout << "Insert node: " << i << " " << coord.latp << " " << coord.lon << std::endl;
-	mLatpLons->emplace(i, coord);
-}
-
-// @brief Make the store empty
-void NodeStore::clear() {
-	mLatpLons->clear();
-}
-
-size_t NodeStore::size() { 
-	return mLatpLons->size(); 
-}
-
-
-// way store
-
-// @brief Lookup a node list
-// @param i OSM ID of a way
-// @return A node list
-// @exception NotFound
-NodeList<WayStore::nodeid_vector_t::const_iterator> WayStore::at(WayID i) const {
-	try {
-		const auto &way = mNodeLists->at(i);
-		return { way.cbegin(), way.cend() };
-	}
-	catch (std::out_of_range &err){
-		stringstream ss;
-		ss << "Could not find way " << i;
-		throw std::out_of_range(ss.str());
-	}
-}
-
-// @brief Return whether a node list is on the store.
-// @param i Any possible OSM ID
-// @return 1 if found, 0 otherwise
-// @note This function is named as count for consistent naming with stl functions.
-size_t WayStore::count(WayID i) const {
-	return mNodeLists->count(i);
-}
-
-// @brief Insert a node list.
-// @param i OSM ID of a way
-// @param nodeVec a node vector to be inserted
-// @invariant The OSM ID i must be larger than previously inserted OSM IDs of ways
-//			  (though unnecessarily for current impl, future impl may impose that)
-
-// @brief Make the store empty
-void WayStore::clear() {
-	mNodeLists->clear();
-}
-
-size_t WayStore::size() { return mNodeLists->size(); }
 
 
 // relation store
@@ -129,70 +46,8 @@ void RelationStore::clear() {
 	mOutInLists->clear();
 }
 
-size_t RelationStore::size() { 
+size_t RelationStore::size() const { 
 	return mOutInLists->size(); 
-}
-
-
-
-//
-// OSM store, containing all above.
-//
-constexpr std::size_t OSMStore::init_map_size;
-
-void OSMStore::remove_mmap_file() {
-	boost::filesystem::remove(osm_store_filename);
-}
-
-void OSMStore::reportSize() {
-	cout << "Stored " << nodes.size() << " nodes, " << ways.size() << " ways, " << relations.size() << " relations" << endl;
-	cout << "Shape points: " << shp_generated.points_store->size() << ", lines: " << shp_generated.linestring_store->size() << ", polygons: " << shp_generated.multi_polygon_store->size() << std::endl;
-	cout << "Generated points: " << osm_generated.points_store->size() << ", lines: " << osm_generated.linestring_store->size() << ", polygons: " << osm_generated.multi_polygon_store->size() << std::endl;
-}
-
-void OSMStore::clear() {
-	nodes.clear();
-	ways.clear();
-	relations.clear();
-}
-
-// Relation -> MultiPolygon
-MultiPolygon OSMStore::wayListMultiPolygon(WayID relId) const {
-	return wayListMultiPolygon(relations.at(relId));
-}
-
-MultiPolygon OSMStore::wayListMultiPolygon(const WayVec &outerWayVec, const WayVec &innerWayVec) const {
-	return wayListMultiPolygon(makeWayList(outerWayVec, innerWayVec));
-}
-
-Linestring OSMStore::wayListLinestring(const WayVec &outerWayVec, const WayVec &innerWayVec) const {
-	MultiPolygon mp = wayListMultiPolygon(makeWayList(outerWayVec, innerWayVec));
-	if(mp.size()>=1) {
-		Linestring out;
-		for(auto pt: mp[0].outer())
-			bg::append(out, pt);
-		return out;
-	}
-	return Linestring();
-}
-
-// Way -> Polygon
-Polygon OSMStore::nodeListPolygon(WayID wayId) const {
-	return nodeListPolygon(ways.at(wayId));
-}
-
-Polygon OSMStore::nodeListPolygon(const NodeVec &nodeVec) const {
-	return nodeListPolygon(makeNodeList(nodeVec));
-}
-
-// Way -> Linestring
-
-Linestring OSMStore::nodeListLinestring(WayID wayId) const {
-	return nodeListLinestring(ways.at(wayId));
-}
-
-Linestring OSMStore::nodeListLinestring(const NodeVec &nodeVec) const {
-	return nodeListLinestring(makeNodeList(nodeVec));
 }
 
 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -196,7 +196,7 @@ int main(int argc, char* argv[]) {
 	// For each tile, objects to be used in processing
 	std::unique_ptr<OSMStore> osmStore;
 	if(osmStoreCompact) {
-		std:: cout << "\nImportant: Tilemaker running with 32-bit node support.\nUse 'osmium renumber' first if working with OpenStreetMap-sourced data,\ninitialize the init store to the highest NodeID that is stored in the input file.\n" << std::endl;
+		std:: cout << "\nImportant: Tilemaker running in compact mode.\nUse 'osmium renumber' first if working with OpenStreetMap-sourced data,\ninitialize the init store to the highest NodeID that is stored in the input file.\n" << std::endl;
    		osmStore.reset(new OSMStoreImpl<NodeStoreCompact>(osmStoreFile, storeNodesSize * 1000000, storeWaysSize * 1000000));
 	} else {
    		osmStore.reset(new OSMStoreImpl<NodeStore>(osmStoreFile, storeNodesSize * 1000000, storeWaysSize * 1000000));


### PR DESCRIPTION
This PR gives the ability to switch to allow tilemaker to switch between 32bit and 64bit node id mode from the command line. This adds the following command line option:

````
  --compact                    Use 32bits NodeIDs and reduce overall memory
                               usage (compact mode).
                               This requires the input to be renumbered and the
                               init-store to be configured
````

It gives the following notice when running in this mode:
````

Important: Tilemaker running with 32-bit node support.
Use 'osmium renumber' first if working with OpenStreetMap-sourced data,
initialize the init store to the highest NodeID that is stored in the input file.

````

It hugely improves the conversion time of my Netherlands extract on my 8G machine. From something like 200 minutes to 50 minutes. 

I am still thinking about adding the VarInt ways to this patch to further reduce memory consumption. For large conversion (like Europe / Planet), I think every byte counts. So it still can be useful. 