### PR TITLE
Small optimization: store multipolygon in mmap in place

### DIFF
--- a/include/geomtypes.h
+++ b/include/geomtypes.h
@@ -76,23 +76,37 @@ struct mmap {
 
 	using linestring_t = linestring_base_t<point_t, vector_t, bi_alloc_t<point_t>>;
 
-    struct polygon_data_t
-    {
-		using inners_type = vector_t<ring_t, scoped_alloc_t<bi_alloc_t<ring_t>>>;
-	    using ring_type = ring_t;
-    };
-
-    using polygon_parent_t = std::pair<polygon_data_t::ring_type, polygon_data_t::inners_type>;
-
-	struct polygon_t 
-		: polygon_parent_t
+	using polygon_base_inners_type = vector_t<ring_t, scoped_alloc_t<bi_alloc_t<ring_t>>>;
+	template<class A>
+	struct polygon_base_t 
 	{
-		using polygon_parent_t::polygon_parent_t;
-		using inners_type = polygon_data_t::inners_type;
-		using ring_type = polygon_data_t::ring_type;
+		using allocator_type = A;
+
+		using inners_type = polygon_base_inners_type;
+	    using ring_type = ring_t;
+		
+		ring_type outer;
+		inners_type inners;
+
+		template<class Alloc>
+		polygon_base_t(polygon_base_t<A>&& other, Alloc const &alloc = Alloc()) noexcept
+			: outer(other.outer)
+			, inners(other.inners)
+		{ } 
+		template<class Alloc>
+		polygon_base_t(polygon_base_t<A>const &other, Alloc const &alloc = Alloc()) noexcept
+			: outer(other.outer)
+			, inners(other.inners)
+		{ } 
+		template<class Alloc>
+		polygon_base_t(std::allocator_arg_t, Alloc const &alloc = Alloc()) noexcept
+			: outer(alloc)
+			, inners(alloc)
+		{ } 
 	};
 
-	using multi_polygon_t = vector_t<mmap::polygon_t, mmap::bi_alloc_t<mmap::polygon_t>>;
+	using polygon_t = polygon_base_t<scoped_alloc_t<polygon_base_inners_type>>;
+	using multi_polygon_t = vector_t<mmap::polygon_t, scoped_alloc_t<mmap::bi_alloc_t<mmap::polygon_t>>>;
 };
 
 namespace boost { namespace geometry { namespace traits {  
@@ -111,22 +125,22 @@ namespace boost { namespace geometry { namespace traits {
 	template<> struct exterior_ring<mmap::polygon_t>
 	{ 
 		static mmap::polygon_t::ring_type& get(mmap::polygon_t& p){
-	        return p.first;
+	        return p.outer;
     	}
 
     	static mmap::polygon_t::ring_type const& get(mmap::polygon_t const& p) {
-	        return p.first;
+	        return p.outer;
     	}
 	};	
 
 	template<> struct interior_rings<mmap::polygon_t>
 	{
     	static mmap::polygon_t::inners_type& get(mmap::polygon_t& p) {
-	        return p.second;
+	        return p.inners;
     	}
 
     	static mmap::polygon_t::inners_type const& get(mmap::polygon_t const& p) {
-	        return p.second;
+	        return p.inners;
     	}
 	};
 

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -801,27 +801,8 @@ public:
 	handle_t store_multi_polygon(generated &store, Input const &src)
 	{
 		 perform_mmap_operation([&]() {
-			 mmap::multi_polygon_t result(store.multi_polygon_store->get_allocator());
-			 result.reserve(src.size());
-
-			for(auto const &polygon: src) {
-				mmap::polygon_t::inners_type inners(result.get_allocator());
-				inners.resize(polygon.inners().size());
-
-				mmap::polygon_t::ring_type outer(result.get_allocator());
-
-				// Copy the outer ring
-				boost::geometry::assign(outer, polygon.outer());
-
-				// Store the inner rings
-				for(std::size_t i = 0; i < polygon.inners().size(); ++i) {
-					boost::geometry::assign(inners[i], polygon.inners()[i]);
-				} 
-			
-				result.emplace_back(outer, inners);
-			}
-
-			store.multi_polygon_store->push_back(result);
+			store.multi_polygon_store->emplace_back();
+			boost::geometry::assign(store.multi_polygon_store->back(), src);
 		});
 
 		return mmap_file.get_handle_from_address(&store.multi_polygon_store->back());


### PR DESCRIPTION
This is a small optimization of multipolygons in the mmap file. It uses boost::geometry::assign to copy the multipolygon now, gives a small improvement to performance. Also, it annoyed me that I could not assign the mmap multipolygon with boost geometry assign, and now it is possible.  