### PR TITLE
Limit combined linestrings to 6000 vertices

### DIFF
--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -35,7 +35,7 @@ void ReorderMultiLinestring(MultiLinestring &input, MultiLinestring &output) {
 			auto foundStart = startPoints.find(xy_pair(lastPoint.x(),lastPoint.y()));
 			if (foundStart != startPoints.end()) {
 				unsigned idx = foundStart->second;
-				if (!added[idx]) {
+				if (!added[idx] && input[idx].size()+ls.size()<6000) {
 					ls.insert(ls.end(), input[idx].begin()+1, input[idx].end());
 					added[idx] = true;
 					continue;
@@ -46,7 +46,7 @@ void ReorderMultiLinestring(MultiLinestring &input, MultiLinestring &output) {
 			auto foundEnd = endPoints.find(xy_pair(firstPoint.x(),firstPoint.y()));
 			if (foundEnd != endPoints.end()) {
 				unsigned idx = foundEnd->second;
-				if (!added[idx]) {
+				if (!added[idx] && input[idx].size()+ls.size()<6000) {
 					ls.insert(ls.begin(), input[idx].begin(), input[idx].end()-1);
 					added[idx] = true;
 					continue;


### PR DESCRIPTION
This addresses #240 - seems to fix it for me. Comparing file sizes:

- current master: 749568 (rendering error)
- disabling ReorderMultiLinestring: 757760 (rendering ok but linestrings are disconnected, hence larger filesize)
- this PR: 749568 (rendering correct, smaller filesize)

My working assumption is that MBGL can't cope with the very long linestrings created at low zoom levels when the coastline is merged together. This PR limits linestrings to 6000 vertices.

There is no formal limit in the MVT specification, but https://docs.mapbox.com/mapbox-tiling-service/reference/ says "complex features will receive additional simplification so that they can be rendered correctly by Mapbox GL. Polygons or MultiPolygons with more than 65535 vertices and LineStrings and polygon rings with more than 6553 points will be simplified to reduce their complexity to these limits", so it's a known issue. I'm not sure whether 6553 is a typo for 65535, but 6000 is plenty anyway!