### PR TITLE
Optionally set minzoom to write attributes

### DIFF
--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -20,7 +20,7 @@
 
 struct AttributeStore
 {
-    using key_value_t = std::pair<std::string, vector_tile::Tile_Value>;    
+    using key_value_t = std::tuple<std::string, vector_tile::Tile_Value, char>;
 	enum class Index { BOOL, FLOAT, STRING };
 
 	static Index type_index(vector_tile::Tile_Value const &v)
@@ -57,7 +57,11 @@ struct AttributeStore
     
     struct key_value_less {
         bool operator()(key_value_t const &lhs, key_value_t const& rhs) const {            
-            return (lhs.first == rhs.first) ? compare(lhs.second, rhs.second) : (lhs.first < rhs.first);
+			return std::get<2>(lhs) != std::get<2>(rhs) ?
+				std::get<2>(lhs) < std::get<2>(rhs) :
+				(std::get<0>(lhs) == std::get<0>(rhs)) ?
+				compare(std::get<1>(lhs), std::get<1>(rhs)) :
+				(std::get<0>(lhs) < std::get<0>(rhs));
         }
     }; 
     
@@ -67,7 +71,11 @@ struct AttributeStore
         
     struct key_value_store_less {
         bool operator()(key_value_store_iter_t lhs, key_value_store_iter_t rhs) const {            
-            return (lhs->first == rhs->first) ? compare(lhs->second, rhs->second) : (lhs->first < rhs->first);
+			return std::get<2>(*lhs) != std::get<2>(*rhs) ?
+				std::get<2>(*lhs) < std::get<2>(*rhs) :
+				(std::get<0>(*lhs) == std::get<0>(*rhs)) ?
+				compare(std::get<1>(*lhs), std::get<1>(*rhs)) :
+				(std::get<0>(*lhs) < std::get<0>(*rhs));
         }
     }; 
     
@@ -104,8 +112,8 @@ struct AttributeStore
 		, next_set_id(0) 
     { }
             
-    key_value_store_iter_t store_key_value(std::string const &key, vector_tile::Tile_Value const &value) {
-        return key_values.insert(std::make_pair(key, value)).first;              
+    key_value_store_iter_t store_key_value(std::string const &key, vector_tile::Tile_Value const &value, char const minZoom) {
+        return key_values.insert(std::make_tuple(key, value, minZoom)).first;              
     }
     
     key_value_set_iter_t store_set(key_value_set_entry_t set) {

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -124,8 +124,11 @@ public:
 	
 	// Set attributes in a vector tile's Attributes table
 	void Attribute(const std::string &key, const std::string &val);
+	void AttributeWithMinZoom(const std::string &key, const std::string &val, const char minzoom);
 	void AttributeNumeric(const std::string &key, const float val);
+	void AttributeNumericWithMinZoom(const std::string &key, const float val, const char minzoom);
 	void AttributeBoolean(const std::string &key, const bool val);
+	void AttributeBooleanWithMinZoom(const std::string &key, const bool val, const char minzoom);
 	void MinZoom(const unsigned z);
 
 	// ----	vector_layers metadata entry

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -62,7 +62,7 @@ public:
 
 	//\brief Write attribute key/value pairs (dictionary-encoded)
 	void writeAttributes(std::vector<std::string> *keyList, 
-		std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Feature *featurePtr) const;
+		std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Feature *featurePtr, char zoom) const;
 	
 	/**
 	 * \brief Find a value in the value dictionary

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -47,9 +47,9 @@ OsmLuaProcessing::OsmLuaProcessing(
 		.addFunction("Length", &OsmLuaProcessing::Length)
 		.addFunction("Layer", &OsmLuaProcessing::Layer)
 		.addFunction("LayerAsCentroid", &OsmLuaProcessing::LayerAsCentroid)
-		.addFunction("Attribute", &OsmLuaProcessing::Attribute)
-		.addFunction("AttributeNumeric", &OsmLuaProcessing::AttributeNumeric)
-		.addFunction("AttributeBoolean", &OsmLuaProcessing::AttributeBoolean)
+		.addOverloadedFunctions("Attribute", &OsmLuaProcessing::Attribute, &OsmLuaProcessing::AttributeWithMinZoom)
+		.addOverloadedFunctions("AttributeNumeric", &OsmLuaProcessing::AttributeNumeric, &OsmLuaProcessing::AttributeNumericWithMinZoom)
+		.addOverloadedFunctions("AttributeBoolean", &OsmLuaProcessing::AttributeBoolean, &OsmLuaProcessing::AttributeBooleanWithMinZoom)
 		.addFunction("MinZoom", &OsmLuaProcessing::MinZoom)
 	);
 	if (luaState["attribute_function"]) {
@@ -338,28 +338,31 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 }
 
 // Set attributes in a vector tile's Attributes table
-void OsmLuaProcessing::Attribute(const string &key, const string &val) {
+void OsmLuaProcessing::Attribute(const string &key, const string &val) { AttributeWithMinZoom(key,val,0); }
+void OsmLuaProcessing::AttributeWithMinZoom(const string &key, const string &val, const char minzoom) {
 	if (val.size()==0) { return; }		// don't set empty strings
 	if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
 	vector_tile::Tile_Value v;
 	v.set_string_value(val);
-	outputs.back().second.push_back(attributeStore.store_key_value(key, v));
+	outputs.back().second.push_back(attributeStore.store_key_value(key, v, minzoom));
 	setVectorLayerMetadata(outputs.back().first->layer, key, 0);
 }
 
-void OsmLuaProcessing::AttributeNumeric(const string &key, const float val) {
+void OsmLuaProcessing::AttributeNumeric(const string &key, const float val) { AttributeNumericWithMinZoom(key,val,0); }
+void OsmLuaProcessing::AttributeNumericWithMinZoom(const string &key, const float val, const char minzoom) {
 	if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
 	vector_tile::Tile_Value v;
 	v.set_float_value(val);
-	outputs.back().second.push_back(attributeStore.store_key_value(key, v));
+	outputs.back().second.push_back(attributeStore.store_key_value(key, v, 0));
 	setVectorLayerMetadata(outputs.back().first->layer, key, 1);
 }
 
-void OsmLuaProcessing::AttributeBoolean(const string &key, const bool val) {
+void OsmLuaProcessing::AttributeBoolean(const string &key, const bool val) { AttributeBooleanWithMinZoom(key,val,0); }
+void OsmLuaProcessing::AttributeBooleanWithMinZoom(const string &key, const bool val, const char minzoom) {
 	if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
 	vector_tile::Tile_Value v;
 	v.set_bool_value(val);
-	outputs.back().second.push_back(attributeStore.store_key_value(key, v));
+	outputs.back().second.push_back(attributeStore.store_key_value(key, v, 0));
 	setVectorLayerMetadata(outputs.back().first->layer, key, 2);
 }
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -353,7 +353,7 @@ void OsmLuaProcessing::AttributeNumericWithMinZoom(const string &key, const floa
 	if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
 	vector_tile::Tile_Value v;
 	v.set_float_value(val);
-	outputs.back().second.push_back(attributeStore.store_key_value(key, v, 0));
+	outputs.back().second.push_back(attributeStore.store_key_value(key, v, minzoom));
 	setVectorLayerMetadata(outputs.back().first->layer, key, 1);
 }
 
@@ -362,7 +362,7 @@ void OsmLuaProcessing::AttributeBooleanWithMinZoom(const string &key, const bool
 	if (outputs.size()==0) { cerr << "Can't add Attribute " << key << " if no Layer set" << endl; return; }
 	vector_tile::Tile_Value v;
 	v.set_bool_value(val);
-	outputs.back().second.push_back(attributeStore.store_key_value(key, v, 0));
+	outputs.back().second.push_back(attributeStore.store_key_value(key, v, minzoom));
 	setVectorLayerMetadata(outputs.back().first->layer, key, 2);
 }
 

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -37,11 +37,10 @@ void OutputObject::writeAttributes(
 	char zoom) const {
 
 	for(auto const &it: attributes->entries) {
-		char minZoom = std::get<2>(*it);
-		if (minZoom > zoom) continue;
+		if (it->minzoom > zoom) continue;
 
 		// Look for key
-		std::string const &key = std::get<0>(*it);
+		std::string const &key = it->key;
 		auto kt = find(keyList->begin(), keyList->end(), key);
 		if (kt != keyList->end()) {
 			uint32_t subscript = kt - keyList->begin();
@@ -53,7 +52,7 @@ void OutputObject::writeAttributes(
 		}
 		
 		// Look for value
-		vector_tile::Tile_Value const &value = std::get<1>(*it);
+		vector_tile::Tile_Value const &value = it->value;
 		int subscript = findValue(valueList, value);
 		if (subscript>-1) {
 			featurePtr->add_tags(subscript);

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -33,11 +33,15 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
 void OutputObject::writeAttributes(
 	vector<string> *keyList, 
 	vector<vector_tile::Tile_Value> *valueList, 
-	vector_tile::Tile_Feature *featurePtr) const {
+	vector_tile::Tile_Feature *featurePtr,
+	char zoom) const {
 
 	for(auto const &it: attributes->entries) {
+		char minZoom = std::get<2>(*it);
+		if (minZoom > zoom) continue;
+
 		// Look for key
-		std::string const &key = it->first;
+		std::string const &key = std::get<0>(*it);
 		auto kt = find(keyList->begin(), keyList->end(), key);
 		if (kt != keyList->end()) {
 			uint32_t subscript = kt - keyList->begin();
@@ -49,7 +53,7 @@ void OutputObject::writeAttributes(
 		}
 		
 		// Look for value
-		vector_tile::Tile_Value const &value = it->second; 
+		vector_tile::Tile_Value const &value = std::get<1>(*it);
 		int subscript = findValue(valueList, value);
 		if (subscript>-1) {
 			featurePtr->add_tags(subscript);

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -77,7 +77,7 @@ void addShapefileAttributes(
 				std::cout << "Didn't recognise Lua output type: " << val << std::endl;
 			}
 
-			attributes.push_back(attributeStore.store_key_value(key, v));
+			attributes.push_back(attributeStore.store_key_value(key, v, 0));
 		}
 
 		oo->setAttributeSet(attributeStore.store_set(attributes));		
@@ -101,7 +101,7 @@ void addShapefileAttributes(
 				         break;
 			}
 			
-			attributes.push_back(attributeStore.store_key_value(key, v));
+			attributes.push_back(attributeStore.store_key_value(key, v, 0));
 		}
 
 		oo->setAttributeSet(attributeStore.store_set(attributes));		

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -110,7 +110,7 @@ void ProcessObjects(OSMStore &osmStore, const ObjectsAtSubLayerIterator &ooSameL
 			featurePtr->add_geometry((xy.second << 1) ^ (xy.second >> 31));
 			featurePtr->set_type(vector_tile::Tile_GeomType_POINT);
 
-			oo->writeAttributes(&keyList, &valueList, featurePtr);
+			oo->writeAttributes(&keyList, &valueList, featurePtr, zoom);
 			if (sharedData.config.includeID) { featurePtr->set_id(oo->objectID); }
 		} else {
 			Geometry g;
@@ -134,7 +134,7 @@ void ProcessObjects(OSMStore &osmStore, const ObjectsAtSubLayerIterator &ooSameL
 			WriteGeometryVisitor w(&bbox, featurePtr, simplifyLevel);
 			boost::apply_visitor(w, g);
 			if (featurePtr->geometry_size()==0) { vtLayer->mutable_features()->RemoveLast(); continue; }
-			oo->writeAttributes(&keyList, &valueList, featurePtr);
+			oo->writeAttributes(&keyList, &valueList, featurePtr, zoom);
 			if (sharedData.config.includeID) { featurePtr->set_id(oo->objectID); }
 
 		}


### PR DESCRIPTION
This fixes #180 by providing a third, optional parameter for `object:Attribute` to specify the minimum zoom at which to write the attribute.

The use case is for layers such as roads and rivers, where at high zooms you want to show them as a line with a name label, but at low zooms you just want to show them as lines. Therefore there's no reason to write the names into the vector tiles at low zooms. For a typical semi-urban z11 tile on a style I'm working on, this reduces the tile size from 193kb to 169kb, which is a very useful saving.

There will be a small impact on memory usage by storing the minimum zoom as a single byte with each key/value pair, but nothing significant enough for `htop` to pick up - performance and memory usage were both on a par with current master.

@kleunen You might want to check that I haven't done anything silly to your `attribute_store` code!