### PR TITLE
Per-layer option to merge polygons

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -66,6 +66,7 @@ You can add optional parameters to layers:
 * `simplify_level` - how much to simplify ways (in degrees of longitude) on the zoom level `simplify_below-1`
 * `simplify_length` - how much to simplify ways (in kilometers) on the zoom level `simplify_below-1`, preceding `simplify_level`
 * `simplify_ratio` - (optional: the default value is 1.0) the actual simplify level will be `simplify_level * pow(simplify_ratio, (simplify_below-1) - <current zoom>)`
+* `combine_polygons_below` - merge adjacent polygons with the same attributes below this zoom level
 
 Use these options to combine different layer specs within one outputted layer. For example:
 

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -23,6 +23,7 @@ struct LayerDef {
 	double simplifyRatio;
 	uint filterBelow;
 	double filterArea;
+	uint combinePolygonsBelow;
 	std::string source;
 	std::vector<std::string> sourceColumns;
 	bool allSourceColumns;
@@ -42,7 +43,7 @@ public:
 	// Define a layer (as read from the .json file)
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,
 			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
-			uint filterBelow, double filterArea,
+			uint filterBelow, double filterArea, uint combinePolygonsBelow,
 			const std::string &source,
 			const std::vector<std::string> &sourceColumns,
 			bool allSourceColumns,

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -18,7 +18,7 @@ SharedData::~SharedData() { }
 // Define a layer (as read from the .json file)
 uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
-		uint filterBelow, double filterArea,
+		uint filterBelow, double filterArea, uint combinePolygonsBelow,
 		const std::string &source,
 		const std::vector<std::string> &sourceColumns,
 		bool allSourceColumns,
@@ -27,7 +27,7 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		const std::string &writeTo)  {
 
 	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
-		filterBelow, filterArea,
+		filterBelow, filterArea, combinePolygonsBelow,
 		source, sourceColumns, allSourceColumns, indexed, indexName,
 		std::map<std::string,uint>() };
 	layers.push_back(layer);
@@ -174,6 +174,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		double simplifyRatio  = it->value.HasMember("simplify_ratio" ) ? it->value["simplify_ratio" ].GetDouble() : 1.0;
 		int    filterBelow    = it->value.HasMember("filter_below"   ) ? it->value["filter_below"   ].GetInt()    : 0;
 		double filterArea     = it->value.HasMember("filter_area"    ) ? it->value["filter_area"    ].GetDouble() : 0.5;
+		int    combinePolyBelow=it->value.HasMember("combine_polygons_below") ? it->value["combine_polygons_below"].GetInt() : 0;
 		string source = it->value.HasMember("source") ? it->value["source"].GetString() : "";
 		vector<string> sourceColumns;
 		bool allSourceColumns = false;
@@ -193,7 +194,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 
 		layers.addLayer(layerName, minZoom, maxZoom,
 				simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
-				filterBelow, filterArea,
+				filterBelow, filterArea, combinePolyBelow,
 				source, sourceColumns, allSourceColumns, indexed, indexName,
 				writeTo);
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -60,40 +60,34 @@ void ReorderMultiLinestring(MultiLinestring &input, MultiLinestring &output) {
 	}
 }
 
+template <typename T>
 void CheckNextObjectAndMerge(OSMStore &osmStore, OutputObjectsConstIt &jt, OutputObjectsConstIt ooSameLayerEnd, 
-	const TileBbox &bbox, MultiLinestring &g) {
+	const TileBbox &bbox, T &g) {
 
-	// If a object is a linestring that is followed by
-	// other linestrings with the same attributes,
+	// If a object is a linestring/polygon that is followed by
+	// other linestrings/polygons with the same attributes,
 	// the following objects are merged into the first object, by taking union of geometries.
 	OutputObjectRef oo = *jt;
 	OutputObjectRef ooNext;
 	if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
 
-	if (oo->geomType == OutputGeometryType::LINESTRING) {
-		while (jt+1 != ooSameLayerEnd &&
-				ooNext->geomType == OutputGeometryType::LINESTRING &&
-				ooNext->attributes == oo->attributes) {
-			jt++;
-			oo = *jt;
-			if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
-			else ooNext.reset();
+	OutputGeometryType gt = oo->geomType;
+	while (jt+1 != ooSameLayerEnd &&
+			ooNext->geomType == gt &&
+			ooNext->attributes == oo->attributes) {
+		jt++;
+		oo = *jt;
+		if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
+		else ooNext.reset();
 
-			try {
-				MultiLinestring to_merge = boost::get<MultiLinestring>(buildWayGeometry(osmStore, *oo, bbox));
-				MultiLinestring output;
-				geom::union_(g, to_merge, output);
-				g = move(output);
-			} catch (std::out_of_range &err) {
-				if (verbose) cerr << "Error while processing LINESTRING " << oo->geomType << "," << oo->objectID <<"," << err.what() << endl;
-			} catch (boost::bad_get &err) {
-				cerr << "Error while processing LINESTRING " << oo->objectID << " has unexpected type" << endl;
-				continue;
-			}
+		try {
+			T to_merge = boost::get<T>(buildWayGeometry(osmStore, *oo, bbox));
+			T output;
+			geom::union_(g, to_merge, output);
+			g = move(output);
+		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << oo->objectID <<"," << err.what() << endl;
+		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << oo->objectID << endl;
 		}
-		MultiLinestring reordered;
-		ReorderMultiLinestring(g, reordered);
-		g = move(reordered);
 	}
 }
 
@@ -129,9 +123,17 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			}
 
 			//This may increment the jt iterator
-			if(oo->geomType == OutputGeometryType::LINESTRING && zoom < sharedData.config.combineBelow) {
-				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiLinestring>(g));
-				oo = *jt;
+			if (zoom < sharedData.config.combineBelow) {
+				if (oo->geomType == OutputGeometryType::LINESTRING) {
+					CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiLinestring>(g));
+					MultiLinestring reordered;
+					ReorderMultiLinestring(boost::get<MultiLinestring>(g), reordered);
+					g = move(reordered);
+					oo = *jt;
+				} else if (oo->geomType == OutputGeometryType::POLYGON) {
+					CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiPolygon>(g));
+					oo = *jt;
+				}
 			}
 
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -119,6 +119,10 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 				continue;
 			}
 
+			if (oo->geomType == OutputGeometryType::POLYGON && filterArea > 0.0) {
+				if (geom::area(g)<filterArea) continue;
+			}
+
 			//This may increment the jt iterator
 			if (oo->geomType == OutputGeometryType::LINESTRING && zoom < sharedData.config.combineBelow) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiLinestring>(g));
@@ -129,9 +133,6 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			} else if (oo->geomType == OutputGeometryType::POLYGON && combinePolygons) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiPolygon>(g));
 				oo = *jt;
-			}
-			if (oo->geomType == OutputGeometryType::POLYGON && filterArea > 0.0) {
-				if (geom::area(g)<filterArea) continue;
 			}
 
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();


### PR DESCRIPTION
This uses Boost.Geometry's `union_` to merge polygons _if_ specified in the layer definition with `combine_polygons_below`. It can be slow so is not enabled by default.