### PR TITLE
Fix processing order of ways

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -177,10 +177,11 @@ private:
 	uint64_t osmID;							///< ID of OSM object (relations have decrementing way IDs)
 	int64_t originalOsmID;					///< Original OSM object ID
 	WayID newWayID = MAX_WAY_ID;			///< Decrementing new ID for relations
-	bool isWay, isRelation;					///< Way, node, relation?
+	bool isWay, isRelation, isClosed;		///< Way, node, relation?
 
 	int32_t lon1,latp1,lon2,latp2;			///< Start/end co-ordinates of OSM object
 	OSMStore::handle_t nodeVec;				///< node vector
+	NodeVec *nodeVecPtr;
   	WayVec *outerWayVec, *innerWayVec;      ///< way vectors
 
 	Linestring linestringCache;

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -293,7 +293,7 @@ public:
 			throw std::out_of_range("Failed to store node " + std::to_string(i) + ", index out of range");
 		}
 
-		mLatpLons->resize(std::max(i + 1, mLatpLons->size()));
+		mLatpLons->resize(std::max<size_t>(i + 1, mLatpLons->size()));
 		(*mLatpLons)[i] = coord;
 	}
 
@@ -663,7 +663,7 @@ public:
 	handle_t store_linestring(generated &store, Input const &src)
 	{
 		perform_mmap_operation([&]() {
-			store.linestring_store->resize(store.linestring_store->size() + 1);
+			store.linestring_store->emplace_back();
 			boost::geometry::assign(store.linestring_store->back(), src);
 		});
 

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -628,11 +628,6 @@ public:
 		return ls;
 	}
 
-	bool wayIsClosed(handle_t handle) {
-		auto const &way = retrieve<WayStore::nodeid_vector_t>(handle);
-		return way.empty() || (way.front() == way.back());
-	}
-
 	handle_t relations_insert_front(WayID i, const WayVec &outerWayVec, const WayVec &innerWayVec) {
 		handle_t result;
 		perform_mmap_operation([&]() {


### PR DESCRIPTION
In 0fb2c00589d554a25c041bf30b9d369fcc7270c8 we accidentally broke the processing order for ways.

We need the way-node list available throughout setWay, particularly including the call to Lua's `way_function`. This means we can access (and correct) the geometry from the `way:Layer` function, check whether the way is closed, and so on.

Because we were only creating nodeVec _after_ `way_function` was called, we were actually using last time's cached linestring - so if that was in any way different from last time (e.g. last way was closed, this one isn't) then the results wouldn't be correct. This basically showed through in lots of output geometries going AWOL.

This PR fixes the order by creating nodeVec the first time we try to access a geometry, which might be in the `way:Layer`, `way:Length`, `way:Layer` or `way:LayerAsCentroid` calls.

(I've also included the macOS build fixes.)

@kleunen Does this look good to you?