### PR TITLE
Use memory for allocation of osm store if no mmap file is specified

### DIFF
--- a/include/geomtypes.h
+++ b/include/geomtypes.h
@@ -21,7 +21,7 @@ using uint = unsigned int;
 #include <boost/geometry/geometries/register/multi_polygon.hpp>
 #include <boost/container/scoped_allocator.hpp>
 
-#include <boost/interprocess/managed_mapped_file.hpp>
+#include <boost/interprocess/managed_external_buffer.hpp>
 #include <boost/interprocess/allocators/node_allocator.hpp>
 
 namespace bi = boost::interprocess;
@@ -45,7 +45,7 @@ struct mmap {
 
 	template<typename T, typename A> using vector_t = std::vector<T, A>;
 
-    template<typename T> using bi_alloc_t = bi::node_allocator<T, bi::managed_mapped_file::segment_manager>;
+    template<typename T> using bi_alloc_t = bi::node_allocator<T, bi::managed_external_buffer::segment_manager>;
     template<typename T> using scoped_alloc_t = boost::container::scoped_allocator_adaptor<T>;
 
 	template<

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -50,8 +50,6 @@ public:
 	void setWay(WayID wayId, OSMStore::handle_t nodeVecHandle, const tag_map_t &tags) override;
 	void setRelation(int64_t relationId, OSMStore::handle_t relationHandle, const tag_map_t &tags) override;
 
-	void save(std::string const &filename);
-
 private:
 
 	OSMStore &osmStore;

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -240,7 +240,3 @@ void PbfIndexWriter::setRelation(int64_t relationId, OSMStore::handle_t relation
 	osmStore.pbf_store_relation_entry(relationId, relationHandle, tags);
 }
 
-void PbfIndexWriter::save(std::string const &filename)
-{
-	osmStore.save(filename);
-}


### PR DESCRIPTION
Following commit makes the osm_store optional. If no filename is specified, no mmap file is created and used and all operations run in memory. 