### PR TITLE
Add z_order sorting support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -127,6 +127,7 @@ To do that, you use these methods:
 * `node:Attribute(key,value)` or `node:Attribute(key,value)`: add an attribute to the most recently written layer.
 * `node:AttributeNumeric(key,value)`, `node:AttributeBoolean(key,value)` (and `way:`...): for numeric/boolean columns.
 * `node:Id()` or `way:Id()`: get the OSM ID of the current object.
+* `node:ZOrder(number)` or `way:ZOrder(number)`: Set a numeric value (default 0, 1-byte unsigned integer) used to sort features within a layer. Use this feature to ensure a proper rendering order if the rendering engine itself does not support sorting. Sorting is not supported across layers merged with `write_to`. Features with different z-order are not merged if `combine_below` or `combine_polygons_below` is used.
 * `node:MinZoom(zoom)` or `way:MinZoom(zoom)`: set the minimum zoom level (0-15) at which this object will be written. Note that the JSON layer configuration minimum still applies (so `:MinZoom(5)` will have no effect if your layer only starts at z6).
 * `way:Length()` and `way:Area()`: return the length (metres)/area (square metres) of the current object. Requires recent Boost.
 * `way:Centroid()`: return the lat/lon of the centre of the current object as a two-element Lua table (element 1 is lat, 2 is lon).

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -148,6 +148,7 @@ public:
 	void AttributeBoolean(const std::string &key, const bool val);
 	void AttributeBooleanWithMinZoom(const std::string &key, const bool val, const char minzoom);
 	void MinZoom(const unsigned z);
+	void ZOrder(const int z);
 
 	// Write error if in verbose mode
 	void ProcessingError(const std::string &errStr) {

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -29,11 +29,12 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
  * Possible future improvements to save memory:
  * - use a global dictionary for attribute key/values
 */
-class OutputObject { 
+class OutputObject {
 
 protected:	
 	OutputObject(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes) 
-		: objectID(id), handle(handle), geomType(type), fromShapefile(shp), layer(l), minZoom(0), references(0), attributes(attributes)
+		: objectID(id), handle(handle), geomType(type), fromShapefile(shp), layer(l), z_order(0),
+		  minZoom(0), references(0), attributes(attributes)
 	{ }
 
 
@@ -43,12 +44,20 @@ public:
 
 	OutputGeometryType geomType : 8;					// point, linestring, polygon...
 	uint_least8_t layer 		: 8;					// what layer is it in?
+	int8_t z_order				: 8;					// z_order: used for sorting features within layers
 	bool fromShapefile 			: 1;
 	unsigned minZoom 			: 4;
 	
 	mutable std::atomic<uint32_t> references;
 
 	AttributeStoreRef attributes;
+
+	void setZOrder(const int z) {
+		if (z <= -127 || z >= 127) {
+			throw std::runtime_error("z_order is limited to 1 byte signed integer.");
+		}
+		z_order = z;
+	}
 
 	void setMinZoom(unsigned z) {
 		minZoom = z;

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -12,9 +12,6 @@
 		"waterway_detail":  { "minzoom": 12,  "maxzoom": 14, "write_to": "waterway" },
 
 		"transportation":             { "minzoom": 4,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003 },
-		"transportation_main":        { "minzoom": 9,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "write_to": "transportation" },
-		"transportation_mid":         { "minzoom": 11, "maxzoom": 14, "write_to": "transportation" },
-		"transportation_detail":      { "minzoom": 13, "maxzoom": 14, "write_to": "transportation" },
 		"transportation_name":        { "minzoom": 8,  "maxzoom": 14 },
 		"transportation_name_mid":    { "minzoom": 12, "maxzoom": 14, "write_to": "transportation_name" },
 		"transportation_name_detail": { "minzoom": 14, "maxzoom": 14, "write_to": "transportation_name" },

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -57,6 +57,7 @@ OsmLuaProcessing::OsmLuaProcessing(
 		.addOverloadedFunctions("AttributeNumeric", &OsmLuaProcessing::AttributeNumeric, &OsmLuaProcessing::AttributeNumericWithMinZoom)
 		.addOverloadedFunctions("AttributeBoolean", &OsmLuaProcessing::AttributeBoolean, &OsmLuaProcessing::AttributeBooleanWithMinZoom)
 		.addFunction("MinZoom", &OsmLuaProcessing::MinZoom)
+		.addFunction("ZOrder", &OsmLuaProcessing::ZOrder)
 	);
 	if (luaState["attribute_function"]) {
 		supportsRemappingShapefiles = true;
@@ -454,6 +455,12 @@ void OsmLuaProcessing::AttributeBooleanWithMinZoom(const string &key, const bool
 void OsmLuaProcessing::MinZoom(const unsigned z) {
 	if (outputs.size()==0) { ProcessingError("Can't set minimum zoom if no Layer set"); return; }
 	outputs.back().first->setMinZoom(z);
+}
+
+// Set z_order
+void OsmLuaProcessing::ZOrder(const int z) {
+	if (outputs.size()==0) { ProcessingError("Can't set z_order if no Layer set"); return; }
+	outputs.back().first->setZOrder(z);
 }
 
 // Record attribute name/type for vector_layers table

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -208,6 +208,7 @@ int OutputObject::findValue(vector<vector_tile::Tile_Value> *valueList, vector_t
 bool operator==(const OutputObjectRef &x, const OutputObjectRef &y) {
 	return
 		x->layer == y->layer &&
+		x->z_order == y->z_order &&
 		x->geomType == y->geomType &&
 		x->attributes == y->attributes &&
 		x->objectID == y->objectID;
@@ -220,6 +221,8 @@ bool operator==(const OutputObjectRef &x, const OutputObjectRef &y) {
 bool operator<(const OutputObjectRef &x, const OutputObjectRef &y) {
 	if (x->layer < y->layer) return true;
 	if (x->layer > y->layer) return false;
+	if (x->z_order < y->z_order) return true;
+	if (x->z_order > y->z_order) return false;
 	if (x->geomType < y->geomType) return true;
 	if (x->geomType > y->geomType) return false;
 	if (x->attributes < y->attributes) return true;

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -72,10 +72,9 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, OutputObjectsConstIt &jt, Outpu
 	if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
 
 	OutputGeometryType gt = oo->geomType;
-    int8_t z_order = oo->z_order;
 	while (jt+1 != ooSameLayerEnd &&
 			ooNext->geomType == gt &&
-			ooNext->z_order == z_order &&
+			ooNext->z_order == oo->z_order &&
 			ooNext->attributes == oo->attributes) {
 		jt++;
 		oo = *jt;

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -72,8 +72,10 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, OutputObjectsConstIt &jt, Outpu
 	if(jt+1 != ooSameLayerEnd) ooNext = *(jt+1);
 
 	OutputGeometryType gt = oo->geomType;
+    int8_t z_order = oo->z_order;
 	while (jt+1 != ooSameLayerEnd &&
 			ooNext->geomType == gt &&
+			ooNext->z_order == z_order &&
 			ooNext->attributes == oo->attributes) {
 		jt++;
 		oo = *jt;


### PR DESCRIPTION
This pull request adds z_order support. The Lua script can set a numeric z_order per feature and Tilemaker will sort the features within a layer by z_order (z_order is more important than geometry type).

z_order sorting is needed for map rendering engines which cannot sort features themselves (e.g. Mapnik with OGR plugin). Sorting is limited to features within a layer. This means, if layers are merged with the `write_to` configuration option, sorting does not happen accross the boundaries of the source layers.

This pull request adds z_order support to the OpenMapTiles configuration that comes with Tilemaker. Upstream OpenMapTiles sorts features in transportation layer by z_order (which is calculated by Imposm).