### PR TITLE
Update instruction about Github Workflow

### DIFF
--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -98,7 +98,7 @@ You can integrate tilemaker as a Github Action into your [Github Workflow](https
 Here is an example:
 
 ```yaml
-- uses: systemed/tilemaker@master
+- uses: systemed/tilemaker@v2.0.0
   with:
     # Required, same to --input
     input: /path/to/osm.pbf


### PR DESCRIPTION
Good to go **ONLY IF** there is a new release `v2.0.0`, as I mentioned in [#166](https://github.com/systemed/tilemaker/pull/166#issuecomment-634568754) (I saw `v2.0.0-rc1` is there).