### PR TITLE
Merge tile contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Build dependencies
       run: |
-        vcpkg install --triplet=x64-windows-static-md lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess 
+        vcpkg install --triplet=x64-windows-static-md lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams
 
     - name: Build tilemaker
       run: |
@@ -77,7 +77,7 @@ jobs:
 
     - name: Build dependencies
       run: |
-        vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess 
+        vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams
 
     - name: Build tilemaker
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
 ENDIF ()
 
-find_package(Boost 1.66 REQUIRED COMPONENTS system filesystem program_options)
+find_package(Boost 1.66 REQUIRED COMPONENTS system filesystem program_options iostreams)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 find_package(Protobuf REQUIRED)
@@ -81,7 +81,7 @@ file(GLOB tilemaker_src_files
   )
 add_executable(tilemaker vector_tile.pb.cc osmformat.pb.cc ${tilemaker_src_files})
 target_link_libraries(tilemaker ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUAJIT_LIBRARY} ${LUA_LIBRARIES} ${ZLIB_LIBRARY} ${THREAD_LIB} ${CMAKE_DL_LIBS}
-	Boost::system Boost::filesystem Boost::program_options)
+	Boost::system Boost::filesystem Boost::program_options Boost::iostreams)
 
 if(MSVC)
     target_link_libraries(tilemaker unofficial::sqlite3::sqlite3)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /
 # install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev && \
+      build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-iostreams-dev && \
     make && \
     make install && \
     # clean up, remove build-time only dependencies

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ endif
 # Main includes
 
 CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++11 -pthread -fPIE $(CONFIG)
-LIB := -L/usr/local/lib -lz $(LUA_LIBS) -lboost_program_options -lsqlite3 -lboost_filesystem -lboost_system -lprotobuf -lshp
+LIB := -L/usr/local/lib -lz $(LUA_LIBS) -lboost_program_options -lsqlite3 -lboost_filesystem -lboost_system -lboost_iostreams -lprotobuf -lshp
 INC := -I/usr/local/include -isystem ./include -I./src $(LUA_CFLAGS)
 
 # Targets

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -27,7 +27,7 @@ inline std::vector<std::string> split_string(std::string &inputStr, char sep) {
 	return res;
 }
 
-std::string decompress_string(const std::string& str);
+std::string decompress_string(const std::string& str, bool asGzip = false);
 
 std::string compress_string(const std::string& str,
                             int compressionlevel = Z_DEFAULT_COMPRESSION,

--- a/include/mbtiles.h
+++ b/include/mbtiles.h
@@ -28,7 +28,7 @@ public:
 	void readBoundingBox(double &minLon, double &maxLon, double &minLat, double &maxLat);
 	void readTileList(std::vector<std::tuple<int,int,int>> &tileList);
 	std::vector<char> readTile(int zoom, int col, int row);
-
+	bool readTileAndUncompress(std::string &data, int zoom, int col, int row);
 };
 
 #endif //_MBTILES_H

--- a/include/mbtiles.h
+++ b/include/mbtiles.h
@@ -28,7 +28,7 @@ public:
 	void readBoundingBox(double &minLon, double &maxLon, double &minLat, double &maxLat);
 	void readTileList(std::vector<std::tuple<int,int,int>> &tileList);
 	std::vector<char> readTile(int zoom, int col, int row);
-	bool readTileAndUncompress(std::string &data, int zoom, int col, int row);
+	bool readTileAndUncompress(std::string &data, int zoom, int col, int row, bool isCompressed, bool asGzip);
 };
 
 #endif //_MBTILES_H

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -81,6 +81,7 @@ class SharedData {
 public:
 	const class LayerDefinition &layers;
 	bool sqlite;
+	bool mergeSqlite;
 	MBTiles mbtiles;
 	std::string outputFile;
 

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -73,6 +73,7 @@ public:
 	virtual ~Config();
 
 	void readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, Box &clippingBox);
+	void enlargeBbox(double cMinLon, double cMaxLon, double cMinLat, double cMaxLat);
 };
 
 ///\brief Data used by worker threads ::outputProc to write output
@@ -85,9 +86,9 @@ public:
 	MBTiles mbtiles;
 	std::string outputFile;
 
-	const class Config &config;
+	Config &config;
 
-	SharedData(const class Config &configIn, const class LayerDefinition &layers);
+	SharedData(Config &configIn, const class LayerDefinition &layers);
 	virtual ~SharedData();
 };
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -64,12 +64,17 @@ std::string compress_string(const std::string& str,
 }
 
 // Decompress an STL string using zlib and return the original data.
-std::string decompress_string(const std::string& str) {
+std::string decompress_string(const std::string& str, bool asGzip) {
     z_stream zs;                        // z_stream is zlib's control structure
     memset(&zs, 0, sizeof(zs));
 
-    if (inflateInit(&zs) != Z_OK)
-        throw(std::runtime_error("inflateInit failed while decompressing."));
+	if (asGzip) {
+		if (inflateInit2(&zs, 16+MAX_WBITS) != Z_OK)
+			throw(std::runtime_error("inflateInit2 failed while decompressing."));
+	} else {
+		if (inflateInit(&zs) != Z_OK)
+			throw(std::runtime_error("inflateInit failed while decompressing."));
+	}
 
     zs.next_in = (Bytef*)str.data();
     zs.avail_in = str.size();

--- a/src/mbtiles.cpp
+++ b/src/mbtiles.cpp
@@ -69,3 +69,22 @@ vector<char> MBTiles::readTile(int zoom, int col, int row) {
 	db << "SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?" << zoom << col << row >> pbfBlob;
 	return pbfBlob;
 }
+
+bool MBTiles::readTileAndUncompress(string &data, int zoom, int x, int y) {
+	int tmsY = pow(2,zoom) - 1 - y;
+	int exists=0;
+	db << "SELECT COUNT(*) FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?" << zoom << x << tmsY >> exists;
+	if (exists==0) return false;
+
+	m.lock();
+	std::vector<char> compressed;
+	db << "SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?" << zoom << x << tmsY >> compressed;
+	m.unlock();
+	try {
+		std::string str(compressed.begin(), compressed.end());
+		data = decompress_string(str, true);
+		return true;
+	} catch(std::runtime_error &e) {
+		return false;
+	}
+}

--- a/src/pbf_blocks.cpp
+++ b/src/pbf_blocks.cpp
@@ -32,7 +32,7 @@ void readBlock(google::protobuf::Message *messagePtr, istream &input) {
 	readMessage(&blob, input, bh.datasize());
 
 	// Unzip the gzipped content
-	string contents = decompress_string(blob.zlib_data());
+	string contents = decompress_string(blob.zlib_data(), false);
 	messagePtr->ParseFromString(contents);
 }
 

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 using namespace rapidjson;
 
-SharedData::SharedData(const class Config &configIn, const class LayerDefinition &layers)
+SharedData::SharedData(Config &configIn, const class LayerDefinition &layers)
 	: layers(layers), config(configIn) {
 	sqlite=false;
 	mergeSqlite=false;
@@ -102,6 +102,15 @@ Config::Config() {
 }
 
 Config::~Config() { }
+
+// ----	Enlarge existing bounding box
+
+void Config::enlargeBbox(double cMinLon, double cMaxLon, double cMinLat, double cMaxLat) {
+	minLon = std::min(minLon, cMinLon);
+	maxLon = std::max(maxLon, cMaxLon);
+	minLat = std::min(minLat, cMinLat);
+	maxLat = std::max(maxLat, cMaxLat);
+}
 
 // ----	Read all config details from JSON file
 

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -9,6 +9,7 @@ using namespace rapidjson;
 SharedData::SharedData(const class Config &configIn, const class LayerDefinition &layers)
 	: layers(layers), config(configIn) {
 	sqlite=false;
+	mergeSqlite=false;
 }
 
 SharedData::~SharedData() { }

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -226,7 +226,7 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 	// Read existing tile if merging
 	if (sharedData.mergeSqlite) {
 		std::string rawTile;
-		if (sharedData.mbtiles.readTileAndUncompress(rawTile, zoom, bbox.index.x, bbox.index.y)) {
+		if (sharedData.mbtiles.readTileAndUncompress(rawTile, zoom, bbox.index.x, bbox.index.y, sharedData.config.compress, sharedData.config.gzip)) {
 			tile.ParseFromString(rawTile);
 		}
 	}

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -421,18 +421,24 @@ int main(int argc, char* argv[]) {
 	// ----	Initialise mbtiles if required
 	
 	if (sharedData.sqlite) {
-		ostringstream bounds;
-		bounds << fixed << sharedData.config.minLon << "," << sharedData.config.minLat << "," << sharedData.config.maxLon << "," << sharedData.config.maxLat;
 		sharedData.mbtiles.openForWriting(&sharedData.outputFile);
 		sharedData.mbtiles.writeMetadata("name",sharedData.config.projectName);
 		sharedData.mbtiles.writeMetadata("type","baselayer");
 		sharedData.mbtiles.writeMetadata("version",sharedData.config.projectVersion);
 		sharedData.mbtiles.writeMetadata("description",sharedData.config.projectDesc);
 		sharedData.mbtiles.writeMetadata("format","pbf");
-		sharedData.mbtiles.writeMetadata("bounds",bounds.str());
 		sharedData.mbtiles.writeMetadata("minzoom",to_string(sharedData.config.startZoom));
 		sharedData.mbtiles.writeMetadata("maxzoom",to_string(sharedData.config.endZoom));
 		if (!sharedData.config.defaultView.empty()) { sharedData.mbtiles.writeMetadata("center",sharedData.config.defaultView); }
+
+		ostringstream bounds;
+		if (mergeSqlite) {
+			double cMinLon, cMaxLon, cMinLat, cMaxLat;
+			sharedData.mbtiles.readBoundingBox(cMinLon, cMaxLon, cMinLat, cMaxLat);
+			sharedData.config.enlargeBbox(cMinLon, cMaxLon, cMinLat, cMaxLat);
+		}
+		bounds << fixed << sharedData.config.minLon << "," << sharedData.config.minLat << "," << sharedData.config.maxLon << "," << sharedData.config.maxLat;
+		sharedData.mbtiles.writeMetadata("bounds",bounds.str());
 	}
 
 	// ----	Write out data

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -416,6 +416,7 @@ int main(int argc, char* argv[]) {
 	class SharedData sharedData(config, layers);
 	sharedData.outputFile = outputFile;
 	sharedData.sqlite = sqlite;
+	sharedData.mergeSqlite = mergeSqlite;
 
 	// ----	Initialise mbtiles if required
 	


### PR DESCRIPTION
This addresses the other half of #192 by merging data within tiles. If (for example) you create an .mbtiles of Belgium:

    tilemaker --input belgium.osm.pbf --output map.mbtiles

you can then run this to add the Netherlands:

    tilemaker --input netherlands.osm.pbf --output map.mbtiles --merge

and all shared tiles will be merged, rather than overwritten.

**Blocking issue:**

This is not thread-safe and will crash unless you pass `--threads 1`. The issue is `decompress_string` in helpers.cpp. As it stands `readTileAndUncompress`(mbtiles.cpp) is pretty ugly - it reads from the .mbtiles as a `vector<char>` (if we try a string, then a 0 is taken as end-of-string); then copies to a `std::string`; and then decompresses that, so that we can do `tile.ParseFromString`. 

It would probably be better to have a thread-safe version of `decompress_string` that can work directly on a `vector<char>`, or something. My brain is a bit frazzled and I haven't worked out how to do this.

**Non-blocking issues:**

- `readTileAndUncompress` runs two SQLite queries; first to check whether a tile exists, then to read it. In theory we could just do this with the second query, but `sqlite_modern_cpp.h` throws a runtime_error and for some reason I haven't been able to catch it.
- Currently we assume the .mbtiles contains compressed tiles. It would probably be better to take this from `sharedData.config.compress`.