### PR TITLE
Allow generation of pbf index file

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -41,7 +41,7 @@ public:
 	// ----	initialization routines
 
 	OsmLuaProcessing(
-        OSMStore &osmStore,
+        OSMStore const *indexStore, OSMStore &osmStore,
         const class Config &configIn, class LayerDefinition &layers, 
 		const std::string &luaFile,
 		const class ShpMemTiles &shpMemTiles, 
@@ -61,26 +61,17 @@ public:
 
 	// ----	Data loading methods
 
-	/// \brief Called when data loading is starting
-	virtual void startOsmData();
-
-	virtual void everyNode(NodeID id, LatpLon node);
-
 	/// \brief We are now processing a significant node
-	virtual void setNode(NodeID id, LatpLon node, const std::map<std::string, std::string> &tags);
+	virtual void setNode(NodeID id, LatpLon node, const tag_map_t &tags);
 
 	/// \brief We are now processing a way
-	virtual void setWay(Way *way, NodeVec *nodeVecPtr, bool inRelation, const std::map<std::string, std::string> &tags);
+	virtual void setWay(WayID wayId, OSMStore::handle_t handle, const tag_map_t &tags);
 
 	/** \brief We are now processing a relation
 	 * (note that we store relations as ways with artificial IDs, and that
 	 *  we use decrementing positive IDs to give a bit more space for way IDs)
 	 */
-	virtual void setRelation(Relation *relation, WayVec *outerWayVecPtr, WayVec *innerWayVecPtr,
-		const std::map<std::string, std::string> &tags);
-
-	/// \brief Called when data loading for a single file is done
-	virtual void endOsmData();
+	virtual void setRelation(int64_t relationId, OSMStore::handle_t relationHandle, const tag_map_t &tags);
 
 	// ----	Metadata queries called from Lua
 
@@ -152,6 +143,7 @@ public:
 
 	inline AttributeStore &getAttributeStore() { return attributeStore; }
 
+	void setIndexStore(OSMStore const *indexStore) { this->indexStore = indexStore; }
 private:
 	/// Internal: clear current cached state
 	inline void reset() {
@@ -166,6 +158,7 @@ private:
 		lon1=a; latp1=b; lon2=c; latp2=d;
 	}
 	
+	OSMStore const *indexStore;				// global OSM for reading input
 	OSMStore &osmStore;						// global OSM store
 
 	kaguya::State luaState;
@@ -180,9 +173,8 @@ private:
 	bool isWay, isRelation, isClosed;		///< Way, node, relation?
 
 	int32_t lon1,latp1,lon2,latp2;			///< Start/end co-ordinates of OSM object
-	OSMStore::handle_t nodeVec;				///< node vector
-	NodeVec *nodeVecPtr;
-  	WayVec *outerWayVec, *innerWayVec;      ///< way vectors
+	OSMStore::handle_t nodeVecHandle;
+	OSMStore::handle_t relationHandle;
 
 	Linestring linestringCache;
 	bool linestringInited;
@@ -195,7 +187,7 @@ private:
 	class LayerDefinition &layers;
 	
 	std::deque<std::pair<OutputObjectRef, AttributeStore::key_value_set_entry_t> > outputs;			///< All output objects that have been created
-	std::map<std::string, std::string> currentTags;
+	boost::container::flat_map<std::string, std::string> currentTags;
 
 };
 


### PR DESCRIPTION
The following branch allow generating an "index" file of a pbf file. This allows multiple generators or subsequent runs of tilemaker to use the index file instead of loading. 

Create an index file from an input file:
````console
./tilemaker --index --compact --input overijssel-latest.osm.pbf --output overijssel-latest.mbtiles 
  --process process-openmaptiles.lua --config config-openmaptiles.json
````

The file 'overijssel-latest.osm.pbf.idx' is generated. Now use the index to generate the mbtiles:
````console
./tilemaker --compact --input overijssel-latest.osm.pbf --output overijssel-latest.mbtiles
  --process process-openmaptiles.lua --config config-openmaptiles.json
````

You can use both compact/non-compact. Just don't mix generating the index with compact and generating the mbtiles without compact. In the output it says:

````
Using index to generate tiles: overijssel-latest.osm.pbf.idx
Generate from index file
````