### PR TITLE
Write metadata.json file when generating directory output

### DIFF
--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -47,7 +47,8 @@ public:
 			const std::string &indexName,
 			const std::string &writeTo);
 
-	std::string serialiseToJSON();
+	rapidjson::Value serialiseToJSONValue(rapidjson::Document::AllocatorType &allocator) const;
+	std::string serialiseToJSON() const;
 };
 
 ///\brief Config read from JSON to control behavior of program

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -44,7 +44,14 @@
 		"name": "Tilemaker to OpenMapTiles schema",
 		"version": "3.0",
 		"description": "Tile config based on OpenMapTiles schema",
-		"compress": "gzip"
+		"compress": "gzip",
+		"filemetadata": {
+			"tilejson": "2.0.0", 
+			"scheme": "xyz", 
+			"type": "baselayer", 
+			"format": "pbf", 
+            "tiles": ["https://example.com/liechtenstein/{z}/{x}/{y}.pbf"]
+		}
 	}
 }
 

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -53,11 +53,8 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 	return layerNum;
 }
 
-std::string LayerDefinition::serialiseToJSON() {
-	Document document;
-	document.SetObject();
-	Document::AllocatorType& allocator = document.GetAllocator();
 
+Value LayerDefinition::serialiseToJSONValue(rapidjson::Document::AllocatorType &allocator) const {
 	Value layerArray(kArrayType);
 	for (auto it = layers.begin(); it != layers.end(); ++it) {
 		Value fieldObj(kObjectType);
@@ -78,7 +75,15 @@ std::string LayerDefinition::serialiseToJSON() {
 		layerArray.PushBack(layerObj, allocator);
 	}
 
-	document.AddMember("vector_layers", layerArray, allocator);
+	return layerArray;
+}
+
+std::string LayerDefinition::serialiseToJSON() const {
+	Document document;
+	document.SetObject();
+	Document::AllocatorType& allocator = document.GetAllocator();
+
+	document.AddMember("vector_layers", serialiseToJSONValue(allocator), allocator);
 
 	StringBuffer buffer;
 	Writer<StringBuffer> writer(buffer);


### PR DESCRIPTION
Create also a 'metadata.json' file when writing pbf files to disk instead of mbtiles. 
To use it, the webserver needs to include the header Content-Encoding: gzip when serving pbf files with compression. 

````
location ~ /map/.+pbf$ {
            # gzip Encoding and MIME type type
            add_header  Content-Encoding  gzip;
            gzip off;
            types { application/x-protobuf pbf; }
}
