### PR TITLE
Seperate line sections instead of clipping linestring

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -185,6 +185,7 @@ public:
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
 	Box getTileBox() const;
+	Box getExtendBox() const;
 };
 
 #endif //_COORDINATES_H

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -97,3 +97,9 @@ Box TileBbox::getTileBox() const {
 	return Box(geom::make<Point>(minLon+xmargin, minLatp+ymargin), geom::make<Point>(maxLon-xmargin, maxLatp-ymargin));
 }
 
+Box TileBbox::getExtendBox() const {
+	return Box(
+    	geom::make<Point>( minLon-(maxLon-minLon)*2.0, minLatp-(maxLatp-minLatp)*(8191.0/8192.0)), 
+		geom::make<Point>( maxLon+(maxLon-minLon)*(8191.0/8192.0), maxLatp+(maxLatp-minLatp)*2.0));
+}
+


### PR DESCRIPTION
This PR chops a linestring into the different sections that overlap a tile bbox, instead of performing clipping. 
Have a try, TBH i do not see any noticable difference. 

![image](https://user-images.githubusercontent.com/230050/116773034-44e81500-aa53-11eb-841a-571cc63e8427.png)

before this was (but this was also before rounding)
![image](https://user-images.githubusercontent.com/230050/116773116-c63fa780-aa53-11eb-8991-a5f9229d3ac7.png)