### PR TITLE
Use unordered_set instead of sort to calculate unique output objects

### DIFF
--- a/include/osm_mem_tiles.h
+++ b/include/osm_mem_tiles.h
@@ -19,8 +19,7 @@ public:
 
 	virtual void MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords);
 
-	virtual void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, 
-		std::vector<OutputObjectRef> &dstTile);
+	virtual void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, OutputObjectsPerLayer &dstTile);
 
 	virtual void AddObject(TileCoordinates index, OutputObjectRef oo);
 

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -12,7 +12,7 @@ public:
 	virtual void MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords);
 
 	virtual void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, 
-		std::vector<OutputObjectRef> &dstTile);
+		 OutputObjectsPerLayer &dstTile);
 
 	// Find intersecting shapefile layer
 	virtual std::vector<std::string> FindIntersecting(const std::string &layerName, Box &box) const;

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -9,7 +9,7 @@ void OsmMemTiles::MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords
 	::MergeTileCoordsAtZoom(zoom, baseZoom, tileIndex, dstCoords);
 }
 
-void OsmMemTiles::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom,  std::vector<OutputObjectRef> &dstTile) {
+void OsmMemTiles::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, OutputObjectsPerLayer &dstTile) {
 	::MergeSingleTileDataAtZoom(dstIndex, zoom, baseZoom, tileIndex, dstTile);
 }
 

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -12,7 +12,7 @@ void ShpMemTiles::MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords
 	::MergeTileCoordsAtZoom(zoom, baseZoom, tileIndex, dstCoords);
 }
 
-void ShpMemTiles::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, std::vector<OutputObjectRef> &dstTile) {
+void ShpMemTiles::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, OutputObjectsPerLayer &dstTile) {
 	::MergeSingleTileDataAtZoom(dstIndex, zoom, baseZoom, tileIndex, dstTile);
 }
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -16,7 +16,7 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, ObjectsAtSubLayerIterator &jt, 
 	// the following objects are merged into the first object, by taking union of geometries.
 	OutputObjectRef oo = *jt;
 	OutputObjectRef ooNext;
-	if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
+	if(std::next(jt) != ooSameLayerEnd) ooNext = *(std::next(jt));
 
 	auto gTyp = oo->geomType;
 	if (gTyp == OutputGeometryType::POLYGON) {
@@ -31,12 +31,12 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, ObjectsAtSubLayerIterator &jt, 
 		PolyTree current;
 		ConvertToClipper(*gAcc, current);
 
-		while (jt+1 != ooSameLayerEnd &&
+		while (std::next(jt) != ooSameLayerEnd &&
 				ooNext->geomType == gTyp &&
 				ooNext->attributes == oo->attributes) {
 			jt++;
 			oo = *jt;
-			if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
+			if(std::next(jt) != ooSameLayerEnd) ooNext = *(std::next(jt));
 			else ooNext.reset();
 
 			try {
@@ -70,12 +70,12 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, ObjectsAtSubLayerIterator &jt, 
 			return;
 		}
 
-		while (jt+1 != ooSameLayerEnd &&
+		while (std::next(jt) != ooSameLayerEnd &&
 				ooNext->geomType == gTyp &&
 				ooNext->attributes == oo->attributes) {
 			jt++;
 			oo = *jt;
-			if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
+			if(std::next(jt) != ooSameLayerEnd) ooNext = *(std::next(jt));
 			else ooNext.reset();
 
 			try {
@@ -167,10 +167,12 @@ void ProcessLayer(OSMStore &osmStore,
 			simplifyLevel *= pow(ld.simplifyRatio, (ld.simplifyBelow-1) - zoom);
 		}
 
-		ObjectsAtSubLayerConstItPair ooListSameLayer = it.GetObjectsAtSubLayer(layerNum);
-		// Loop through output objects
-		ProcessObjects(osmStore, ooListSameLayer.first, ooListSameLayer.second, sharedData, 
-			simplifyLevel, zoom, bbox, vtLayer, keyList, valueList);
+		if(it.HasObjectsAtSubLayer(layerNum)) {
+			auto const &objects = it.GetObjectsAtSubLayer(layerNum);
+			// Loop through output objects
+			ProcessObjects(osmStore, objects.cbegin(), objects.cend(), sharedData, 
+				simplifyLevel, zoom, bbox, vtLayer, keyList, valueList);
+		}
 	}
 
 	// If there are any objects, then add tags


### PR DESCRIPTION
Use unordered_set instead of sort to generate unique list of output objects per layer. 