### PR TITLE
Keep parts of docker build and small optimisation in tile rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ LABEL Description="Tilemaker" Version="1.4.0"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-COPY . /
-WORKDIR /
-
 # install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-iostreams-dev && \
-    make && \
+      build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-iostreams-dev
+
+COPY . /
+WORKDIR /
+
+RUN make && \
     make install && \
     # clean up, remove build-time only dependencies
     rm -rf /var/lib/apt/lists/* && \

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -394,8 +394,12 @@ int main(int argc, char* argv[]) {
 			}
 		}
 
-		std::size_t interval = 100;
+		std::size_t interval = 1;
 		for(std::size_t start_index = 0; start_index < tile_coordinates.size(); start_index += interval) {
+			unsigned int zoom = tile_coordinates[start_index].first;
+			if (zoom > 10) interval = 10;
+			if (zoom > 11) interval = 100;
+			if (zoom > 12) interval = 1000;
 
 			boost::asio::post(pool, [=, &tile_coordinates, &pool, &sharedData, &osmStore, &io_mutex, &tc]() {
 				std::size_t end_index = std::min(tile_coordinates.size(), start_index + interval);


### PR DESCRIPTION
Hello,

Here is a very small contribution in this project:
- First part is in the Dockerfile, when making tests it's faster to keep APT dependencies between builds
- When rendering tiles, lower the tiles per thread on low zoom so that 1 CPU is not doing all the massive tiles