### PR TITLE
Perform static build of tilemaker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ env:
 jobs:
   build:
     name: Compile, install and build mbtiles
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-all-dev
+        sudo apt-get install -y --no-install-recommends build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev 
 
     - name: Build and install
       env:
@@ -29,7 +29,7 @@ jobs:
         mkdir build
         cd build  
         export CFLAGS=${S_CFLAGS} && export CXXFLAGS=${S_CXXFLAGS} && export LDFLAGS=${S_LDFLAGS}
-        cmake -DTILEMAKER_USE_STATIC_BOOST=true ..
+        BOOST_ROOT=$BOOST_ROOT_1_72_0 cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release ..
         make -j 
         sudo make install
 
@@ -46,7 +46,7 @@ jobs:
 
   Github-Action:
     name: Generate mbtiles with Github Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check out repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 project(tilemaker)
 
-OPTION(TILEMAKER_USE_STATIC_BOOST "Statically link with boost libraries" OFF)
+OPTION(TILEMAKER_BUILD_STATIC "Attempt to link dependencies static" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -17,9 +17,10 @@ endif()
 include_directories(include)
 include_directories(${CMAKE_BINARY_DIR}) # for generated files
 
-IF (TILEMAKER_USE_STATIC_BOOST)
+IF (TILEMAKER_BUILD_STATIC)
     MESSAGE (STATUS "Staticly linking with Boost")
     SET (Boost_USE_STATIC_LIBS TRUE)
+	SET (CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
 ELSE ()
     MESSAGE (STATUS "Dynamically linking with Boost")
     SET (Boost_USE_STATIC_LIBS FALSE)


### PR DESCRIPTION
Build a static executable with CI on ubuntu 16.04. Allows the user to download and run the executable without installing any dependencies. You can download the executable from the CI artifacts and provide it on the website as release. 