### PR TITLE
Refactor shapefile spatial queries

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -197,7 +197,6 @@ Or you can find out what country(/ies) the node is within using `FindIntersectin
 
 To enable these functions, set `index` to true in your shapefile layer definition. `index_column` is not needed for `Intersects` but required for `FindIntersecting`.
 
-Note these significant provisos:
+`CoveredBy` and `FindCovering` work similarly but check if the object is covered by a shapefile layer object.
 
-* Way queries are performed on the start and end points of ways, not the full way geometry. So if your way starts and ends outside a polygon, `Intersects` will return false, even if the midpoints are within the polygon. This may be changed in a future version.
-* Spatial queries do not work where the OSM object is a multipolygon, and will return false/empty. This may be changed in a future version.
+`AreaIntersecting` returns the area of the current way's intersection with the shapefile layer. You can use this to find whether a water body is already represented in a shapefile ocean layer.

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -92,11 +92,11 @@ public:
 	double AreaIntersecting(const std::string &layerName);
 	bool Intersects(const std::string &layerName);
 	template <typename GeometryT> double intersectsArea(const std::string &layerName, GeometryT &geom) const;
-	template <typename GeometryT> std::vector<uint> intersectsQuery(const std::string &layerName, GeometryT &geom) const;
+	template <typename GeometryT> std::vector<uint> intersectsQuery(const std::string &layerName, bool once, GeometryT &geom) const;
 
 	std::vector<std::string> FindCovering(const std::string &layerName);
 	bool CoveredBy(const std::string &layerName);
-	template <typename GeometryT> std::vector<uint> coveredQuery(const std::string &layerName, GeometryT &geom) const;
+	template <typename GeometryT> std::vector<uint> coveredQuery(const std::string &layerName, bool once, GeometryT &geom) const;
 		
 	// Returns whether it is closed polygon
 	bool IsClosed() const;

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -89,7 +89,9 @@ public:
 
 	// Find intersecting shapefile layer
 	std::vector<std::string> FindIntersecting(const std::string &layerName);
+	double AreaIntersecting(const std::string &layerName);
 	bool Intersects(const std::string &layerName);
+	template <typename GeometryT> double intersectsArea(const std::string &layerName, GeometryT &geom) const;
 	template <typename GeometryT> std::vector<uint> intersectsQuery(const std::string &layerName, GeometryT &geom) const;
 
 	std::vector<std::string> FindCovering(const std::string &layerName);
@@ -101,6 +103,7 @@ public:
 
 	// Returns area
 	double Area();
+	double multiPolygonArea(const MultiPolygon &mp) const;
 
 	// Returns length
 	double Length();

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -90,7 +90,12 @@ public:
 	// Find intersecting shapefile layer
 	std::vector<std::string> FindIntersecting(const std::string &layerName);
 	bool Intersects(const std::string &layerName);
+	template <typename GeometryT> std::vector<uint> intersectsQuery(const std::string &layerName, GeometryT &geom) const;
 
+	std::vector<std::string> FindCovering(const std::string &layerName);
+	bool CoveredBy(const std::string &layerName);
+	template <typename GeometryT> std::vector<uint> coveredQuery(const std::string &layerName, GeometryT &geom) const;
+		
 	// Returns whether it is closed polygon
 	bool IsClosed() const;
 
@@ -160,6 +165,10 @@ private:
 	// Internal: set start/end co-ordinates
 	inline void setLocation(int32_t a, int32_t b, int32_t c, int32_t d) {
 		lon1=a; latp1=b; lon2=c; latp2=d;
+	}
+	
+	const inline Point getPoint() {
+		return Point(lon1/10000000.0,latp1/10000000.0);
 	}
 	
 	OSMStore const *indexStore;				// global OSM for reading input

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -162,13 +162,8 @@ private:
 		multiPolygonInited = false;
 	}
 
-	// Internal: set start/end co-ordinates
-	inline void setLocation(int32_t a, int32_t b, int32_t c, int32_t d) {
-		lon1=a; latp1=b; lon2=c; latp2=d;
-	}
-	
 	const inline Point getPoint() {
-		return Point(lon1/10000000.0,latp1/10000000.0);
+		return Point(lon/10000000.0,latp/10000000.0);
 	}
 	
 	OSMStore const *indexStore;				// global OSM for reading input
@@ -185,7 +180,7 @@ private:
 	WayID newWayID = MAX_WAY_ID;			///< Decrementing new ID for relations
 	bool isWay, isRelation, isClosed;		///< Way, node, relation?
 
-	int32_t lon1,latp1,lon2,latp2;			///< Start/end co-ordinates of OSM object
+	int32_t lon,latp;						///< Node coordinates
 	OSMStore::handle_t nodeVecHandle;
 	OSMStore::handle_t relationHandle;
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -125,9 +125,6 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 //\brief Build a node geometry
 LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox);
 
-///\brief Check if the object intersects with the given point
-bool intersects(OSMStore &osmStore, OutputObject const &oo, Point const &p);
-
 // Comparison functions
 
 bool operator==(const OutputObjectRef &x, const OutputObjectRef &y);

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -21,7 +21,7 @@ public:
 	void AddObject(TileCoordinates const &index, OutputObjectRef const &oo) {
 		tileIndex[index].push_back(oo);
 	}
-	std::vector<uint> QueryMatchingGeometries(const std::string &layerName, Box &box, 
+	std::vector<uint> QueryMatchingGeometries(const std::string &layerName, bool once, Box &box, 
 		std::function<std::vector<IndexValue>(const RTree &rtree)> indexQuery, 
 		std::function<bool(OutputObject &oo)> checkQuery) const;
 	std::vector<std::string> namesOfGeometries(const std::vector<uint> &ids) const;

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -9,9 +9,6 @@ class ShpMemTiles : public TileDataSource
 public:
 	ShpMemTiles(OSMStore &osmStore, uint baseZoom);
 
-	// Find intersecting shapefile layer
-	std::vector<std::string> FindIntersecting(const std::string &layerName, Box &box) const;
-	bool Intersects(const std::string &layerName, Box &box) const;
 	void CreateNamedLayerIndex(const std::string &layerName);
 
 	// Used in shape file loading
@@ -24,11 +21,12 @@ public:
 	void AddObject(TileCoordinates const &index, OutputObjectRef const &oo) {
 		tileIndex[index].push_back(oo);
 	}
-private:
-	std::vector<uint> findIntersectingGeometries(const std::string &layerName, Box &box) const;
-	std::vector<uint> verifyIntersectResults(std::vector<IndexValue> &results, Point &p1, Point &p2) const;
-	std::vector<std::string> namesOfGeometries(std::vector<uint> &ids) const;
+	std::vector<uint> QueryMatchingGeometries(const std::string &layerName, Box &box, 
+		std::function<std::vector<IndexValue>(const RTree &rtree)> indexQuery, 
+		std::function<bool(OutputObject &oo)> checkQuery) const;
+	std::vector<std::string> namesOfGeometries(const std::vector<uint> &ids) const;
 
+private:
 	/// Add an OutputObject to all tiles between min/max lat/lon
 	void addToTileIndexByBbox(OutputObjectRef &oo, 
 		double minLon, double minLatp, double maxLon, double maxLatp);

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -22,7 +22,7 @@
 		"building":          { "minzoom": 13, "maxzoom": 14 },
 
 		"water":             { "minzoom": 6,  "maxzoom": 14, "simplify_below": 12, "simplify_length": 1, "simplify_ratio": 2},
-		"ocean":             { "minzoom": 0,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "simplify_below": 13, "simplify_level": 0.0005, "write_to": "water" },
+		"ocean":             { "minzoom": 0,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "simplify_below": 13, "simplify_level": 0.0005, "write_to": "water", "index": true },
 		"water_name":        { "minzoom": 14, "maxzoom": 14 },
 		"water_name_detail": { "minzoom": 14, "maxzoom": 14, "write_to": "water_name" },
 

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -396,6 +396,7 @@ function way_function(way)
 		if way:Find("covered")=="yes" or not isClosed then return end
 		local class="lake"; if natural=="bay" then class="ocean" elseif waterway~="" then class="river" end
 		if class=="lake" and way:Find("wikidata")=="Q192770" then return end
+		if class=="ocean" and isClosed and (way:AreaIntersecting("ocean")/way:Area() > 0.98) then return end
 		way:Layer("water",true)
 		SetMinZoomByArea(way)
 		way:Attribute("class",class)

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -114,31 +114,31 @@ string OsmLuaProcessing::Find(const string& key) const {
 // ----	Spatial queries called from Lua
 
 vector<string> OsmLuaProcessing::FindIntersecting(const string &layerName) {
-	if      (!isWay   ) { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, getPoint())); }
-	else if (!isClosed) { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, linestringCached())); }
-	else if (isRelation){ return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, multiPolygonCached())); }
-	else                { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, polygonCached())); }
+	if      (!isWay   ) { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, getPoint())); }
+	else if (!isClosed) { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, linestringCached())); }
+	else if (isRelation){ return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, multiPolygonCached())); }
+	else                { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, polygonCached())); }
 }
 
 bool OsmLuaProcessing::Intersects(const string &layerName) {
-	if      (!isWay   ) { return !intersectsQuery(layerName, getPoint()).empty(); }
-	else if (!isClosed) { return !intersectsQuery(layerName, linestringCached()).empty(); }
-	else if (isRelation){ return !intersectsQuery(layerName, multiPolygonCached()).empty(); }
-	else                { return !intersectsQuery(layerName, polygonCached()).empty(); }
+	if      (!isWay   ) { return !intersectsQuery(layerName, true, getPoint()).empty(); }
+	else if (!isClosed) { return !intersectsQuery(layerName, true, linestringCached()).empty(); }
+	else if (isRelation){ return !intersectsQuery(layerName, true, multiPolygonCached()).empty(); }
+	else                { return !intersectsQuery(layerName, true, polygonCached()).empty(); }
 }
 
 vector<string> OsmLuaProcessing::FindCovering(const string &layerName) {
-	if      (!isWay   ) { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, getPoint())); }
-	else if (!isClosed) { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, linestringCached())); }
-	else if (isRelation){ return shpMemTiles.namesOfGeometries(coveredQuery(layerName, multiPolygonCached())); }
-	else                { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, polygonCached())); }
+	if      (!isWay   ) { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, getPoint())); }
+	else if (!isClosed) { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, linestringCached())); }
+	else if (isRelation){ return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, multiPolygonCached())); }
+	else                { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, polygonCached())); }
 }
 
 bool OsmLuaProcessing::CoveredBy(const string &layerName) {
-	if      (!isWay   ) { return !coveredQuery(layerName, getPoint()).empty(); }
-	else if (!isClosed) { return !coveredQuery(layerName, linestringCached()).empty(); }
-	else if (isRelation){ return !coveredQuery(layerName, multiPolygonCached()).empty(); }
-	else                { return !coveredQuery(layerName, polygonCached()).empty(); }
+	if      (!isWay   ) { return !coveredQuery(layerName, true, getPoint()).empty(); }
+	else if (!isClosed) { return !coveredQuery(layerName, true, linestringCached()).empty(); }
+	else if (isRelation){ return !coveredQuery(layerName, true, multiPolygonCached()).empty(); }
+	else                { return !coveredQuery(layerName, true, polygonCached()).empty(); }
 }
 
 double OsmLuaProcessing::AreaIntersecting(const string &layerName) {
@@ -149,9 +149,9 @@ double OsmLuaProcessing::AreaIntersecting(const string &layerName) {
 
 
 template <typename GeometryT>
-std::vector<uint> OsmLuaProcessing::intersectsQuery(const string &layerName, GeometryT &geom) const {
+std::vector<uint> OsmLuaProcessing::intersectsQuery(const string &layerName, bool once, GeometryT &geom) const {
 	Box box; geom::envelope(geom, box);
-	std::vector<uint> ids = shpMemTiles.QueryMatchingGeometries(layerName, box,
+	std::vector<uint> ids = shpMemTiles.QueryMatchingGeometries(layerName, once, box,
 		[&](const RTree &rtree) { // indexQuery
 			vector<IndexValue> results;
 			rtree.query(geom::index::intersects(box), back_inserter(results));
@@ -168,7 +168,7 @@ template <typename GeometryT>
 double OsmLuaProcessing::intersectsArea(const string &layerName, GeometryT &geom) const {
 	Box box; geom::envelope(geom, box);
 	double area = 0.0;
-	std::vector<uint> ids = shpMemTiles.QueryMatchingGeometries(layerName, box,
+	std::vector<uint> ids = shpMemTiles.QueryMatchingGeometries(layerName, false, box,
 		[&](const RTree &rtree) { // indexQuery
 			vector<IndexValue> results;
 			rtree.query(geom::index::intersects(box), back_inserter(results));
@@ -185,9 +185,9 @@ double OsmLuaProcessing::intersectsArea(const string &layerName, GeometryT &geom
 }
 
 template <typename GeometryT>
-std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, GeometryT &geom) const {
+std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool once, GeometryT &geom) const {
 	Box box; geom::envelope(geom, box);
-	std::vector<uint> ids = shpMemTiles.QueryMatchingGeometries(layerName, box,
+	std::vector<uint> ids = shpMemTiles.QueryMatchingGeometries(layerName, once, box,
 		[&](const RTree &rtree) { // indexQuery
 			vector<IndexValue> results;
 			rtree.query(geom::index::intersects(box), back_inserter(results));

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -133,24 +133,6 @@ LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 	throw std::runtime_error("Geometry type is not point");			
 }
 
-bool intersects(OSMStore &osmStore, OutputObject const &oo, Point const &p)
-{
-	switch(oo.geomType) {
-		case OutputGeometryType::POINT:
-			return boost::geometry::intersects(osmStore.retrieve<mmap::point_t>(oo.handle), p);
-
-		case OutputGeometryType::LINESTRING:
-			return boost::geometry::intersects(osmStore.retrieve<mmap::linestring_t>(oo.handle), p);
-
-
-		case OutputGeometryType::POLYGON:
-			return boost::geometry::intersects(osmStore.retrieve<mmap::multi_polygon_t>(oo.handle), p);
-
-		default:
-			throw std::runtime_error("Invalid output geometry");
-	}
-}
-
 // Find a value in the value dictionary
 // (we can't easily use find() because of the different value-type encoding - 
 //	should be possible to improve this though)

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -13,7 +13,7 @@ ShpMemTiles::ShpMemTiles(OSMStore &osmStore, uint baseZoom)
 // - bounding box to match against
 // - indexQuery(rtree, results) lambda, implements: rtree.query(geom::index::covered_by(box), back_inserter(results))
 // - checkQuery(osmstore, id) lambda, implements:   return geom::covered_by(osmStore.retrieve(id), geom)
-vector<uint> ShpMemTiles::QueryMatchingGeometries(const string &layerName, Box &box, 
+vector<uint> ShpMemTiles::QueryMatchingGeometries(const string &layerName, bool once, Box &box, 
 	function<vector<IndexValue>(const RTree &rtree)> indexQuery, 
 	function<bool(OutputObject &oo)> checkQuery) const {
 	
@@ -31,7 +31,7 @@ vector<uint> ShpMemTiles::QueryMatchingGeometries(const string &layerName, Box &
 	vector<uint> ids;
 	for (auto it: results) {
 		uint id = it.second;
-		if (checkQuery(*cachedGeometries.at(id))) { ids.push_back(id); }
+		if (checkQuery(*cachedGeometries.at(id))) { ids.push_back(id); if (once) break; }
 	}
 	return ids;
 }

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -7,42 +7,36 @@ ShpMemTiles::ShpMemTiles(OSMStore &osmStore, uint baseZoom)
 	: TileDataSource(baseZoom), osmStore(osmStore)
 { }
 
-// Find intersecting shapefile layer
-// TODO: multipolygon relations not supported, will always return false
-vector<string> ShpMemTiles::FindIntersecting(const string &layerName, Box &box) const {
-	vector<uint> ids = findIntersectingGeometries(layerName, box);
-	return namesOfGeometries(ids);
-}
-
-bool ShpMemTiles::Intersects(const string &layerName, Box &box) const {
-	return !findIntersectingGeometries(layerName, box).empty();
-}
-
-vector<uint> ShpMemTiles::findIntersectingGeometries(const string &layerName, Box &box) const {
-	vector<IndexValue> results;
-	vector<uint> ids;
-
-	auto f = indices.find(layerName);
+// Look for shapefile objects that fulfil a spatial query (e.g. intersects)
+// Parameters:
+// - shapefile layer name to search
+// - bounding box to match against
+// - indexQuery(rtree, results) lambda, implements: rtree.query(geom::index::covered_by(box), back_inserter(results))
+// - checkQuery(osmstore, id) lambda, implements:   return geom::covered_by(osmStore.retrieve(id), geom)
+vector<uint> ShpMemTiles::QueryMatchingGeometries(const string &layerName, Box &box, 
+	function<vector<IndexValue>(const RTree &rtree)> indexQuery, 
+	function<bool(OutputObject &oo)> checkQuery) const {
+	
+	// Find the layer
+	auto f = indices.find(layerName); // f is an RTree
 	if (f==indices.end()) {
 		cerr << "Couldn't find indexed layer " << layerName << endl;
 		return vector<uint>();	// empty, relations not supported
 	}
-
-	f->second.query(geom::index::intersects(box), back_inserter(results));
-	return verifyIntersectResults(results,box.min_corner(),box.max_corner());
-}
-
-vector<uint> ShpMemTiles::verifyIntersectResults(vector<IndexValue> &results, Point &p1, Point &p2) const {
+	
+	// Run the index query
+	vector<IndexValue> results = indexQuery(f->second);
+	
+	// Run the check query
 	vector<uint> ids;
-	for (auto it : results) {
-		uint id=it.second;
-		if      (intersects(osmStore, *cachedGeometries.at(id), p1)) { ids.push_back(id); }
-		else if (intersects(osmStore, *cachedGeometries.at(id), p2)) { ids.push_back(id); }
+	for (auto it: results) {
+		uint id = it.second;
+		if (checkQuery(*cachedGeometries.at(id))) { ids.push_back(id); }
 	}
 	return ids;
 }
 
-vector<string> ShpMemTiles::namesOfGeometries(vector<uint> &ids) const {
+vector<string> ShpMemTiles::namesOfGeometries(const vector<uint> &ids) const {
 	vector<string> names;
 	for (uint i=0; i<ids.size(); i++) {
 		if (cachedGeometryNames.find(ids[i])!=cachedGeometryNames.end()) {


### PR DESCRIPTION
This reworks the code that enables queries on shapefile data like "is this road within a town?" or "what county is this town in?". Changes are:

- Now uses the full geometry for checking, not just the start/end points
- New `CoveredBy` and `FindCovering` operations
- Easier to add [more algorithms](https://www.boost.org/doc/libs/1_62_0/libs/geometry/doc/html/geometry/reference/algorithms.html)

These queries are now implemented in osm_lua_processing.cpp, typically as a wrapper function (`Intersects`/`FindIntersecting`) and a query function (`intersectsQuery`). The latter supplies two lambdas: one to get candidates from the RTree with a simple bbox check, the second to run the test on all candidates.

There's still a bit of copy & paste within osm_lua_processing.cpp, but going any further looked like it would be getting into crazy template territory and this is already at the limit of my C++ skills. ;)