### PR TITLE
Pack OutputObject bitfields more efficiently

### DIFF
--- a/include/geom.h
+++ b/include/geom.h
@@ -43,7 +43,7 @@ typedef boost::geometry::index::rtree< IndexValue, boost::geometry::index::quadr
 typedef uint64_t NodeID;
 typedef uint64_t WayID;
 
-#define MAX_WAY_ID std::numeric_limits<WayID>::max()
+#define MAX_WAY_ID pow(2,40)-1
 typedef std::vector<NodeID> NodeVec;
 typedef std::vector<WayID> WayVec;
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -39,7 +39,7 @@ protected:
 
 
 public:
-	NodeID objectID 			: 40;					// id of way (linestring/polygon) or node (point)
+	NodeID objectID 			: 40;					// id of way (linestring/polygon) or node (point) - cf MAX_WAY_ID
 	uint_least8_t layer 		: 8;					// what layer is it in?
 	int8_t z_order				: 8;					// z_order: used for sorting features within layers
 	OutputGeometryType geomType : 2;					// point, linestring, polygon

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -29,6 +29,7 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
  * Possible future improvements to save memory:
  * - use a global dictionary for attribute key/values
 */
+#pragma pack(push, 4)
 class OutputObject {
 
 protected:	
@@ -76,6 +77,7 @@ public:
 	 */
 	int findValue(std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Value const &value) const;
 };
+#pragma pack(pop)
 
 /**
  * \brief An OutputObject derived class that contains data originally from OsmMemTiles

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -18,7 +18,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <atomic>
 
-enum class OutputGeometryType : uint8_t { POINT, LINESTRING, POLYGON };
+enum OutputGeometryType { POINT, LINESTRING, POLYGON };
 
 //\brief Display the geometry type
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
@@ -86,7 +86,7 @@ public:
 	OutputObjectOsmStorePoint(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == OutputGeometryType::POINT);
+		assert(type == POINT);
 	}
 }; 
 
@@ -96,7 +96,7 @@ public:
 	OutputObjectOsmStoreLinestring(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == OutputGeometryType::LINESTRING);
+		assert(type == LINESTRING);
 	}
 };
 
@@ -106,7 +106,7 @@ public:
 	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == OutputGeometryType::POLYGON);
+		assert(type == POLYGON);
 	}
 };
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -39,17 +39,15 @@ protected:
 
 
 public:
-	NodeID objectID;									// id of way (linestring/polygon) or node (point)
-	OSMStore::handle_t handle;							// Handle within global store of geometries
-
-	OutputGeometryType geomType : 8;					// point, linestring, polygon...
+	NodeID objectID 			: 40;					// id of way (linestring/polygon) or node (point)
 	uint_least8_t layer 		: 8;					// what layer is it in?
 	int8_t z_order				: 8;					// z_order: used for sorting features within layers
+	OutputGeometryType geomType : 2;					// point, linestring, polygon
 	bool fromShapefile 			: 1;
 	unsigned minZoom 			: 4;
-	
-	mutable std::atomic<uint32_t> references;
 
+	OSMStore::handle_t handle;							// Handle within global store of geometries
+	mutable std::atomic<uint32_t> references;
 	AttributeStoreRef attributes;
 
 	void setZOrder(const int z) {

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -18,7 +18,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <atomic>
 
-enum OutputGeometryType { POINT, LINESTRING, POLYGON };
+enum OutputGeometryType { POINT_, LINESTRING_, POLYGON_ };
 
 //\brief Display the geometry type
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
@@ -86,7 +86,7 @@ public:
 	OutputObjectOsmStorePoint(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == POINT);
+		assert(type == POINT_);
 	}
 }; 
 
@@ -96,7 +96,7 @@ public:
 	OutputObjectOsmStoreLinestring(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == LINESTRING);
+		assert(type == LINESTRING_);
 	}
 };
 
@@ -106,7 +106,7 @@ public:
 	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == POLYGON);
+		assert(type == POLYGON_);
 	}
 };
 

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -36,7 +36,7 @@ public:
 		MultiPolygon mp, tmp;
 		for (auto it : results) {
 			OutputObjectRef oo = cachedGeometries.at(it.second);
-			if (oo->geomType!=POLYGON) continue;
+			if (oo->geomType!=POLYGON_) continue;
 			geom::union_(mp, osmStore.retrieve<OSMStore::multi_polygon_t>(oo->handle), tmp);
 			geom::assign(mp, tmp);
 		}

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -36,7 +36,7 @@ public:
 		MultiPolygon mp, tmp;
 		for (auto it : results) {
 			OutputObjectRef oo = cachedGeometries.at(it.second);
-			if (oo->geomType!=OutputGeometryType::POLYGON) continue;
+			if (oo->geomType!=POLYGON) continue;
 			geom::union_(mp, osmStore.retrieve<OSMStore::multi_polygon_t>(oo->handle), tmp);
 			geom::assign(mp, tmp);
 		}

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -198,7 +198,7 @@ std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool o
 			return results;
 		},
 		[&](OutputObject &oo) { // checkQuery
-			if (oo.geomType!=OutputGeometryType::POLYGON) return false; // can only be covered by a polygon!
+			if (oo.geomType!=POLYGON) return false; // can only be covered by a polygon!
 			return geom::covered_by(geom, osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle));
 		}
 	);
@@ -310,9 +310,9 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 		throw out_of_range("ERROR: Layer(): a layer named as \"" + layerName + "\" doesn't exist.");
 	}
 
-	OutputGeometryType geomType = isWay ? (area ? OutputGeometryType::POLYGON : OutputGeometryType::LINESTRING) : OutputGeometryType::POINT;
+	OutputGeometryType geomType = isWay ? (area ? POLYGON : LINESTRING) : POINT;
 	try {
-		if (geomType==OutputGeometryType::POINT) {
+		if (geomType==POINT) {
 			Point p = Point(lon, latp);
 
             if(!CorrectGeometry(p)) return;
@@ -323,7 +323,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
             return;
 		}
-		else if (geomType==OutputGeometryType::POLYGON) {
+		else if (geomType==POLYGON) {
 			// polygon
 
 			MultiPolygon mp;
@@ -352,7 +352,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 							osmStore.store_multi_polygon(osmStore.osm(), mp), attributeStore.empty_set()));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 		}
-		else if (geomType==OutputGeometryType::LINESTRING) {
+		else if (geomType==LINESTRING) {
 			// linestring
 			Linestring ls = linestringCached();
 
@@ -392,7 +392,7 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
-	OutputObjectRef oo(new OutputObjectOsmStorePoint(OutputGeometryType::POINT,
+	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT,
 					false, layers.layerMap[layerName], osmID, 
 					osmStore.store_point(osmStore.osm(), geomp), attributeStore.empty_set()));
 	outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
@@ -543,7 +543,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 			for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 				TileCoordinates index = *it;
 				for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-					if (jt->first->geomType == OutputGeometryType::POLYGON) {
+					if (jt->first->geomType == POLYGON) {
 						polygonExists = true;
 						continue;
 					}
@@ -557,7 +557,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 				for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 					TileCoordinates index = *it;
 					for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-						if (jt->first->geomType != OutputGeometryType::POLYGON) continue;
+						if (jt->first->geomType != POLYGON) continue;
 						osmMemTiles.AddObject(index, jt->first);
 					}
 				}

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -198,7 +198,7 @@ std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool o
 			return results;
 		},
 		[&](OutputObject &oo) { // checkQuery
-			if (oo.geomType!=POLYGON) return false; // can only be covered by a polygon!
+			if (oo.geomType!=POLYGON_) return false; // can only be covered by a polygon!
 			return geom::covered_by(geom, osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle));
 		}
 	);
@@ -310,9 +310,9 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 		throw out_of_range("ERROR: Layer(): a layer named as \"" + layerName + "\" doesn't exist.");
 	}
 
-	OutputGeometryType geomType = isWay ? (area ? POLYGON : LINESTRING) : POINT;
+	OutputGeometryType geomType = isWay ? (area ? POLYGON_ : LINESTRING_) : POINT_;
 	try {
-		if (geomType==POINT) {
+		if (geomType==POINT_) {
 			Point p = Point(lon, latp);
 
             if(!CorrectGeometry(p)) return;
@@ -323,7 +323,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
             return;
 		}
-		else if (geomType==POLYGON) {
+		else if (geomType==POLYGON_) {
 			// polygon
 
 			MultiPolygon mp;
@@ -352,7 +352,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 							osmStore.store_multi_polygon(osmStore.osm(), mp), attributeStore.empty_set()));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 		}
-		else if (geomType==LINESTRING) {
+		else if (geomType==LINESTRING_) {
 			// linestring
 			Linestring ls = linestringCached();
 
@@ -392,7 +392,7 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
-	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT,
+	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT_,
 					false, layers.layerMap[layerName], osmID, 
 					osmStore.store_point(osmStore.osm(), geomp), attributeStore.empty_set()));
 	outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
@@ -543,7 +543,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 			for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 				TileCoordinates index = *it;
 				for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-					if (jt->first->geomType == POLYGON) {
+					if (jt->first->geomType == POLYGON_) {
 						polygonExists = true;
 						continue;
 					}
@@ -557,7 +557,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 				for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 					TileCoordinates index = *it;
 					for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-						if (jt->first->geomType != POLYGON) continue;
+						if (jt->first->geomType != POLYGON_) continue;
 						osmMemTiles.AddObject(index, jt->first);
 					}
 				}

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -13,14 +13,14 @@ namespace geom = boost::geometry;
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
 {
 	switch(geomType) {
-		case OutputGeometryType::POINT:
-			os << "OutputGeometryType::POINT";
+		case POINT:
+			os << "POINT";
 			break;
-		case OutputGeometryType::LINESTRING:
-			os << "OutputGeometryType::LINESTRING";
+		case LINESTRING:
+			os << "LINESTRING";
 			break;
-		case OutputGeometryType::POLYGON:
-			os << "OutputGeometryType::POLYGON";
+		case POLYGON:
+			os << "POLYGON";
 			break;
 	}
 
@@ -69,7 +69,7 @@ void OutputObject::writeAttributes(
 Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox) 
 {
 	switch(oo.geomType) {
-		case OutputGeometryType::POINT:
+		case POINT:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			if (geom::within(p, bbox.clippingBox)) {
@@ -78,7 +78,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return MultiLinestring();
 		}
 
-		case OutputGeometryType::LINESTRING:
+		case LINESTRING:
 		{
 			auto const &ls = osmStore.retrieve<OSMStore::linestring_t>(oo.handle);
 
@@ -106,7 +106,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return result;
 		}
 
-		case OutputGeometryType::POLYGON:
+		case POLYGON:
 		{
 			auto const &input = osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle);
 
@@ -174,7 +174,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox)
 {
 	switch(oo.geomType) {
-		case OutputGeometryType::POINT:
+		case POINT:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			LatpLon out;

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -13,13 +13,13 @@ namespace geom = boost::geometry;
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
 {
 	switch(geomType) {
-		case POINT:
+		case POINT_:
 			os << "POINT";
 			break;
-		case LINESTRING:
+		case LINESTRING_:
 			os << "LINESTRING";
 			break;
-		case POLYGON:
+		case POLYGON_:
 			os << "POLYGON";
 			break;
 	}
@@ -69,7 +69,7 @@ void OutputObject::writeAttributes(
 Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox) 
 {
 	switch(oo.geomType) {
-		case POINT:
+		case POINT_:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			if (geom::within(p, bbox.clippingBox)) {
@@ -78,7 +78,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return MultiLinestring();
 		}
 
-		case LINESTRING:
+		case LINESTRING_:
 		{
 			auto const &ls = osmStore.retrieve<OSMStore::linestring_t>(oo.handle);
 
@@ -106,7 +106,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return result;
 		}
 
-		case POLYGON:
+		case POLYGON_:
 		{
 			auto const &input = osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle);
 
@@ -174,7 +174,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox)
 {
 	switch(oo.geomType) {
-		case POINT:
+		case POINT_:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			LatpLon out;

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -177,7 +177,7 @@ void readShapefile(const Box &clippingBox,
 				if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT_, p, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}
@@ -199,7 +199,7 @@ void readShapefile(const Box &clippingBox,
 					if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 					auto &attributeStore = osmLuaProcessing.getAttributeStore();
-					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
+					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING_, *it, isIndexed, hasName, name, attributeStore.empty_set());
 
 					addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 				}
@@ -272,7 +272,7 @@ void readShapefile(const Box &clippingBox,
 
 				// create OutputObject
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON_, out, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -177,7 +177,7 @@ void readShapefile(const Box &clippingBox,
 				if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}
@@ -199,7 +199,7 @@ void readShapefile(const Box &clippingBox,
 					if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 					auto &attributeStore = osmLuaProcessing.getAttributeStore();
-					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
+					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
 
 					addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 				}
@@ -272,7 +272,7 @@ void readShapefile(const Box &clippingBox,
 
 				// create OutputObject
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -67,7 +67,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 	uint tilex = 0, tiley = 0;
 	switch(geomType) {
-		case OutputGeometryType::POINT:
+		case POINT:
 		{
 			Point *p = boost::get<Point>(&geometry);
 			if (p != nullptr) {
@@ -81,7 +81,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			}
 		} break;
 
-		case OutputGeometryType::LINESTRING:
+		case LINESTRING:
 		{
 			oo = new OutputObjectOsmStoreLinestring(
 						geomType, true, layerNum, id,  
@@ -91,7 +91,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			addToTileIndexPolyline(oo, &geometry);
 		} break;
 
-		case OutputGeometryType::POLYGON:
+		case POLYGON:
 		{
 			oo = new OutputObjectOsmStoreMultiPolygon(
 						geomType, true, layerNum, id,

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -67,7 +67,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 	uint tilex = 0, tiley = 0;
 	switch(geomType) {
-		case POINT:
+		case POINT_:
 		{
 			Point *p = boost::get<Point>(&geometry);
 			if (p != nullptr) {
@@ -81,7 +81,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			}
 		} break;
 
-		case LINESTRING:
+		case LINESTRING_:
 		{
 			oo = new OutputObjectOsmStoreLinestring(
 						geomType, true, layerNum, id,  
@@ -91,7 +91,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			addToTileIndexPolyline(oo, &geometry);
 		} break;
 
-		case POLYGON:
+		case POLYGON_:
 		{
 			oo = new OutputObjectOsmStoreMultiPolygon(
 						geomType, true, layerNum, id,

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -101,7 +101,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 		OutputObjectRef oo = *jt;
 		if (zoom < oo->minZoom) { continue; }
 
-		if (oo->geomType == OutputGeometryType::POINT) {
+		if (oo->geomType == POINT) {
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();
 			LatpLon pos = buildNodeGeometry(osmStore, *oo, bbox);
 			featurePtr->add_geometry(9);					// moveTo, repeat x1
@@ -121,18 +121,18 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 				continue;
 			}
 
-			if (oo->geomType == OutputGeometryType::POLYGON && filterArea > 0.0) {
+			if (oo->geomType == POLYGON && filterArea > 0.0) {
 				if (geom::area(g)<filterArea) continue;
 			}
 
 			//This may increment the jt iterator
-			if (oo->geomType == OutputGeometryType::LINESTRING && zoom < sharedData.config.combineBelow) {
+			if (oo->geomType == LINESTRING && zoom < sharedData.config.combineBelow) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiLinestring>(g));
 				MultiLinestring reordered;
 				ReorderMultiLinestring(boost::get<MultiLinestring>(g), reordered);
 				g = move(reordered);
 				oo = *jt;
-			} else if (oo->geomType == OutputGeometryType::POLYGON && combinePolygons) {
+			} else if (oo->geomType == POLYGON && combinePolygons) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiPolygon>(g));
 				oo = *jt;
 			}

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -86,9 +86,9 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, OutputObjectsConstIt &jt, Outpu
 			T output;
 			geom::union_(g, to_merge, output);
 			g = move(output);
-		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << std::to_string(oo->objectID) <<"," << err.what() << endl;
-		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
-		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
+		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << static_cast<int>(oo->objectID) <<"," << err.what() << endl;
+		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << static_cast<int>(oo->objectID) << endl;
+		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << static_cast<int>(oo->objectID) << endl;
 		}
 	}
 }
@@ -117,7 +117,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			try {
 				g = buildWayGeometry(osmStore, *oo, bbox);
 			} catch (std::out_of_range &err) {
-				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << std::to_string(oo->objectID) <<"," << err.what() << endl;
+				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << static_cast<int>(oo->objectID) <<"," << err.what() << endl;
 				continue;
 			}
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -86,9 +86,9 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, OutputObjectsConstIt &jt, Outpu
 			T output;
 			geom::union_(g, to_merge, output);
 			g = move(output);
-		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << oo->objectID <<"," << err.what() << endl;
-		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << oo->objectID << endl;
-		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << oo->objectID << endl;
+		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << std::to_string(oo->objectID) <<"," << err.what() << endl;
+		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
+		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
 		}
 	}
 }
@@ -117,7 +117,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			try {
 				g = buildWayGeometry(osmStore, *oo, bbox);
 			} catch (std::out_of_range &err) {
-				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << oo->objectID <<"," << err.what() << endl;
+				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << std::to_string(oo->objectID) <<"," << err.what() << endl;
 				continue;
 			}
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -101,7 +101,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 		OutputObjectRef oo = *jt;
 		if (zoom < oo->minZoom) { continue; }
 
-		if (oo->geomType == POINT) {
+		if (oo->geomType == POINT_) {
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();
 			LatpLon pos = buildNodeGeometry(osmStore, *oo, bbox);
 			featurePtr->add_geometry(9);					// moveTo, repeat x1
@@ -121,18 +121,18 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 				continue;
 			}
 
-			if (oo->geomType == POLYGON && filterArea > 0.0) {
+			if (oo->geomType == POLYGON_ && filterArea > 0.0) {
 				if (geom::area(g)<filterArea) continue;
 			}
 
 			//This may increment the jt iterator
-			if (oo->geomType == LINESTRING && zoom < sharedData.config.combineBelow) {
+			if (oo->geomType == LINESTRING_ && zoom < sharedData.config.combineBelow) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiLinestring>(g));
 				MultiLinestring reordered;
 				ReorderMultiLinestring(boost::get<MultiLinestring>(g), reordered);
 				g = move(reordered);
 				oo = *jt;
-			} else if (oo->geomType == POLYGON && combinePolygons) {
+			} else if (oo->geomType == POLYGON_ && combinePolygons) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiPolygon>(g));
 				oo = *jt;
 			}


### PR DESCRIPTION
Restricting `objectID` to 40 bits as per #293 means we can fit the rest of the flags into the remaining 24 bits.

Edit: this works fine on clang, but GCC appears to squawk at the bitfield not being big enough for the uint8_t underlying the enum, even though we only have 2 bits worth of enum values.

Edit 2: we may need to look at newWayID/MAX_WAY_ID too.