### PR TITLE
Make index pbf reader independent of significant nodes

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -131,8 +131,6 @@ public:
 
 	void setVectorLayerMetadata(const uint_least8_t layer, const std::string &key, const uint type);
 
-	std::vector<std::string> GetSignificantNodeKeys();
-
 	// ---- Cached geometries creation
 
 	const Linestring &linestringCached();

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -66,13 +66,13 @@ class PbfReader
 public:
 	PbfReader(OSMStore &osmStore);
 
-	int ReadPbfFile(std::istream &inputFile, std::unordered_set<std::string> &nodeKeys);
+	int ReadPbfFile(std::istream &inputFile);
 
 	///Pointer to output object. Loaded objects are sent here.
 	PbfReaderOutput * output;
 
 private:
-	bool ReadNodes(PrimitiveGroup &pg, PrimitiveBlock const &pb, const std::unordered_set<int> &nodeKeyPositions);
+	bool ReadNodes(PrimitiveGroup &pg, PrimitiveBlock const &pb);
 
 	bool ReadWays(PrimitiveGroup &pg, PrimitiveBlock const &pb);
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -561,7 +561,3 @@ void OsmLuaProcessing::setRelation(int64_t relationId, OSMStore::handle_t relati
 	}
 }
 
-vector<string> OsmLuaProcessing::GetSignificantNodeKeys() {
-	return luaState["node_keys"];
-}
-

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -293,11 +293,6 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
-	// ----	Read significant node tags
-
-	vector<string> nodeKeyVec = osmLuaProcessing.GetSignificantNodeKeys();
-	unordered_set<string> nodeKeys(nodeKeyVec.begin(), nodeKeyVec.end());
-
 	// ----	Read all PBFs
 	
 	PbfReader pbfReader(*osmStore);
@@ -331,7 +326,7 @@ int main(int argc, char* argv[]) {
 				ifstream infile(inputFile, ios::in | ios::binary);
 				if (!infile) { cerr << "Couldn't open .pbf file " << inputFile << endl; return -1; }
 
-				int ret = pbfReader.ReadPbfFile(infile, nodeKeys);
+				int ret = pbfReader.ReadPbfFile(infile);
 				if (ret != 0) return ret;
 			} 
 		}
@@ -409,7 +404,7 @@ int main(int argc, char* argv[]) {
 			vector<char> pbf = mapsplitFile.readTile(srcZ,srcX,tmsY);
 
 			boost::interprocess::bufferstream pbfstream(pbf.data(), pbf.size(),  ios::in | ios::binary);
-			pbfReader.ReadPbfFile(pbfstream, nodeKeys);
+			pbfReader.ReadPbfFile(pbfstream);
 
 			tileList.pop_back();
 		}


### PR DESCRIPTION
The following removes checking significant nodes from pbf_reader. I see no negative performance impact, and this way, the generated index is independent of the lua file. This way you can switch lua file between generating or update lua file regenerate the map.