### PR TITLE
Add filter_below to skip small areas at low zooms

### DIFF
--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -21,6 +21,8 @@ struct LayerDef {
 	double simplifyLevel;
 	double simplifyLength;
 	double simplifyRatio;
+	uint filterBelow;
+	double filterArea;
 	std::string source;
 	std::vector<std::string> sourceColumns;
 	bool allSourceColumns;
@@ -40,6 +42,7 @@ public:
 	// Define a layer (as read from the .json file)
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,
 			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
+			uint filterBelow, double filterArea,
 			const std::string &source,
 			const std::vector<std::string> &sourceColumns,
 			bool allSourceColumns,

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -22,6 +22,7 @@ SharedData::~SharedData() { }
 // Define a layer (as read from the .json file)
 uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
+		uint filterBelow, double filterArea,
 		const std::string &source,
 		const std::vector<std::string> &sourceColumns,
 		bool allSourceColumns,
@@ -30,6 +31,7 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		const std::string &writeTo)  {
 
 	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
+		filterBelow, filterArea,
 		source, sourceColumns, allSourceColumns, indexed, indexName,
 		std::map<std::string,uint>() };
 	layers.push_back(layer);
@@ -175,6 +177,8 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		double simplifyLevel  = it->value.HasMember("simplify_level" ) ? it->value["simplify_level" ].GetDouble() : 0.01;
 		double simplifyLength = it->value.HasMember("simplify_length") ? it->value["simplify_length"].GetDouble() : 0.0;
 		double simplifyRatio  = it->value.HasMember("simplify_ratio" ) ? it->value["simplify_ratio" ].GetDouble() : 1.0;
+		int    filterBelow    = it->value.HasMember("filter_below"   ) ? it->value["filter_below"   ].GetInt()    : 0;
+		double filterArea     = it->value.HasMember("filter_area"    ) ? it->value["filter_area"    ].GetDouble() : 0.5;
 		string source = it->value.HasMember("source") ? it->value["source"].GetString() : "";
 		vector<string> sourceColumns;
 		bool allSourceColumns = false;
@@ -194,6 +198,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 
 		layers.addLayer(layerName, minZoom, maxZoom,
 				simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
+				filterBelow, filterArea,
 				source, sourceColumns, allSourceColumns, indexed, indexName,
 				writeTo);
 


### PR DESCRIPTION
This allows us to entirely filter out polygons based on area size, by setting the config parameters `filter_below` and `filter_area`. These work in a similar way to `simplify_below` and `simplify_length`.

We can already do this in the Lua profile with `SetMinZoom`, but that works only on OSM-derived objects, not shapefile objects. This works for shapefiles too and will therefore be useful for landuse (#203) and similar.