### PR TITLE
Show version number in --help output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ include_directories(${ZLIB_INCLUDE_DIR})
 
 set(CMAKE_CXX_STANDARD 14)
 
+execute_process(
+	COMMAND git describe --tags --abbrev=0
+	OUTPUT_VARIABLE tm_version)
+add_compile_definitions(TM_VERSION=${tm_version})
+
 if(MSVC)
  	find_package(unofficial-sqlite3 CONFIG REQUIRED)
 	add_definitions(-D_USE_MATH_DEFINES -DWIN32_LEAN_AND_MEAN -DNOGDI)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ endif
 
 # Main includes
 
-CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++14 -pthread -fPIE $(CONFIG)
+TM_VERSION := $(shell git describe --tags --abbrev=0)
+CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++14 -pthread -fPIE -DTM_VERSION=$(TM_VERSION) $(CONFIG)
 LIB := -L/usr/local/lib -lz $(LUA_LIBS) -lboost_program_options -lsqlite3 -lboost_filesystem -lboost_system -lboost_iostreams -lprotobuf -lshp
 INC := -I/usr/local/include -isystem ./include -I./src $(LUA_CFLAGS)
 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -52,6 +52,12 @@
 #include <boost/asio/post.hpp>
 #include <boost/interprocess/streams/bufferstream.hpp>
 
+#ifndef TM_VERSION
+#define TM_VERSION (version not set)
+#endif
+#define STR1(x)  #x
+#define STR(x)  STR1(x)
+
 // Namespaces
 using namespace std;
 namespace po = boost::program_options;
@@ -137,7 +143,7 @@ int main(int argc, char* argv[]) {
 	string outputFile;
 	bool _verbose = false, sqlite= false, mergeSqlite = false, mapsplit = false;
 
-	po::options_description desc("tilemaker (c) 2016-2020 Richard Fairhurst and contributors\nConvert OpenStreetMap .pbf files into vector tiles\n\nAvailable options");
+	po::options_description desc("tilemaker " STR(TM_VERSION) "\nConvert OpenStreetMap .pbf files into vector tiles\n\nAvailable options");
 	desc.add_options()
 		("help",                                                                 "show help message")
 		("input",  po::value< vector<string> >(&inputFiles),                     "source .osm.pbf file")


### PR DESCRIPTION
This uses the latest git tag to write a version number in tilemaker's `--help` output. Should work with both plain makefile and CMake builds.