### PR TITLE
Return compact mode

### DIFF
--- a/src/osm_store.cpp
+++ b/src/osm_store.cpp
@@ -257,6 +257,8 @@ void void_mmap_allocator::destroy(void *p)
 }
 
 void NodeStore::sort(unsigned int threadNum) { 
+	std::cout << "\nSorting nodes" << std::endl;
+
 	std::lock_guard<std::mutex> lock(mutex);
 	boost::sort::block_indirect_sort(
 		mLatpLons->begin(), mLatpLons->end(), 
@@ -265,6 +267,8 @@ void NodeStore::sort(unsigned int threadNum) {
 }
 
 void WayStore::sort(unsigned int threadNum) { 
+	std::cout << "\nSorting ways" << std::endl;
+
 	std::lock_guard<std::mutex> lock(mutex);
 	boost::sort::block_indirect_sort(
 		mNodeLists->begin(), mNodeLists->end(), 

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -283,11 +283,9 @@ int PbfReader::ReadPbfFile(unordered_set<string> const &nodeKeys, unsigned int t
 		pool.join();
 
 		if(phase == ReadPhase::Nodes) {
-			std::cout << "\nSorting nodes" << std::endl;
 			osmStore.nodes_sort(threadNum);
 		}
 		if(phase == ReadPhase::Ways) {
-			std::cout << "\nSorting ways" << std::endl;
 			osmStore.ways_sort(threadNum);
 		}
 	}

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -141,7 +141,7 @@ int main(int argc, char* argv[]) {
 	string jsonFile;
 	uint threadNum;
 	string outputFile;
-	bool _verbose = false, sqlite= false, mergeSqlite = false, mapsplit = false;
+	bool _verbose = false, sqlite= false, mergeSqlite = false, mapsplit = false,osmStoreCompact = false;
 
 	po::options_description desc("tilemaker " STR(TM_VERSION) "\nConvert OpenStreetMap .pbf files into vector tiles\n\nAvailable options");
 	desc.add_options()
@@ -152,6 +152,7 @@ int main(int argc, char* argv[]) {
 		("config", po::value< string >(&jsonFile)->default_value("config.json"), "config JSON file")
 		("process",po::value< string >(&luaFile)->default_value("process.lua"),  "tag-processing Lua file")
 		("store",  po::value< string >(&osmStoreFile),  "temporary storage for node/ways/relations data")
+		("compact",po::bool_switch(&osmStoreCompact),  "Reduce overall memory usage (compact mode).\nNOTE: This requires the input to be renumbered (osmium renumber)")
 		("verbose",po::bool_switch(&_verbose),                                   "verbose error output")
 		("threads",po::value< uint >(&threadNum)->default_value(0),              "number of threads (automatically detected if 0)");
 	po::positional_options_description p;
@@ -238,6 +239,7 @@ int main(int argc, char* argv[]) {
 
 	// For each tile, objects to be used in processing
 	OSMStore osmStore;
+	osmStore.use_compact_store(osmStoreCompact);
 	if(!osmStoreFile.empty()) {
 		std::cout << "Using osm store file: " << osmStoreFile << std::endl;
 		osmStore.open(osmStoreFile);


### PR DESCRIPTION
The following PR returns the compact mode for storing the nodes (reduced memory consumption). 

Use osmium renumber to renumber the nodes:
osmium renumber --input planet-latest.osm.pbf --output planet-renum.osm.pbf

Use compact mode switch to use the compact mode:
./tilemaker --input planet-renum.osm.pbf --output planet.mbtiles --store osm_store --compact