### PR TITLE
 Tilemaker CI for windows, macos and linux with boost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,40 +9,96 @@ env:
   AREA: liechtenstein
 
 jobs:
-  build:
-    name: Compile, install and build mbtiles
-    runs-on: ubuntu-16.04
+
+  Windows-Build:
+    name: Windows build
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev 
 
-    - name: Build and install
-      env:
-        S_CFLAGS: -flto -ffunction-sections -fdata-sections
-        S_CXXFLAGS: -flto -ffunction-sections -fdata-sections
-        S_LDFLAGS: -Wl,-gc-sections
+    - name: Enable vcpkg cache
+      uses: actions/cache@v2
+      with:
+        path: c:\vcpkg\installed
+        key: windows-vcpkg-x64-0 # Increase the number whenever dependencies are modified
+        restore-keys: windows-vcpkg-x64
+
+    - name: Build dependencies
       run: |
-        mkdir build
-        cd build  
-        export CFLAGS=${S_CFLAGS} && export CXXFLAGS=${S_CXXFLAGS} && export LDFLAGS=${S_LDFLAGS}
-        BOOST_ROOT=$BOOST_ROOT_1_72_0 cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release ..
-        make -j 
-        sudo make install
+        vcpkg install --triplet=x64-windows-static-md lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess 
+
+    - name: Build tilemaker
+      run: |
+        mkdir ${{ github.workspace }}\build        
+        cd ${{ github.workspace }}\build && cmake -DTILEMAKER_BUILD_STATIC=ON -DVCPKG_TARGET_TRIPLET="x64-windows-static-md" -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake"  ..
+        cd ${{ github.workspace }}\build && cmake --build . --config Release
 
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
-        curl http://download.geofabrik.de/europe/${AREA}-latest.osm.pbf -o ${AREA}.osm.pbf
-        tilemaker ${AREA}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${AREA}.mbtiles --verbose
+        Invoke-WebRequest -Uri http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -OutFile ${{ env.AREA }}.osm.pbf
+        ${{ github.workspace }}\build\Release\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose || true
 
     - name: 'Upload compiled executable'
       uses: actions/upload-artifact@v2
       with:
-        name: tilemaker
-        path: build/tilemaker
+        name: tilemaker-windows
+        path: |
+          ${{ github.workspace }}\resources
+          ${{ github.workspace }}\build\Release\tilemaker.exe
+
+  unix-build:  
+    strategy:  
+      matrix: 
+        include:
+          - os: ubuntu-16.04
+            triplet: x64-linux
+            executable: tilemaker
+            path: /usr/local/share/vcpkg/installed
+            toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+          - os: macos-10.15
+            triplet: x64-osx
+            executable: tilemaker
+            path: /usr/local/share/vcpkg/installed
+            toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    name: ${{ matrix.os }} build
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Enable vcpkg cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ matrix.path }}
+        key: vcpkg-${{ matrix.triplet }}-0 # Increase the number whenever dependencies are modified
+        restore-keys: vcpkg-${{ matrix.triplet }}
+
+    - name: Build dependencies
+      run: |
+        vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess 
+
+    - name: Build tilemaker
+      run: |
+        mkdir build        
+        cd build        
+        cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DCMAKE_CXX_COMPILER=g++ ..
+        cmake --build . 
+        strip tilemaker
+
+    - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
+      run: |
+        curl http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -o ${{ env.AREA }}.osm.pbf
+        ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose || true
+
+    - name: 'Upload compiled executable'
+      uses: actions/upload-artifact@v2
+      with:
+        name: tilemaker-${{ matrix.os }}
+        path: |
+          ${{ github.workspace }}/resources
+          ${{ github.workspace }}/build/${{ matrix.executable }}
 
   Github-Action:
     name: Generate mbtiles with Github Action

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
   message(FATAL_ERROR "In-source builds are not allowed, please use a separate build directory.")
 endif()
 
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 include_directories(include)
 include_directories(${CMAKE_BINARY_DIR}) # for generated files
 
@@ -36,25 +40,32 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 find_package(Protobuf REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIR})
 
-find_package(SQLite3 REQUIRED)
-include_directories(${SQLITE3_INCLUDE_DIR})
-
 find_package(libshp REQUIRED)
 include_directories(${LIBSHP_INCLUDE_DIR})
 
-find_package(Lua REQUIRED)
-include_directories(${LUA_INCLUDE_DIR})
+find_package(Lua)
+
+if(LUA_FOUND)
+	include_directories(${LUA_INCLUDE_DIR})
+else()
+	find_package(LuaJIT REQUIRED)
+	add_definitions(-DLUAJIT)
+	include_directories(${LUAJIT_INCLUDE_DIR})
+endif()
 
 find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIR})
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 if(MSVC)
-  add_definitions(-D_USE_MATH_DEFINES)
-  set(THREAD_LIB "")
+ 	find_package(unofficial-sqlite3 CONFIG REQUIRED)
+	add_definitions(-D_USE_MATH_DEFINES -DWIN32_LEAN_AND_MEAN -DNOGDI)
+  	set(THREAD_LIB "")
 else()
-  set(THREAD_LIB pthread)
+	find_package(SQLite3 REQUIRED)
+	include_directories(${SQLITE3_INCLUDE_DIRS})
+  	set(THREAD_LIB pthread)
 endif()
 
 ADD_CUSTOM_COMMAND(OUTPUT vector_tile.pb.cc vector_tile.pb.h
@@ -70,7 +81,11 @@ file(GLOB tilemaker_src_files
     "clipper/*.cpp"
   )
 add_executable(tilemaker vector_tile.pb.cc osmformat.pb.cc ${tilemaker_src_files})
-target_link_libraries(tilemaker ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUA_LIBRARIES} ${ZLIB_LIBRARY} ${THREAD_LIB} ${CMAKE_DL_LIBS}
+target_link_libraries(tilemaker ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUAJIT_LIBRARY} ${LUA_LIBRARIES} ${ZLIB_LIBRARY} ${THREAD_LIB} ${CMAKE_DL_LIBS}
 	Boost::system Boost::filesystem Boost::program_options)
 
+if(MSVC)
+    target_link_libraries(tilemaker unofficial::sqlite3::sqlite3)
+endif()
+	
 install(TARGETS tilemaker RUNTIME DESTINATION bin)

--- a/Makefile
+++ b/Makefile
@@ -4,25 +4,25 @@
 ifneq ("$(wildcard /usr/local/include/luajit-2.1/lua.h)","")
   LUA_VER := LuaJIT 2.1
   LUA_CFLAGS := -I/usr/local/include/luajit-2.1
-  LUA_LIBS := -lluajit
+  LUA_LIBS := -lluajit-5.1
   LUAJIT := 1
 
 else ifneq ("$(wildcard /usr/include/luajit-2.1/lua.h)","")
   LUA_VER := LuaJIT 2.1
   LUA_CFLAGS := -I/usr/include/luajit-2.1
-  LUA_LIBS := -lluajit
+  LUA_LIBS := -lluajit-5.1
   LUAJIT := 1
 
 else ifneq ("$(wildcard /usr/local/include/luajit-2.0/lua.h)","")
   LUA_VER := LuaJIT 2.0
   LUA_CFLAGS := -I/usr/local/include/luajit-2.0
-  LUA_LIBS := -lluajit
+  LUA_LIBS := -lluajit-5.1
   LUAJIT := 1
 
 else ifneq ("$(wildcard /usr/include/luajit-2.0/lua.h)","")
   LUA_VER := LuaJIT 2.0
   LUA_CFLAGS := -I/usr/include/luajit-2.0
-  LUA_LIBS := -lluajit
+  LUA_LIBS := -lluajit-5.1
   LUAJIT := 1
 
 else ifneq ("$(wildcard /usr/local/include/lua/lua.h)","")
@@ -61,7 +61,7 @@ endif
 
 # Main includes
 
-CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++11 -pthread $(CONFIG)
+CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++11 -pthread -fPIE $(CONFIG)
 LIB := -L/usr/local/lib -lz $(LUA_LIBS) -lboost_program_options -lsqlite3 -lboost_filesystem -lboost_system -lprotobuf -lshp
 INC := -I/usr/local/include -isystem ./include -I./src $(LUA_CFLAGS)
 

--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -1,0 +1,59 @@
+# Locate LuaJIT library
+# This module defines
+#  LUAJIT_FOUND, if false, do not try to link to Lua
+#  LUAJIT_LIBRARIES
+#  LUAJIT_INCLUDE_DIR, where to find lua.h
+#  LUAJIT_VERSION_STRING, the version of Lua found (since CMake 2.8.8)
+
+## Copied from default CMake FindLua51.cmake
+
+find_path(LUAJIT_INCLUDE_DIR luajit.h
+  HINTS
+    ENV LUA_DIR
+  PATH_SUFFIXES include/luajit-2.1 include/luajit-2.0 include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/csw # Blastwave
+  /opt
+)
+
+find_library(LUAJIT_LIBRARY
+  NAMES luajit-5.1
+  HINTS
+    ENV LUA_DIR
+  PATH_SUFFIXES lib
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /sw
+  /opt/local
+  /opt/csw
+  /opt
+)
+
+if(LUAJIT_LIBRARY)
+  # include the math library for Unix
+  if(UNIX AND NOT APPLE)
+    find_library(LUA_MATH_LIBRARY m)
+    set( LUAJIT_LIBRARIES "${LUAJIT_LIBRARY};${LUA_MATH_LIBRARY}" CACHE STRING "Lua Libraries")
+  # For Windows and Mac, don't need to explicitly include the math library
+  else()
+    set( LUAJIT_LIBRARIES "${LUAJIT_LIBRARY}" CACHE STRING "Lua Libraries")
+  endif()
+endif()
+
+if(LUAJIT_INCLUDE_DIR AND EXISTS "${LUAJIT_INCLUDE_DIR}/luajit.h")
+  file(STRINGS "${LUAJIT_INCLUDE_DIR}/luajit.h" luajit_version_str REGEX "^#define[ \t]+LUAJIT_VERSION[ \t]+\"LuaJIT .+\"")
+  string(REGEX REPLACE "^#define[ \t]+LUAJIT_VERSION[ \t]+\"LuaJIT ([^\"]+)\".*" "\\1" LUAJIT_VERSION_STRING "${luajit_version_str}")
+  unset(luajit_version_str)
+endif()
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LUA_FOUND to TRUE if
+# all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LuaJIT
+	REQUIRED_VARS LUAJIT_LIBRARIES LUAJIT_INCLUDE_DIR VERSION_VAR LUAJIT_VERSION_STRING)
+mark_as_advanced(LUAJIT_INCLUDE_DIR LUAJIT_LIBRARIES LUAJIT_LIBRARY LUA_MATH_LIBRARY)

--- a/include/geomtypes.h
+++ b/include/geomtypes.h
@@ -2,6 +2,10 @@
 #ifndef _GEOM_TYPES_H
 #define _GEOM_TYPES_H
 
+#ifdef _MSC_VER
+using uint = unsigned int;
+#endif
+
 #include <vector>
 #include <limits>
 

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -22,6 +22,7 @@ extern "C" {
     #include "lualib.h"
     #include "lauxlib.h"
 }
+
 #include "kaguya.hpp"
 
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -20,8 +20,10 @@
 #include <boost/intrusive_ptr.hpp>
 #include <atomic>
 
-///\brief Specifies geometry type for an OutputObject
-enum OutputGeometryType { POINT, LINESTRING, POLYGON, CENTROID, CACHED_POINT, CACHED_LINESTRING, CACHED_POLYGON };
+enum class OutputGeometryType : uint8_t { POINT, LINESTRING, POLYGON };
+
+//\brief Display the geometry type
+std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
 
 /**
  * \brief OutputObject - any object (node, linestring, polygon) to be outputted to tiles
@@ -41,10 +43,10 @@ public:
 	NodeID objectID;									// id of way (linestring/polygon) or node (point)
 	OSMStore::handle_t handle;							// Handle within global store of geometries
 
-	OutputGeometryType geomType : 3;					// point, linestring, polygon...
+	OutputGeometryType geomType : 8;					// point, linestring, polygon...
+	uint_least8_t layer 		: 8;					// what layer is it in?
 	bool fromShapefile 			: 1;
 	unsigned minZoom 			: 4;
-	uint_least8_t layer 		: 8;					// what layer is it in?
 	
 	mutable std::atomic<uint32_t> references;
 
@@ -79,7 +81,7 @@ public:
 	OutputObjectOsmStorePoint(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == POINT || type == CENTROID || type == CACHED_POINT);
+		assert(type == OutputGeometryType::POINT);
 	}
 }; 
 
@@ -89,7 +91,7 @@ public:
 	OutputObjectOsmStoreLinestring(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == LINESTRING || type == CACHED_LINESTRING);
+		assert(type == OutputGeometryType::LINESTRING);
 	}
 };
 
@@ -99,7 +101,7 @@ public:
 	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == POLYGON || type == CACHED_POLYGON);
+		assert(type == OutputGeometryType::POLYGON);
 	}
 };
 

--- a/include/pbf_blocks.h
+++ b/include/pbf_blocks.h
@@ -11,7 +11,6 @@
 #include "osmformat.pb.h"
 #include "vector_tile.pb.h"
 
-
 /* -------------------
    Protobuf handling
    ------------------- */
@@ -39,10 +38,10 @@ void readStringMap(std::map<std::string, int> *mapPtr, PrimitiveBlock *pbPtr);
 std::map<std::string, std::string> getTags(std::vector<std::string> *strPtr, Way *wayPtr);
 
 /// Find the index of a string in the StringTable, adding it if it's not there
-uint findStringInTable(std::string *strPtr, std::map<std::string, int> *mapPtr, PrimitiveBlock *pbPtr);
+unsigned int findStringInTable(std::string *strPtr, std::map<std::string, int> *mapPtr, PrimitiveBlock *pbPtr);
 
 /// Set a tag for a way to a new value
-void setTag(Way *wayPtr, uint keyIndex, uint valueIndex);
+void setTag(Way *wayPtr, unsigned int keyIndex, unsigned int valueIndex);
 
 #endif //_PBF_BLOCKS_H
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -232,9 +232,9 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 		throw out_of_range("ERROR: Layer(): a layer named as \"" + layerName + "\" doesn't exist.");
 	}
 
-	OutputGeometryType geomType = isWay ? (area ? POLYGON : LINESTRING) : POINT;
+	OutputGeometryType geomType = isWay ? (area ? OutputGeometryType::POLYGON : OutputGeometryType::LINESTRING) : OutputGeometryType::POINT;
 	try {
-		if (geomType==POINT) {
+		if (geomType==OutputGeometryType::POINT) {
 			LatpLon pt = indexStore->nodes_at(osmID);
 			Point p = Point(pt.lon, pt.latp);
 
@@ -246,7 +246,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
     	    outputs.push_back(std::make_pair(oo, AttributeStore::key_value_set_entry_t()));
             return;
 		}
-		else if (geomType==POLYGON) {
+		else if (geomType==OutputGeometryType::POLYGON) {
 			// polygon
 
 			MultiPolygon mp;
@@ -275,7 +275,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
                             osmID, osmStore.store_multi_polygon(osmStore.osm(), mp), attributeStore.empty_set()));
     	    outputs.push_back(std::make_pair(oo, AttributeStore::key_value_set_entry_t()));
 		}
-		else if (geomType==LINESTRING) {
+		else if (geomType==OutputGeometryType::LINESTRING) {
 			// linestring
 			Linestring ls = linestringCached();
 
@@ -341,7 +341,7 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		cerr << "Error in OutputObjectOsmStore constructor: " << err.what() << endl;
 	}
 
-	OutputObjectRef oo(new OutputObjectOsmStorePoint(CENTROID,
+	OutputObjectRef oo(new OutputObjectOsmStorePoint(OutputGeometryType::POINT,
 					false, layers.layerMap[layerName],
 					osmID, osmStore.store_point(osmStore.osm(), geomp), attributeStore.empty_set()));
     outputs.push_back(std::make_pair(oo, AttributeStore::key_value_set_entry_t()));
@@ -469,7 +469,7 @@ void OsmLuaProcessing::setWay(WayID wayId, OSMStore::handle_t handle, const tag_
 					// Store the attributes of the generated geometry
 					jt->first->setAttributeSet(attributeStore.store_set(jt->second));		
 
-					if (jt->first->geomType == POLYGON) {
+					if (jt->first->geomType == OutputGeometryType::POLYGON) {
 						polygonExists = true;
 						continue;
 					}
@@ -487,7 +487,7 @@ void OsmLuaProcessing::setWay(WayID wayId, OSMStore::handle_t handle, const tag_
 						// Store the attributes of the generated geometry
 						jt->first->setAttributeSet(attributeStore.store_set(jt->second));		
 
-						if (jt->first->geomType != POLYGON) continue;
+						if (jt->first->geomType != OutputGeometryType::POLYGON) continue;
 						osmMemTiles.AddObject(index, jt->first);
 					}
 				}

--- a/src/osm_store.cpp
+++ b/src/osm_store.cpp
@@ -16,38 +16,4 @@ WayList<WayVec::const_iterator> makeWayList( const WayVec &outerWayVec, const Wa
 }
 
 
-// relation store
-
-// @brief Lookup a way list
-// @param i Pseudo OSM ID of a relational way
-// @return A way list
-// @exception NotFound
-WayList<RelationStore::const_iterator> RelationStore::at(WayID i) const {
-	try {
-		const auto &outInList = mOutInLists->at(i);
-		return { outInList.first.cbegin(), outInList.first.cend(), outInList.second.cbegin(), outInList.second.cend() };
-	} catch (std::out_of_range &err){
-		stringstream ss;
-		ss << "Could not find pseudo OSM ID of polygon " << i;
-		throw std::out_of_range(ss.str());
-	}
-}
-
-// @brief Return whether a way list is on the store.
-// @param i Any possible OSM ID
-// @return 1 if found, 0 otherwise
-// @note This function is named as count for consistent naming with stl functions.
-size_t RelationStore::count(WayID i) const {
-	return mOutInLists->count(i);
-}
-
-// @brief Make the store empty
-void RelationStore::clear() {
-	mOutInLists->clear();
-}
-
-size_t RelationStore::size() const { 
-	return mOutInLists->size(); 
-}
-
 

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -11,6 +11,23 @@ namespace geom = boost::geometry;
 
 // **********************************************************
 
+std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
+{
+	switch(geomType) {
+		case OutputGeometryType::POINT:
+			os << "OutputGeometryType::POINT";
+			break;
+		case OutputGeometryType::LINESTRING:
+			os << "OutputGeometryType::LINESTRING";
+			break;
+		case OutputGeometryType::POLYGON:
+			os << "OutputGeometryType::POLYGON";
+			break;
+	}
+
+	return os;
+}
+
 
 // Write attribute key/value pairs (dictionary-encoded)
 void OutputObject::writeAttributes(
@@ -50,9 +67,7 @@ void OutputObject::writeAttributes(
 Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox) 
 {
 	switch(oo.geomType) {
-		case POINT:
-		case CACHED_POINT:
-		case CENTROID:
+		case OutputGeometryType::POINT:
 		{
 			auto const &p = osmStore.retrieve<mmap::point_t>(oo.handle);
 			if (geom::within(p, bbox.clippingBox)) {
@@ -61,16 +76,14 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return MultiLinestring();
 		}
 
-		case LINESTRING:
-		case CACHED_LINESTRING:
+		case OutputGeometryType::LINESTRING:
 		{
 			MultiLinestring out;
 			geom::intersection(osmStore.retrieve<mmap::linestring_t>(oo.handle), bbox.clippingBox, out);
 			return out;
 		}
 
-		case POLYGON:
-		case CACHED_POLYGON:
+		case OutputGeometryType::POLYGON:
 		{
 			auto const &mp = osmStore.retrieve<mmap::multi_polygon_t>(oo.handle);
 
@@ -102,9 +115,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox)
 {
 	switch(oo.geomType) {
-		case POINT:
-		case CACHED_POINT:
-		case CENTROID:
+		case OutputGeometryType::POINT:
 		{
 			auto const &pt = osmStore.retrieve<mmap::point_t>(oo.handle);
 			LatpLon out;
@@ -113,27 +124,24 @@ LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 		 	return out;
 		}
 
-		default:	
-			throw std::runtime_error("Geometry type is not point");
-
+		default:
+			break;
 	}
+
+	throw std::runtime_error("Geometry type is not point");			
 }
 
 bool intersects(OSMStore &osmStore, OutputObject const &oo, Point const &p)
 {
 	switch(oo.geomType) {
-		case POINT:
-		case CACHED_POINT:
-		case CENTROID:
+		case OutputGeometryType::POINT:
 			return boost::geometry::intersects(osmStore.retrieve<mmap::point_t>(oo.handle), p);
 
-		case LINESTRING:
-		case CACHED_LINESTRING:
+		case OutputGeometryType::LINESTRING:
 			return boost::geometry::intersects(osmStore.retrieve<mmap::linestring_t>(oo.handle), p);
 
 
-		case POLYGON:
-		case CACHED_POLYGON:
+		case OutputGeometryType::POLYGON:
 			return boost::geometry::intersects(osmStore.retrieve<mmap::multi_polygon_t>(oo.handle), p);
 
 		default:

--- a/src/pbf_blocks.cpp
+++ b/src/pbf_blocks.cpp
@@ -57,7 +57,7 @@ void writeBlock(google::protobuf::Message *messagePtr, ostream &output, string h
 	bh.SerializeToString(&header_encoded);
 	
 	// write out
-	uint bhLength=header_encoded.length();
+	unsigned int bhLength=header_encoded.length();
 	endian_swap(bhLength);
 	output.write(reinterpret_cast<const char *>(&bhLength), 4);
 	output.write(header_encoded.c_str(), header_encoded.length() );
@@ -94,17 +94,17 @@ map<string, string> getTags(vector<string> *strPtr, Way *wayPtr) {
 }
 
 // Find the index of a string in the StringTable, adding it if it's not there
-uint findStringInTable(string *strPtr, map<string, int> *mapPtr, PrimitiveBlock *pbPtr) {
+unsigned int findStringInTable(string *strPtr, map<string, int> *mapPtr, PrimitiveBlock *pbPtr) {
 	if (mapPtr->find(*strPtr) == mapPtr->end()) {
 		pbPtr->mutable_stringtable()->add_s(*strPtr);
-		uint ix = pbPtr->stringtable().s_size()-1;
+		unsigned int ix = pbPtr->stringtable().s_size()-1;
 		mapPtr->insert(pair<string, int> (*strPtr, ix));
 	}
 	return mapPtr->at(*strPtr);
 }
 
 // Set a tag for a way to a new value
-void setTag(Way *wayPtr, uint keyIndex, uint valueIndex) {
+void setTag(Way *wayPtr, unsigned int keyIndex, unsigned int valueIndex) {
 	for (int i=0; i<wayPtr->keys_size(); i++) {
 		if (wayPtr->keys(i)==keyIndex) {
 			wayPtr->mutable_vals()->Set(i,valueIndex);

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -176,7 +176,7 @@ void readShapefile(const Box &clippingBox,
 				if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, CACHED_POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}
@@ -198,7 +198,7 @@ void readShapefile(const Box &clippingBox,
 					if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 					auto &attributeStore = osmLuaProcessing.getAttributeStore();
-					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, CACHED_LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
+					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
 
 					addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 				}
@@ -269,7 +269,7 @@ void readShapefile(const Box &clippingBox,
 
 				// create OutputObject
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, CACHED_POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -82,7 +82,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 	uint tilex = 0, tiley = 0;
 	switch(geomType) {
-		case CACHED_POINT:
+		case OutputGeometryType::POINT:
 		{
 			Point *p = boost::get<Point>(&geometry);
 			if (p != nullptr) {
@@ -96,7 +96,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			}
 		} break;
 
-		case CACHED_LINESTRING:
+		case OutputGeometryType::LINESTRING:
 		{
 			oo = new OutputObjectOsmStoreLinestring(
 						geomType, true, layerNum, id, osmStore.store_linestring(osmStore.shp(), boost::get<Linestring>(geometry)), attributes);
@@ -105,7 +105,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			addToTileIndexPolyline(oo, tileIndex, &geometry);
 		} break;
 
-		case CACHED_POLYGON:
+		case OutputGeometryType::POLYGON:
 		{
 			oo = new OutputObjectOsmStoreMultiPolygon(
 						geomType, true, layerNum, id, osmStore.store_multi_polygon(osmStore.shp(), boost::get<MultiPolygon>(geometry)), attributes);

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -19,7 +19,7 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, ObjectsAtSubLayerIterator &jt, 
 	if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
 
 	auto gTyp = oo->geomType;
-	if (gTyp == POLYGON || gTyp == CACHED_POLYGON) {
+	if (gTyp == OutputGeometryType::POLYGON) {
 		MultiPolygon *gAcc = nullptr;
 		try {
 			gAcc = &boost::get<MultiPolygon>(g);
@@ -61,7 +61,7 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, ObjectsAtSubLayerIterator &jt, 
 		ConvertFromClipper(current, *gAcc);
 	}
 
-	if (gTyp == LINESTRING || gTyp == CACHED_LINESTRING) {
+	if (gTyp == OutputGeometryType::LINESTRING) {
 		MultiLinestring *gAcc = nullptr;
 		try {
 			gAcc = &boost::get<MultiLinestring>(g);
@@ -101,7 +101,7 @@ void ProcessObjects(OSMStore &osmStore, const ObjectsAtSubLayerIterator &ooSameL
 		OutputObjectRef oo = *jt;
 		if (zoom < oo->minZoom) { continue; }
 
-		if (oo->geomType == POINT) {
+		if (oo->geomType == OutputGeometryType::POINT) {
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();
 			LatpLon pos = buildNodeGeometry(osmStore, *oo, bbox);
 			featurePtr->add_geometry(9);					// moveTo, repeat x1

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -12,7 +12,6 @@
 #include <stdexcept>
 #include <thread>
 #include <mutex>
-#include <sys/resource.h>
 #include <chrono>
 
 // Other utilities
@@ -26,8 +25,8 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/filereadstream.h"
 
-#ifdef _MSC_VER
-typedef unsigned uint;
+#ifndef _MSC_VER
+#include <sys/resource.h>
 #endif
 
 #include "geomtypes.h"
@@ -129,7 +128,6 @@ void generate_from_index(OSMStore &osmStore, PbfReaderOutput *output)
 int main(int argc, char* argv[]) {
 
 	// ----	Read command-line options
-	
 	vector<string> inputFiles;
 	string luaFile;
 	string osmStoreFile;
@@ -477,11 +475,13 @@ int main(int argc, char* argv[]) {
 	}
 	google::protobuf::ShutdownProtobufLibrary();
 
+#ifndef _MSC_VER
 	if (verbose) {
 		struct rusage r_usage;
 		getrusage(RUSAGE_SELF, &r_usage);
 		cout << "\nMemory used: " << r_usage.ru_maxrss << endl;
 	}
+#endif
 
 	cout << endl << "Filled the tileset with good things at " << sharedData.outputFile << endl;
 }


### PR DESCRIPTION
CI for windows, linux and macos
- Build boost from CI, this is required because boost is removed from virtual environments
- Lua 5.4 fixes
- LuaJit compilation
- Artifacts for windows/linux/macos are generated

First build is slow(boost is build), but the dependencies are cached. 