### PR TITLE
Close mmap file before deleting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
         Invoke-WebRequest -Uri http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -OutFile ${{ env.AREA }}.osm.pbf
-        ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose || true
+        ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --store osm_store --verbose || true
 
     - name: 'Upload compiled executable'
       uses: actions/upload-artifact@v2

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -301,8 +301,6 @@ public:
 		reopen();
 	}
 
-	~OSMStore();
-
 	void open(std::string const &osm_store_filename);
 
 	void nodes_insert_back(NodeID i, LatpLon coord) {


### PR DESCRIPTION
On windows platform the osm_store files were not closed before deletion. 
On linux this works fine, on windows this causes an error message that the file could not be removed. 

I also enabled osm_store on windows test run now, in CI