### PR TITLE
Cleanup to tile coordinates generation

### DIFF
--- a/include/osm_mem_tiles.h
+++ b/include/osm_mem_tiles.h
@@ -17,18 +17,8 @@ class OsmMemTiles : public TileDataSource {
 public:
 	OsmMemTiles(uint baseZoom);
 
-	virtual void MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords);
 
-	virtual void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, 
-		std::vector<OutputObjectRef> &dstTile);
-
-	virtual void AddObject(TileCoordinates index, OutputObjectRef oo);
-
-	virtual void Clear();
-
-private:
-	TileIndex tileIndex;
-	uint baseZoom;
+	void Clear();
 };
 
 #endif //_OSM_MEM_TILES

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -78,8 +78,6 @@ public:
 class SharedData {
 
 public:
-	///Number of worker threads to create
-	std::map<uint, TileData> &tileData;
 	const class LayerDefinition &layers;
 	bool sqlite;
 	MBTiles mbtiles;
@@ -87,8 +85,7 @@ public:
 
 	const class Config &config;
 
-	SharedData(const class Config &configIn, const class LayerDefinition &layers,
-		std::map<uint, TileData> &tileData);
+	SharedData(const class Config &configIn, const class LayerDefinition &layers);
 	virtual ~SharedData();
 };
 

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -9,38 +9,35 @@ class ShpMemTiles : public TileDataSource
 public:
 	ShpMemTiles(OSMStore &osmStore, uint baseZoom);
 
-	virtual void MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords);
-
-	virtual void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, 
-		std::vector<OutputObjectRef> &dstTile);
-
 	// Find intersecting shapefile layer
-	virtual std::vector<std::string> FindIntersecting(const std::string &layerName, Box &box) const;
-	virtual bool Intersects(const std::string &layerName, Box &box) const;
-	virtual void CreateNamedLayerIndex(const std::string &layerName);
+	std::vector<std::string> FindIntersecting(const std::string &layerName, Box &box) const;
+	bool Intersects(const std::string &layerName, Box &box) const;
+	void CreateNamedLayerIndex(const std::string &layerName);
 
 	// Used in shape file loading
-	virtual OutputObjectRef AddObject(uint_least8_t layerNum,
+	OutputObjectRef AddObject(uint_least8_t layerNum,
 		const std::string &layerName, 
 		enum OutputGeometryType geomType,
 		Geometry geometry, 
 		bool isIndexed, bool hasName, const std::string &name, AttributeStoreRef attributes);
 
+	void AddObject(TileCoordinates const &index, OutputObjectRef const &oo) {
+		tileIndex[index].push_back(oo);
+	}
 private:
 	std::vector<uint> findIntersectingGeometries(const std::string &layerName, Box &box) const;
 	std::vector<uint> verifyIntersectResults(std::vector<IndexValue> &results, Point &p1, Point &p2) const;
 	std::vector<std::string> namesOfGeometries(std::vector<uint> &ids) const;
 
 	/// Add an OutputObject to all tiles between min/max lat/lon
-	void addToTileIndexByBbox(OutputObjectRef &oo, TileIndex &tileIndex,
+	void addToTileIndexByBbox(OutputObjectRef &oo, 
 		double minLon, double minLatp, double maxLon, double maxLatp);
 
 	/// Add an OutputObject to all tiles along a polyline
-	void addToTileIndexPolyline(OutputObjectRef &oo, TileIndex &tileIndex, Geometry *geom);
+	void addToTileIndexPolyline(OutputObjectRef &oo, Geometry *geom);
 
 	OSMStore &osmStore;
-	uint baseZoom;
-	TileIndex tileIndex;
+
 	std::vector<OutputObjectRef> cachedGeometries;					// prepared boost::geometry objects (from shapefiles)
 	std::map<uint, std::string> cachedGeometryNames;			//  | optional names for each one
 	std::map<std::string, RTree> indices;			// Spatial indices, boost::geometry::index objects for shapefile indices

--- a/include/tile_worker.h
+++ b/include/tile_worker.h
@@ -6,6 +6,6 @@
 #include <boost/asio/thread_pool.hpp>
 
 /// Start function for worker threads
-bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore &osmStore, TilesAtZoomIterator const &it, uint zoom);
+bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore &osmStore, std::vector<OutputObjectRef> const &data, TileCoordinates coordinates, uint zoom);
 
 #endif //_TILE_WORKER_H

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -1,21 +1,9 @@
 #include "osm_mem_tiles.h"
 using namespace std;
 
-OsmMemTiles::OsmMemTiles(uint baseZoom):
-	TileDataSource(),
-	baseZoom(baseZoom) { }
-
-void OsmMemTiles::MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords) {
-	::MergeTileCoordsAtZoom(zoom, baseZoom, tileIndex, dstCoords);
-}
-
-void OsmMemTiles::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom,  std::vector<OutputObjectRef> &dstTile) {
-	::MergeSingleTileDataAtZoom(dstIndex, zoom, baseZoom, tileIndex, dstTile);
-}
-
-void OsmMemTiles::AddObject(TileCoordinates index, OutputObjectRef oo) {
-	tileIndex[index].push_back(oo);
-}
+OsmMemTiles::OsmMemTiles(uint baseZoom)
+	: TileDataSource(baseZoom) 
+{ }
 
 void OsmMemTiles::Clear() {
 	tileIndex.clear();

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -6,12 +6,8 @@
 using namespace std;
 using namespace rapidjson;
 
-SharedData::SharedData(const class Config &configIn, const class LayerDefinition &layers,
-	std::map<uint, TileData> &tileData):
-	tileData(tileData),
-	layers(layers),
-	config(configIn) {
-
+SharedData::SharedData(const class Config &configIn, const class LayerDefinition &layers)
+	: layers(layers), config(configIn) {
 	sqlite=false;
 }
 

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -5,7 +5,7 @@ using namespace std;
 
 typedef std::pair<OutputObjectsConstIt,OutputObjectsConstIt> OutputObjectsConstItPair;
 
-void MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, TileCoordinatesSet &dstCoords) {
+void TileDataSource::MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, TileCoordinatesSet &dstCoords) {
 	if (zoom==baseZoom) {
 		// at z14, we can just use tileIndex
 		for (auto it = srcTiles.begin(); it!= srcTiles.end(); ++it) {
@@ -25,8 +25,7 @@ void MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, 
 	}
 }
 
-void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, uint baseZoom, const TileIndex &srcTiles, 
-	std::vector<OutputObjectRef> &dstTile) {
+void TileDataSource::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, uint baseZoom, const TileIndex &srcTiles, std::vector<OutputObjectRef> &dstTile) {
 	if (zoom==baseZoom) {
 		// at z14, we can just use tileIndex
 		auto oosetIt = srcTiles.find(dstIndex);
@@ -55,104 +54,3 @@ void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, uint baseZoo
 		}
 	}
 }
-
-// *********************************
-
-ObjectsAtSubLayerIterator::ObjectsAtSubLayerIterator(OutputObjectsConstIt it, const class TileData &tileData):
-	OutputObjectsConstIt(it),
-	tileData(tileData) { }
-
-// ********************************
-
-TilesAtZoomIterator::TilesAtZoomIterator(TileCoordinatesSet::const_iterator it, class TileData &tileData, uint zoom):
-	TileCoordinatesSet::const_iterator(it),
-	tileData(tileData),
-	zoom(zoom) {
-
-	RefreshData();
-}
-
-TileCoordinates TilesAtZoomIterator::GetCoordinates() const {
-	TileCoordinatesSet::const_iterator it = *this;
-	return *it;
-}
-
-ObjectsAtSubLayerConstItPair TilesAtZoomIterator::GetObjectsAtSubLayer(uint_least8_t layerNum) const {
-	TileCoordinatesSet::const_iterator it = *this;
-
-    struct layerComp
-    {
-        bool operator() ( const OutputObjectRef &x, uint_least8_t layer ) const { return x->layer < layer; }
-        bool operator() ( uint_least8_t layer, const OutputObjectRef &x ) const { return layer < x->layer; }
-    };
-
-	// compare only by `layer`
-	// We get the range within ooList, where the layer of each object is `layerNum`.
-	// Note that ooList is sorted by a lexicographic order, `layer` being the most significant.
-	const std::vector<OutputObjectRef> &ooList = data;
-
-	OutputObjectsConstItPair ooListSameLayer = equal_range(ooList.begin(), ooList.end(), layerNum, layerComp());
-	return ObjectsAtSubLayerConstItPair(ObjectsAtSubLayerIterator(ooListSameLayer.first, tileData), ObjectsAtSubLayerIterator(ooListSameLayer.second, tileData));
-}
-
-TilesAtZoomIterator& TilesAtZoomIterator::operator++() {
-	TileCoordinatesSet::const_iterator::operator++();
-	RefreshData();
-	return *this;
-}
-
-TilesAtZoomIterator TilesAtZoomIterator::operator++(int a) {
-	TileCoordinatesSet::const_iterator::operator++(a);
-	RefreshData();
-	return *this;
-}
-
-TilesAtZoomIterator& TilesAtZoomIterator::operator--() {
-	TileCoordinatesSet::const_iterator::operator--();
-	RefreshData();
-	return *this;
-}
-
-TilesAtZoomIterator TilesAtZoomIterator::operator--(int a) {
-	TileCoordinatesSet::const_iterator::operator--(a);
-	RefreshData();
-	return *this;
-}
-
-void TilesAtZoomIterator::RefreshData() {
-	data.clear();
-	TileCoordinatesSet::const_iterator it = *this;
-	if(it == tileData.tileCoordinates.end()) return;
-
-	for(size_t i=0; i<tileData.sources.size(); i++)
-		tileData.sources[i]->MergeSingleTileDataAtZoom(*it, zoom, data);
-
-	sort(data.begin(), data.end());
-	data.erase(unique(data.begin(), data.end()), data.end());
-}
-
-// *********************************
-
-TileData::TileData(std::vector<class TileDataSource *> const &sources, uint zoom):
-	sources(sources),
-	zoom(zoom) {
-
-	// Create list of tiles
-	tileCoordinates.clear();
-	for(size_t i=0; i<sources.size(); i++)
-		sources[i]->MergeTileCoordsAtZoom(zoom, tileCoordinates);
-}
-
-class TilesAtZoomIterator TileData::GetTilesAtZoomBegin() {
-	return TilesAtZoomIterator(tileCoordinates.begin(), *this, zoom);
-}
-
-class TilesAtZoomIterator TileData::GetTilesAtZoomEnd() {
-	return TilesAtZoomIterator(tileCoordinates.end(), *this, zoom);
-}
-
-size_t TileData::GetTilesAtZoomSize() const {
-	return tileCoordinates.size();
-}
-
-

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -315,9 +315,9 @@ int main(int argc, char* argv[]) {
 	std::unique_ptr<OSMStore> osmStore;
 	if(osmStoreCompact) {
 		std:: cout << "\nImportant: Tilemaker running in compact mode.\nUse 'osmium renumber' first if working with OpenStreetMap-sourced data,\ninitialize the init store to the highest NodeID that is stored in the input file.\n" << std::endl;
-   		osmStore.reset(new OSMStoreImpl<NodeStoreCompact>(storeNodesSize * 1000000, storeWaysSize * 1000000));
+   		osmStore.reset(new OSMStoreImpl<NodeStoreCompact>());
 	} else {
-   		osmStore.reset(new OSMStoreImpl<NodeStore>(storeNodesSize * 1000000, storeWaysSize * 1000000));
+   		osmStore.reset(new OSMStoreImpl<NodeStore>());
 	}
 
 	std::string indexfilename = inputFiles[0] + ".idx";
@@ -328,6 +328,8 @@ int main(int argc, char* argv[]) {
 		std::cout << "Using osm store file: " << osmStoreFile << std::endl;
 		osmStore->open(osmStoreFile, true);
 	}
+
+   	osmStore->reserve(storeNodesSize * 1000000, storeWaysSize * 1000000);
 
 	AttributeStore attributeStore;
 
@@ -380,9 +382,10 @@ int main(int argc, char* argv[]) {
 		if(!index && boost::filesystem::exists(indexfilename)) {
 			std::unique_ptr<OSMStore> indexStore;
 			if(osmStoreCompact)
-	   			indexStore.reset(new OSMStoreImpl<NodeStoreCompact>(storeNodesSize * 1000000, storeWaysSize * 1000000));
+	   			indexStore.reset(new OSMStoreImpl<NodeStoreCompact>());
 			else
-   				indexStore.reset(new OSMStoreImpl<NodeStore>(storeNodesSize * 1000000, storeWaysSize * 1000000));
+   				indexStore.reset(new OSMStoreImpl<NodeStore>());
+	   		indexStore->reserve(storeNodesSize * 1000000, storeWaysSize * 1000000);
 	
 			std::cout << "Using index to generate tiles: " << indexfilename << std::endl;
 			indexStore->open(indexfilename, false);


### PR DESCRIPTION
This PR cleans up the tile coordinate generation and moves the obtaining of the OutputObject lists for a tile in a worker. This reduces the memory requirement, because this list of OutputObjects for a tile is now generated once the tile is about the be generated instead of beforehand. 

Finally, a patch for closing the mmap file before resizing, this is required on windows to resize the mmap file. 