### PR TITLE
Several optimization to reduce outputobject size

### DIFF
--- a/include/geom.h
+++ b/include/geom.h
@@ -43,7 +43,7 @@ typedef boost::geometry::index::rtree< IndexValue, boost::geometry::index::quadr
 typedef uint64_t NodeID;
 typedef uint64_t WayID;
 
-#define MAX_WAY_ID std::numeric_limits<WayID>::max()
+#define MAX_WAY_ID pow(2,40)-1
 typedef std::vector<NodeID> NodeVec;
 typedef std::vector<WayID> WayVec;
 

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -445,7 +445,17 @@ public:
 	void store_multi_polygon(generated &store, NodeID id, Input const &src)
 	{
 		multi_polygon_t dst;
-		boost::geometry::assign(dst, src);
+		dst.resize(src.size());
+		for(std::size_t i = 0; i < src.size(); ++i) {
+			dst[i].outer().resize(src[i].outer().size());
+			boost::geometry::assign(dst[i].outer(), src[i].outer());
+
+			dst[i].inners().resize(src[i].inners().size());
+			for(std::size_t j = 0; j < src[i].inners().size(); ++j) {
+				dst[i].inners()[j].resize(src[i].inners()[j].size());
+				boost::geometry::assign(dst[i].inners()[j], src[i].inners()[j]);
+			}
+		}
 		
 		std::lock_guard<std::mutex> lock(store.multi_polygon_store_mutex);
 		store.multi_polygon_store->emplace_back(id, std::move(dst));

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -309,14 +309,14 @@ private:
 class OSMStore
 {
 public:
-	using point_store_t = std::deque<Point>;
+	using point_store_t = std::deque<std::pair<NodeID, Point>>;
 
 	using linestring_t = boost::geometry::model::linestring<Point, std::vector, mmap_allocator>;
-	using linestring_store_t = std::deque<linestring_t>;
+	using linestring_store_t = std::deque<std::pair<NodeID, linestring_t>>;
 
 	using polygon_t = boost::geometry::model::polygon<Point, true, true, std::vector, std::vector, mmap_allocator, mmap_allocator>;
 	using multi_polygon_t = boost::geometry::model::multi_polygon<polygon_t, std::vector, mmap_allocator>;
-	using multi_polygon_store_t = std::deque<multi_polygon_t>;
+	using multi_polygon_store_t = std::deque<std::pair<NodeID, multi_polygon_t>>;
 
 	struct generated {
 		std::mutex points_store_mutex;
@@ -366,6 +366,9 @@ public:
 
 	void use_compact_store(bool use = true) { use_compact_nodes = use; }
 
+	void shapes_sort(unsigned int threadNum = 1);
+	void generated_sort(unsigned int threadNum = 1);
+
 	void nodes_insert_back(NodeID i, LatpLon coord) {
 		if(!use_compact_nodes)
 			nodes.insert_back(i, coord);
@@ -378,10 +381,7 @@ public:
 		else
 			compact_nodes.insert_back(new_nodes);
 	}
-	void nodes_sort(unsigned int threadNum) {
-		if(!use_compact_nodes)
-			nodes.sort(threadNum);
-	}
+	void nodes_sort(unsigned int threadNum);
 	
 	LatpLon nodes_at(NodeID i) const { 
 		return use_compact_nodes ? compact_nodes.at(i) : nodes.at(i);
@@ -390,13 +390,12 @@ public:
 	void ways_insert_back(std::vector<WayStore::element_t> &new_ways) {
 		ways.insert_back(new_ways);
 	}
-	void ways_sort(unsigned int threadNum) { 
-		ways.sort(threadNum); 
-	}
+	void ways_sort(unsigned int threadNum);
 
 	void relations_insert_front(std::vector<RelationStore::element_t> &new_relations) {
 		relations.insert_front(new_relations);
 	}
+	void relations_sort(unsigned int threadNum);
 
 	generated &osm() { return osm_generated; }
 	generated const &osm() const { return osm_generated; }
@@ -406,50 +405,61 @@ public:
 	using handle_t = void *;
 
 	template<typename T>
-	static T const &retrieve(handle_t handle) 
-	{
-		return *reinterpret_cast<T const *>(handle);
-	}
-
-	template<typename T>
-	handle_t store_point(generated &store, T const &input) {	
+	void store_point(generated &store, NodeID id, T const &input) {	
 		std::lock_guard<std::mutex> lock(store.points_store_mutex);
-		store.points_store->push_back(input);		   	
-		return &store.points_store->back();		   	
+		store.points_store->emplace_back(id, input);		   	
 	}
 
-	Point retrieve_point(generated const &store, std::size_t id) const {
-		return store.points_store->at(id);		   
+	Point const &retrieve_point(generated const &store, NodeID id) const {
+		auto iter = std::lower_bound(store.points_store->begin(), store.points_store->end(), id, [](auto const &e, auto id) { 
+			return e.first < id; 
+		});
+
+		if(iter == store.points_store->end() || iter->first != id)
+			throw std::out_of_range("Could not find generated node with id " + std::to_string(id));
+
+		return iter->second;
 	}
 	
 	template<typename Input>
-	handle_t store_linestring(generated &store, Input const &src)
+	void store_linestring(generated &store, NodeID id, Input const &src)
 	{
 		linestring_t dst(src.begin(), src.end());
 
 		std::lock_guard<std::mutex> lock(store.linestring_store_mutex);
-		store.linestring_store->emplace_back(std::move(dst));
-		return &store.linestring_store->back();
+		store.linestring_store->emplace_back(id, std::move(dst));
 	}
 
-	linestring_t const &retrieve_linestring(generated const &store, std::size_t id) const {
-		return store.linestring_store->at(id);
+	linestring_t const &retrieve_linestring(generated const &store, NodeID id) const {
+		auto iter = std::lower_bound(store.linestring_store->begin(), store.linestring_store->end(), id, [](auto const &e, auto id) { 
+			return e.first < id; 
+		});
+
+		if(iter == store.linestring_store->end() || iter->first != id)
+			throw std::out_of_range("Could not find generated linestring with id " + std::to_string(id));
+
+		return iter->second;
 	}
 
 	template<typename Input>
-	handle_t store_multi_polygon(generated &store, Input const &src)
+	void store_multi_polygon(generated &store, NodeID id, Input const &src)
 	{
 		multi_polygon_t dst;
 		boost::geometry::assign(dst, src);
 		
 		std::lock_guard<std::mutex> lock(store.multi_polygon_store_mutex);
-		std::size_t id = store.multi_polygon_store->size();
-		store.multi_polygon_store->emplace_back(std::move(dst));
-		return &store.multi_polygon_store->back();
+		store.multi_polygon_store->emplace_back(id, std::move(dst));
 	}
 
-	multi_polygon_t const &retrieve_multi_polygon(generated const &store, std::size_t id) const {
-		return store.multi_polygon_store->at(id);
+	multi_polygon_t const &retrieve_multi_polygon(generated const &store, NodeID id) const {
+		auto iter = std::lower_bound(store.multi_polygon_store->begin(), store.multi_polygon_store->end(), id, [](auto const &e, auto id) { 
+			return e.first < id; 
+		});
+
+		if(iter == store.multi_polygon_store->end() || iter->first != id)
+			throw std::out_of_range("Could not find generated multi polygon with id " + std::to_string(id));
+
+		return iter->second;
 	}
 
 	void clear() {

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -39,7 +39,7 @@ protected:
 
 
 public:
-	NodeID objectID 			: 40;					// id of way (linestring/polygon) or node (point)
+	NodeID objectID 			: 40;					// id of way (linestring/polygon) or node (point) - cf MAX_WAY_ID
 	uint_least8_t layer 		: 8;					// what layer is it in?
 	int8_t z_order				: 8;					// z_order: used for sorting features within layers
 	OutputGeometryType geomType : 2;					// point, linestring, polygon

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -20,6 +20,13 @@
 
 enum OutputGeometryType { POINT_, LINESTRING_, POLYGON_ };
 
+#define OSMID_TYPE_OFFSET	40
+#define OSMID_MASK 		((1L<<OSMID_TYPE_OFFSET)-1)
+#define OSMID_SHAPE 	(0L<<OSMID_TYPE_OFFSET)
+#define OSMID_NODE 		(1L<<OSMID_TYPE_OFFSET)
+#define OSMID_WAY 		(2L<<OSMID_TYPE_OFFSET)
+#define OSMID_RELATION 	(3L<<OSMID_TYPE_OFFSET)
+
 //\brief Display the geometry type
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
 
@@ -33,22 +40,19 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
 class OutputObject {
 
 protected:	
-	OutputObject(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes) 
-		: objectID(id), handle(handle), geomType(type), fromShapefile(shp), layer(l), z_order(0),
+	OutputObject(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes) 
+		: objectID(id), geomType(type), layer(l), z_order(0),
 		  minZoom(0), attributes(attributes)
 	{ }
 
 
 public:
-	NodeID objectID 			: 40;					// id of way (linestring/polygon) or node (point) - cf MAX_WAY_ID
+	NodeID objectID 			: 42;					// id of way (linestring/polygon) or node (point) - cf MAX_WAY_ID
 	uint_least8_t layer 		: 8;					// what layer is it in?
 	int8_t z_order				: 8;					// z_order: used for sorting features within layers
 	OutputGeometryType geomType : 2;					// point, linestring, polygon
-	bool fromShapefile 			: 1;
 	unsigned minZoom 			: 4;
 
-	OSMStore::handle_t handle;							// Handle within global store of geometries
-	mutable std::atomic<uint32_t> references;
 	AttributeStoreRef attributes;
 
 	void setZOrder(const int z) {
@@ -85,8 +89,8 @@ public:
 class OutputObjectOsmStorePoint : public OutputObject
 {
 public:
-	OutputObjectOsmStorePoint(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
-		: OutputObject(type, shp, l, id, handle, attributes)
+	OutputObjectOsmStorePoint(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes)
+		: OutputObject(type, l, id, attributes)
 	{ 
 		assert(type == POINT_);
 	}
@@ -95,8 +99,8 @@ public:
 class OutputObjectOsmStoreLinestring : public OutputObject
 {
 public:
-	OutputObjectOsmStoreLinestring(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
-		: OutputObject(type, shp, l, id, handle, attributes)
+	OutputObjectOsmStoreLinestring(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes)
+		: OutputObject(type, l, id, attributes)
 	{ 
 		assert(type == LINESTRING_);
 	}
@@ -105,8 +109,8 @@ public:
 class OutputObjectOsmStoreMultiPolygon : public OutputObject
 {
 public:
-	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
-		: OutputObject(type, shp, l, id, handle, attributes)
+	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes)
+		: OutputObject(type, l, id, attributes)
 	{ 
 		assert(type == POLYGON_);
 	}

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -29,6 +29,7 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
  * Possible future improvements to save memory:
  * - use a global dictionary for attribute key/values
 */
+#pragma pack(push, 4)
 class OutputObject {
 
 protected:	
@@ -76,6 +77,7 @@ public:
 	 */
 	int findValue(std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Value const &value) const;
 };
+#pragma pack(pop)
 
 /**
  * \brief An OutputObject derived class that contains data originally from OsmMemTiles

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -18,7 +18,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <atomic>
 
-enum class OutputGeometryType : uint8_t { POINT, LINESTRING, POLYGON };
+enum OutputGeometryType { POINT, LINESTRING, POLYGON };
 
 //\brief Display the geometry type
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
@@ -86,7 +86,7 @@ public:
 	OutputObjectOsmStorePoint(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == OutputGeometryType::POINT);
+		assert(type == POINT);
 	}
 }; 
 
@@ -96,7 +96,7 @@ public:
 	OutputObjectOsmStoreLinestring(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == OutputGeometryType::LINESTRING);
+		assert(type == LINESTRING);
 	}
 };
 
@@ -106,7 +106,7 @@ public:
 	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == OutputGeometryType::POLYGON);
+		assert(type == POLYGON);
 	}
 };
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -39,17 +39,15 @@ protected:
 
 
 public:
-	NodeID objectID;									// id of way (linestring/polygon) or node (point)
-	OSMStore::handle_t handle;							// Handle within global store of geometries
-
-	OutputGeometryType geomType : 8;					// point, linestring, polygon...
+	NodeID objectID 			: 40;					// id of way (linestring/polygon) or node (point)
 	uint_least8_t layer 		: 8;					// what layer is it in?
 	int8_t z_order				: 8;					// z_order: used for sorting features within layers
+	OutputGeometryType geomType : 2;					// point, linestring, polygon
 	bool fromShapefile 			: 1;
 	unsigned minZoom 			: 4;
-	
-	mutable std::atomic<uint32_t> references;
 
+	OSMStore::handle_t handle;							// Handle within global store of geometries
+	mutable std::atomic<uint32_t> references;
 	AttributeStoreRef attributes;
 
 	void setZOrder(const int z) {

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -15,9 +15,6 @@
 #include "osmformat.pb.h"
 #include "vector_tile.pb.h"
 
-#include <boost/intrusive_ptr.hpp>
-#include <atomic>
-
 enum OutputGeometryType { POINT_, LINESTRING_, POLYGON_ };
 
 #define OSMID_TYPE_OFFSET	40

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -18,7 +18,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <atomic>
 
-enum OutputGeometryType { POINT, LINESTRING, POLYGON };
+enum OutputGeometryType { POINT_, LINESTRING_, POLYGON_ };
 
 //\brief Display the geometry type
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
@@ -86,7 +86,7 @@ public:
 	OutputObjectOsmStorePoint(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == POINT);
+		assert(type == POINT_);
 	}
 }; 
 
@@ -96,7 +96,7 @@ public:
 	OutputObjectOsmStoreLinestring(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == LINESTRING);
+		assert(type == LINESTRING_);
 	}
 };
 
@@ -106,7 +106,7 @@ public:
 	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, bool shp, uint_least8_t l, NodeID id, OSMStore::handle_t handle, AttributeStoreRef attributes)
 		: OutputObject(type, shp, l, id, handle, attributes)
 	{ 
-		assert(type == POLYGON);
+		assert(type == POLYGON_);
 	}
 };
 

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -36,7 +36,7 @@ public:
 		MultiPolygon mp, tmp;
 		for (auto it : results) {
 			OutputObjectRef oo = cachedGeometries.at(it.second);
-			if (oo->geomType!=POLYGON) continue;
+			if (oo->geomType!=POLYGON_) continue;
 			geom::union_(mp, osmStore.retrieve<OSMStore::multi_polygon_t>(oo->handle), tmp);
 			geom::assign(mp, tmp);
 		}

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -37,7 +37,7 @@ public:
 		for (auto it : results) {
 			OutputObjectRef oo = cachedGeometries.at(it.second);
 			if (oo->geomType!=POLYGON_) continue;
-			geom::union_(mp, osmStore.retrieve<OSMStore::multi_polygon_t>(oo->handle), tmp);
+			geom::union_(mp, osmStore.retrieve_multi_polygon(osmStore.shp(), oo->objectID), tmp);
 			geom::assign(mp, tmp);
 		}
 		geom::correct(mp);

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -36,7 +36,7 @@ public:
 		MultiPolygon mp, tmp;
 		for (auto it : results) {
 			OutputObjectRef oo = cachedGeometries.at(it.second);
-			if (oo->geomType!=OutputGeometryType::POLYGON) continue;
+			if (oo->geomType!=POLYGON) continue;
 			geom::union_(mp, osmStore.retrieve<OSMStore::multi_polygon_t>(oo->handle), tmp);
 			geom::assign(mp, tmp);
 		}

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -23,7 +23,7 @@ public:
 	}
 	std::vector<uint> QueryMatchingGeometries(const std::string &layerName, bool once, Box &box, 
 		std::function<std::vector<IndexValue>(const RTree &rtree)> indexQuery, 
-		std::function<bool(OutputObject &oo)> checkQuery) const;
+		std::function<bool(OutputObject const &oo)> checkQuery) const;
 	std::vector<std::string> namesOfGeometries(const std::vector<uint> &ids) const;
 
 	template <typename GeometryT>

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -18,6 +18,7 @@ class TileDataSource {
 protected:	
 	std::mutex mutex;
 	TileIndex tileIndex;
+	std::deque<OutputObject> objects;
 
 	unsigned int baseZoom;
 
@@ -34,6 +35,12 @@ public:
 	///This must be thread safe!
 	void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, std::vector<OutputObjectRef> &dstTile) {
 		MergeSingleTileDataAtZoom(dstIndex, zoom, baseZoom, tileIndex, dstTile);
+	}
+
+	OutputObjectRef CreateObject(OutputObject const &oo) {
+		std::lock_guard<std::mutex> lock(mutex);
+		objects.push_back(oo);
+		return &objects.back();
 	}
 
 	void AddObject(TileCoordinates const &index, OutputObjectRef const &oo) {

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -197,15 +197,9 @@ std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool o
 			rtree.query(geom::index::intersects(box), back_inserter(results));
 			return results;
 		},
-<<<<<<< HEAD
-		[&](OutputObject &oo) { // checkQuery
-			if (oo.geomType!=POLYGON_) return false; // can only be covered by a polygon!
-			return geom::covered_by(geom, osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle));
-=======
 		[&](OutputObject const &oo) { // checkQuery
-			if (oo.geomType!=OutputGeometryType::POLYGON) return false; // can only be covered by a polygon!
+			if (oo.geomType!=POLYGON_) return false; // can only be covered by a polygon!
 			return geom::covered_by(geom, osmStore.retrieve_multi_polygon(osmStore.shp(), oo.objectID));
->>>>>>> Use OsmID to lookup generated geometry
 		}
 	);
 	return ids;
@@ -398,19 +392,9 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT_,
-=======
-	OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(OutputGeometryType::POINT,
->>>>>>> Remove reference counted outputobject
-					false, layers.layerMap[layerName], osmID, 
-					osmStore.store_point(osmStore.osm(), geomp), attributeStore.empty_set()));
-=======
 	osmStore.store_point(osmStore.osm(), osmID, geomp);
-	OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(OutputGeometryType::POINT,
+	OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(POINT_,
 					layers.layerMap[layerName], osmID, attributeStore.empty_set()));
->>>>>>> Use OsmID to lookup generated geometry
 	outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 }
 
@@ -445,7 +429,7 @@ void OsmLuaProcessing::AttributeWithMinZoom(const string &key, const string &val
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
 	vector_tile::Tile_Value v;
 	v.set_string_value(val);
-	outputs.back().second->emplace(key, v, minzoom);
+	outputs.back().second->values.emplace(key, v, minzoom);
 	setVectorLayerMetadata(outputs.back().first->layer, key, 0);
 }
 
@@ -454,7 +438,7 @@ void OsmLuaProcessing::AttributeNumericWithMinZoom(const string &key, const floa
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
 	vector_tile::Tile_Value v;
 	v.set_float_value(val);
-	outputs.back().second->emplace(key, v, minzoom);
+	outputs.back().second->values.emplace(key, v, minzoom);
 	setVectorLayerMetadata(outputs.back().first->layer, key, 1);
 }
 
@@ -463,7 +447,7 @@ void OsmLuaProcessing::AttributeBooleanWithMinZoom(const string &key, const bool
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
 	vector_tile::Tile_Value v;
 	v.set_bool_value(val);
-	outputs.back().second->emplace(key, v, minzoom);
+	outputs.back().second->values.emplace(key, v, minzoom);
 	setVectorLayerMetadata(outputs.back().first->layer, key, 2);
 }
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -198,7 +198,7 @@ std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool o
 			return results;
 		},
 		[&](OutputObject &oo) { // checkQuery
-			if (oo.geomType!=OutputGeometryType::POLYGON) return false; // can only be covered by a polygon!
+			if (oo.geomType!=POLYGON) return false; // can only be covered by a polygon!
 			return geom::covered_by(geom, osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle));
 		}
 	);
@@ -310,9 +310,9 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 		throw out_of_range("ERROR: Layer(): a layer named as \"" + layerName + "\" doesn't exist.");
 	}
 
-	OutputGeometryType geomType = isWay ? (area ? OutputGeometryType::POLYGON : OutputGeometryType::LINESTRING) : OutputGeometryType::POINT;
+	OutputGeometryType geomType = isWay ? (area ? POLYGON : LINESTRING) : POINT;
 	try {
-		if (geomType==OutputGeometryType::POINT) {
+		if (geomType==POINT) {
 			Point p = Point(lon, latp);
 
             if(!CorrectGeometry(p)) return;
@@ -323,7 +323,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
             return;
 		}
-		else if (geomType==OutputGeometryType::POLYGON) {
+		else if (geomType==POLYGON) {
 			// polygon
 
 			MultiPolygon mp;
@@ -352,7 +352,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 							osmStore.store_multi_polygon(osmStore.osm(), mp), attributeStore.empty_set()));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 		}
-		else if (geomType==OutputGeometryType::LINESTRING) {
+		else if (geomType==LINESTRING) {
 			// linestring
 			Linestring ls = linestringCached();
 
@@ -392,7 +392,7 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
-	OutputObjectRef oo(new OutputObjectOsmStorePoint(OutputGeometryType::POINT,
+	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT,
 					false, layers.layerMap[layerName], osmID, 
 					osmStore.store_point(osmStore.osm(), geomp), attributeStore.empty_set()));
 	outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
@@ -543,7 +543,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 			for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 				TileCoordinates index = *it;
 				for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-					if (jt->first->geomType == OutputGeometryType::POLYGON) {
+					if (jt->first->geomType == POLYGON) {
 						polygonExists = true;
 						continue;
 					}
@@ -557,7 +557,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 				for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 					TileCoordinates index = *it;
 					for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-						if (jt->first->geomType != OutputGeometryType::POLYGON) continue;
+						if (jt->first->geomType != POLYGON) continue;
 						osmMemTiles.AddObject(index, jt->first);
 					}
 				}

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -198,7 +198,7 @@ std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool o
 			return results;
 		},
 		[&](OutputObject &oo) { // checkQuery
-			if (oo.geomType!=POLYGON) return false; // can only be covered by a polygon!
+			if (oo.geomType!=POLYGON_) return false; // can only be covered by a polygon!
 			return geom::covered_by(geom, osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle));
 		}
 	);
@@ -310,9 +310,9 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 		throw out_of_range("ERROR: Layer(): a layer named as \"" + layerName + "\" doesn't exist.");
 	}
 
-	OutputGeometryType geomType = isWay ? (area ? POLYGON : LINESTRING) : POINT;
+	OutputGeometryType geomType = isWay ? (area ? POLYGON_ : LINESTRING_) : POINT_;
 	try {
-		if (geomType==POINT) {
+		if (geomType==POINT_) {
 			Point p = Point(lon, latp);
 
             if(!CorrectGeometry(p)) return;
@@ -323,7 +323,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
             return;
 		}
-		else if (geomType==POLYGON) {
+		else if (geomType==POLYGON_) {
 			// polygon
 
 			MultiPolygon mp;
@@ -352,7 +352,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 							osmStore.store_multi_polygon(osmStore.osm(), mp), attributeStore.empty_set()));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 		}
-		else if (geomType==LINESTRING) {
+		else if (geomType==LINESTRING_) {
 			// linestring
 			Linestring ls = linestringCached();
 
@@ -392,7 +392,7 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
-	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT,
+	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT_,
 					false, layers.layerMap[layerName], osmID, 
 					osmStore.store_point(osmStore.osm(), geomp), attributeStore.empty_set()));
 	outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
@@ -543,7 +543,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 			for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 				TileCoordinates index = *it;
 				for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-					if (jt->first->geomType == POLYGON) {
+					if (jt->first->geomType == POLYGON_) {
 						polygonExists = true;
 						continue;
 					}
@@ -557,7 +557,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 				for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 					TileCoordinates index = *it;
 					for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-						if (jt->first->geomType != POLYGON) continue;
+						if (jt->first->geomType != POLYGON_) continue;
 						osmMemTiles.AddObject(index, jt->first);
 					}
 				}

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -161,7 +161,7 @@ std::vector<uint> OsmLuaProcessing::intersectsQuery(const string &layerName, boo
 			rtree.query(geom::index::intersects(box), back_inserter(results));
 			return results;
 		},
-		[&](OutputObject &oo) { // checkQuery
+		[&](OutputObject const &oo) { // checkQuery
 			return geom::intersects(geom, osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle));
 		}
 	);
@@ -178,7 +178,7 @@ double OsmLuaProcessing::intersectsArea(const string &layerName, GeometryT &geom
 			rtree.query(geom::index::intersects(box), back_inserter(results));
 			return results;
 		},
-		[&](OutputObject &oo) { // checkQuery
+		[&](OutputObject const &oo) { // checkQuery
 			MultiPolygon tmp;
 			geom::intersection(geom, osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle), tmp);
 			area += multiPolygonArea(tmp);
@@ -317,7 +317,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
             if(!CorrectGeometry(p)) return;
 
-			OutputObjectRef oo(new OutputObjectOsmStorePoint(geomType, false,
+			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(geomType, false,
 							layers.layerMap[layerName], osmID, 
 							osmStore.store_point(osmStore.osm(), p), attributeStore.empty_set()));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
@@ -347,7 +347,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
             if(!CorrectGeometry(mp)) return;
 
-			OutputObjectRef oo(new OutputObjectOsmStoreMultiPolygon(geomType, false,
+			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreMultiPolygon(geomType, false,
 							layers.layerMap[layerName], osmID, 
 							osmStore.store_multi_polygon(osmStore.osm(), mp), attributeStore.empty_set()));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
@@ -358,7 +358,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
             if(!CorrectGeometry(ls)) return;
 
-			OutputObjectRef oo(new OutputObjectOsmStoreLinestring(geomType, false,
+			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreLinestring(geomType, false,
 						layers.layerMap[layerName], osmID, 
 						osmStore.store_linestring(osmStore.osm(), ls), attributeStore.empty_set()));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
@@ -392,7 +392,11 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
+<<<<<<< HEAD
 	OutputObjectRef oo(new OutputObjectOsmStorePoint(POINT_,
+=======
+	OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(OutputGeometryType::POINT,
+>>>>>>> Remove reference counted outputobject
 					false, layers.layerMap[layerName], osmID, 
 					osmStore.store_point(osmStore.osm(), geomp), attributeStore.empty_set()));
 	outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -35,7 +35,7 @@ void OutputObject::writeAttributes(
 	vector_tile::Tile_Feature *featurePtr,
 	char zoom) const {
 
-	for(auto const &it: *attributes) {
+	for(auto const &it: attributes->values) {
 		if (it.minzoom > zoom) continue;
 
 		// Look for key
@@ -225,8 +225,8 @@ bool operator<(const OutputObjectRef x, const OutputObjectRef y) {
 	if (x->z_order > y->z_order) return false;
 	if (x->geomType < y->geomType) return true;
 	if (x->geomType > y->geomType) return false;
-	if (x->attributes < y->attributes) return true;
-	if (x->attributes > y->attributes) return false;
+	if (x->attributes.get() < y->attributes.get()) return true;
+	if (x->attributes.get() > y->attributes.get()) return false;
 	if (x->objectID < y->objectID) return true;
 	return false;
 } 

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -205,20 +205,20 @@ int OutputObject::findValue(vector<vector_tile::Tile_Value> *valueList, vector_t
 
 // Comparision functions
 
-bool operator==(const OutputObjectRef &x, const OutputObjectRef &y) {
+bool operator==(const OutputObjectRef x, const OutputObjectRef y) {
 	return
 		x->layer == y->layer &&
 		x->z_order == y->z_order &&
 		x->geomType == y->geomType &&
 		x->attributes == y->attributes &&
 		x->objectID == y->objectID;
-}
+} 
 
 // Do lexicographic comparison, with the order of: layer, geomType, attributes, and objectID.
 // Note that attributes is preffered to objectID.
 // It is to arrange objects with the identical attributes continuously.
 // Such objects will be merged into one object, to reduce the size of output.
-bool operator<(const OutputObjectRef &x, const OutputObjectRef &y) {
+bool operator<(const OutputObjectRef x, const OutputObjectRef y) {
 	if (x->layer < y->layer) return true;
 	if (x->layer > y->layer) return false;
 	if (x->z_order < y->z_order) return true;
@@ -229,7 +229,7 @@ bool operator<(const OutputObjectRef &x, const OutputObjectRef &y) {
 	if (x->attributes > y->attributes) return false;
 	if (x->objectID < y->objectID) return true;
 	return false;
-}
+} 
 
 namespace vector_tile {
 	bool operator==(const vector_tile::Tile_Value &x, const vector_tile::Tile_Value &y) {

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -13,14 +13,14 @@ namespace geom = boost::geometry;
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
 {
 	switch(geomType) {
-		case OutputGeometryType::POINT:
-			os << "OutputGeometryType::POINT";
+		case POINT:
+			os << "POINT";
 			break;
-		case OutputGeometryType::LINESTRING:
-			os << "OutputGeometryType::LINESTRING";
+		case LINESTRING:
+			os << "LINESTRING";
 			break;
-		case OutputGeometryType::POLYGON:
-			os << "OutputGeometryType::POLYGON";
+		case POLYGON:
+			os << "POLYGON";
 			break;
 	}
 
@@ -69,7 +69,7 @@ void OutputObject::writeAttributes(
 Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox) 
 {
 	switch(oo.geomType) {
-		case OutputGeometryType::POINT:
+		case POINT:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			if (geom::within(p, bbox.clippingBox)) {
@@ -78,7 +78,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return MultiLinestring();
 		}
 
-		case OutputGeometryType::LINESTRING:
+		case LINESTRING:
 		{
 			auto const &ls = osmStore.retrieve<OSMStore::linestring_t>(oo.handle);
 
@@ -106,7 +106,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return result;
 		}
 
-		case OutputGeometryType::POLYGON:
+		case POLYGON:
 		{
 			auto const &input = osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle);
 
@@ -174,7 +174,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox)
 {
 	switch(oo.geomType) {
-		case OutputGeometryType::POINT:
+		case POINT:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			LatpLon out;

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -71,7 +71,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 	switch(oo.geomType) {
 		case POINT_:
 		{
-			auto p = osmStore.retrieve<Point>(oo.handle);
+			auto p = osmStore.retrieve_point((oo.objectID >> OSMID_TYPE_OFFSET) > 0 ? osmStore.osm() : osmStore.shp(), oo.objectID);
 			if (geom::within(p, bbox.clippingBox)) {
 				return p;
 			} 
@@ -80,7 +80,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 
 		case LINESTRING_:
 		{
-			auto const &ls = osmStore.retrieve<OSMStore::linestring_t>(oo.handle);
+			auto const &ls = osmStore.retrieve_linestring((oo.objectID >> OSMID_TYPE_OFFSET) > 0 ? osmStore.osm() : osmStore.shp(), oo.objectID);
 
 			MultiLinestring out;
 			if(ls.empty())
@@ -108,7 +108,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 
 		case POLYGON_:
 		{
-			auto const &input = osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle);
+			auto const &input = osmStore.retrieve_multi_polygon((oo.objectID >> OSMID_TYPE_OFFSET) > 0 ? osmStore.osm() : osmStore.shp(), oo.objectID);
 
 			Box box = bbox.clippingBox;
 			
@@ -176,7 +176,7 @@ LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 	switch(oo.geomType) {
 		case POINT_:
 		{
-			auto p = osmStore.retrieve<Point>(oo.handle);
+			auto p = osmStore.retrieve_point((oo.objectID >> OSMID_TYPE_OFFSET) > 0 ? osmStore.osm() : osmStore.shp(), oo.objectID);
 			LatpLon out;
 			out.latp = p.y();
 			out.lon = p.x();

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -13,13 +13,13 @@ namespace geom = boost::geometry;
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
 {
 	switch(geomType) {
-		case POINT:
+		case POINT_:
 			os << "POINT";
 			break;
-		case LINESTRING:
+		case LINESTRING_:
 			os << "LINESTRING";
 			break;
-		case POLYGON:
+		case POLYGON_:
 			os << "POLYGON";
 			break;
 	}
@@ -69,7 +69,7 @@ void OutputObject::writeAttributes(
 Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox) 
 {
 	switch(oo.geomType) {
-		case POINT:
+		case POINT_:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			if (geom::within(p, bbox.clippingBox)) {
@@ -78,7 +78,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return MultiLinestring();
 		}
 
-		case LINESTRING:
+		case LINESTRING_:
 		{
 			auto const &ls = osmStore.retrieve<OSMStore::linestring_t>(oo.handle);
 
@@ -106,7 +106,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			return result;
 		}
 
-		case POLYGON:
+		case POLYGON_:
 		{
 			auto const &input = osmStore.retrieve<OSMStore::multi_polygon_t>(oo.handle);
 
@@ -174,7 +174,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const TileBbox &bbox)
 {
 	switch(oo.geomType) {
-		case POINT:
+		case POINT_:
 		{
 			auto p = osmStore.retrieve<Point>(oo.handle);
 			LatpLon out;

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -290,8 +290,10 @@ int PbfReader::ReadPbfFile(unordered_set<string> const &nodeKeys, unsigned int t
 		}
 	}
 
-
+	// ---- Sort the generated geometries
+	osmStore.generated_sort(threadNum);
 	osmStore.reportSize();
+
 	return 0;
 }
 

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -78,7 +78,7 @@ void addShapefileAttributes(
 				std::cout << "Didn't recognise Lua output type: " << val << std::endl;
 			}
 
-			attributes->emplace(key, v, 0);
+			attributes->values.emplace(key, v, 0);
 		}
 
 		oo->setAttributeSet(attributeStore.store_set(attributes));		
@@ -102,7 +102,7 @@ void addShapefileAttributes(
 				         break;
 			}
 			
-			attributes->emplace(key, v, 0);
+			attributes->values.emplace(key, v, 0);
 		}
 
 		oo->setAttributeSet(attributeStore.store_set(attributes));		

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -177,7 +177,7 @@ void readShapefile(const Box &clippingBox,
 				if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT_, p, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}
@@ -199,7 +199,7 @@ void readShapefile(const Box &clippingBox,
 					if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 					auto &attributeStore = osmLuaProcessing.getAttributeStore();
-					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
+					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING_, *it, isIndexed, hasName, name, attributeStore.empty_set());
 
 					addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 				}
@@ -272,7 +272,7 @@ void readShapefile(const Box &clippingBox,
 
 				// create OutputObject
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON_, out, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -177,7 +177,7 @@ void readShapefile(const Box &clippingBox,
 				if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT, p, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}
@@ -199,7 +199,7 @@ void readShapefile(const Box &clippingBox,
 					if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 					auto &attributeStore = osmLuaProcessing.getAttributeStore();
-					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
+					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING, *it, isIndexed, hasName, name, attributeStore.empty_set());
 
 					addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 				}
@@ -272,7 +272,7 @@ void readShapefile(const Box &clippingBox,
 
 				// create OutputObject
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, OutputGeometryType::POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON, out, isIndexed, hasName, name, attributeStore.empty_set());
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -67,7 +67,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 	uint tilex = 0, tiley = 0;
 	switch(geomType) {
-		case OutputGeometryType::POINT:
+		case POINT:
 		{
 			Point *p = boost::get<Point>(&geometry);
 			if (p != nullptr) {
@@ -81,7 +81,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			}
 		} break;
 
-		case OutputGeometryType::LINESTRING:
+		case LINESTRING:
 		{
 			oo = new OutputObjectOsmStoreLinestring(
 						geomType, true, layerNum, id,  
@@ -91,7 +91,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			addToTileIndexPolyline(oo, &geometry);
 		} break;
 
-		case OutputGeometryType::POLYGON:
+		case POLYGON:
 		{
 			oo = new OutputObjectOsmStoreMultiPolygon(
 						geomType, true, layerNum, id,

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -15,7 +15,7 @@ ShpMemTiles::ShpMemTiles(OSMStore &osmStore, uint baseZoom)
 // - checkQuery(osmstore, id) lambda, implements:   return geom::covered_by(osmStore.retrieve(id), geom)
 vector<uint> ShpMemTiles::QueryMatchingGeometries(const string &layerName, bool once, Box &box, 
 	function<vector<IndexValue>(const RTree &rtree)> indexQuery, 
-	function<bool(OutputObject &oo)> checkQuery) const {
+	function<bool(OutputObject const &oo)> checkQuery) const {
 	
 	// Find the layer
 	auto f = indices.find(layerName); // f is an RTree
@@ -71,8 +71,8 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 		{
 			Point *p = boost::get<Point>(&geometry);
 			if (p != nullptr) {
-				oo = new OutputObjectOsmStorePoint(
-					geomType, true, layerNum, id, osmStore.store_point(osmStore.shp(), *p), attributes);
+				oo = CreateObject(OutputObjectOsmStorePoint(
+					geomType, true, layerNum, id, osmStore.store_point(osmStore.shp(), *p), attributes));
 				cachedGeometries.push_back(oo);
 
 				tilex =  lon2tilex(p->x(), baseZoom);
@@ -83,9 +83,9 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 		case LINESTRING_:
 		{
-			oo = new OutputObjectOsmStoreLinestring(
+			oo = CreateObject(OutputObjectOsmStoreLinestring(
 						geomType, true, layerNum, id,  
-						osmStore.store_linestring(osmStore.shp(), boost::get<Linestring>(geometry)), attributes);
+						osmStore.store_linestring(osmStore.shp(), boost::get<Linestring>(geometry)), attributes));
 			cachedGeometries.push_back(oo);
 
 			addToTileIndexPolyline(oo, &geometry);
@@ -93,9 +93,9 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 		case POLYGON_:
 		{
-			oo = new OutputObjectOsmStoreMultiPolygon(
+			oo = CreateObject(OutputObjectOsmStoreMultiPolygon(
 						geomType, true, layerNum, id,
-						osmStore.store_multi_polygon(osmStore.shp(), boost::get<MultiPolygon>(geometry)), attributes);
+						osmStore.store_multi_polygon(osmStore.shp(), boost::get<MultiPolygon>(geometry)), attributes));
 			cachedGeometries.push_back(oo);
 			
 			// add to tile index

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -71,8 +71,10 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 		{
 			Point *p = boost::get<Point>(&geometry);
 			if (p != nullptr) {
+	
+				osmStore.store_point(osmStore.shp(), id, *p);
 				oo = CreateObject(OutputObjectOsmStorePoint(
-					geomType, true, layerNum, id, osmStore.store_point(osmStore.shp(), *p), attributes));
+					geomType, layerNum, id, attributes));
 				cachedGeometries.push_back(oo);
 
 				tilex =  lon2tilex(p->x(), baseZoom);
@@ -83,9 +85,9 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 		case LINESTRING_:
 		{
+			osmStore.store_linestring(osmStore.shp(), id, boost::get<Linestring>(geometry));
 			oo = CreateObject(OutputObjectOsmStoreLinestring(
-						geomType, true, layerNum, id,  
-						osmStore.store_linestring(osmStore.shp(), boost::get<Linestring>(geometry)), attributes));
+						geomType, layerNum, id, attributes));
 			cachedGeometries.push_back(oo);
 
 			addToTileIndexPolyline(oo, &geometry);
@@ -93,9 +95,9 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 		case POLYGON_:
 		{
+			osmStore.store_multi_polygon(osmStore.shp(), id, boost::get<MultiPolygon>(geometry));
 			oo = CreateObject(OutputObjectOsmStoreMultiPolygon(
-						geomType, true, layerNum, id,
-						osmStore.store_multi_polygon(osmStore.shp(), boost::get<MultiPolygon>(geometry)), attributes));
+						geomType, layerNum, id, attributes));
 			cachedGeometries.push_back(oo);
 			
 			// add to tile index

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -67,7 +67,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 
 	uint tilex = 0, tiley = 0;
 	switch(geomType) {
-		case POINT:
+		case POINT_:
 		{
 			Point *p = boost::get<Point>(&geometry);
 			if (p != nullptr) {
@@ -81,7 +81,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			}
 		} break;
 
-		case LINESTRING:
+		case LINESTRING_:
 		{
 			oo = new OutputObjectOsmStoreLinestring(
 						geomType, true, layerNum, id,  
@@ -91,7 +91,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 			addToTileIndexPolyline(oo, &geometry);
 		} break;
 
-		case POLYGON:
+		case POLYGON_:
 		{
 			oo = new OutputObjectOsmStoreMultiPolygon(
 						geomType, true, layerNum, id,

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -101,7 +101,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 		OutputObjectRef oo = *jt;
 		if (zoom < oo->minZoom) { continue; }
 
-		if (oo->geomType == OutputGeometryType::POINT) {
+		if (oo->geomType == POINT) {
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();
 			LatpLon pos = buildNodeGeometry(osmStore, *oo, bbox);
 			featurePtr->add_geometry(9);					// moveTo, repeat x1
@@ -121,18 +121,18 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 				continue;
 			}
 
-			if (oo->geomType == OutputGeometryType::POLYGON && filterArea > 0.0) {
+			if (oo->geomType == POLYGON && filterArea > 0.0) {
 				if (geom::area(g)<filterArea) continue;
 			}
 
 			//This may increment the jt iterator
-			if (oo->geomType == OutputGeometryType::LINESTRING && zoom < sharedData.config.combineBelow) {
+			if (oo->geomType == LINESTRING && zoom < sharedData.config.combineBelow) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiLinestring>(g));
 				MultiLinestring reordered;
 				ReorderMultiLinestring(boost::get<MultiLinestring>(g), reordered);
 				g = move(reordered);
 				oo = *jt;
-			} else if (oo->geomType == OutputGeometryType::POLYGON && combinePolygons) {
+			} else if (oo->geomType == POLYGON && combinePolygons) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiPolygon>(g));
 				oo = *jt;
 			}

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -86,9 +86,9 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, OutputObjectsConstIt &jt, Outpu
 			T output;
 			geom::union_(g, to_merge, output);
 			g = move(output);
-		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << std::to_string(oo->objectID) <<"," << err.what() << endl;
-		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
-		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
+		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << static_cast<int>(oo->objectID) <<"," << err.what() << endl;
+		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << static_cast<int>(oo->objectID) << endl;
+		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << static_cast<int>(oo->objectID) << endl;
 		}
 	}
 }
@@ -117,7 +117,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			try {
 				g = buildWayGeometry(osmStore, *oo, bbox);
 			} catch (std::out_of_range &err) {
-				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << std::to_string(oo->objectID) <<"," << err.what() << endl;
+				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << static_cast<int>(oo->objectID) <<"," << err.what() << endl;
 				continue;
 			}
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -86,9 +86,9 @@ void CheckNextObjectAndMerge(OSMStore &osmStore, OutputObjectsConstIt &jt, Outpu
 			T output;
 			geom::union_(g, to_merge, output);
 			g = move(output);
-		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << oo->objectID <<"," << err.what() << endl;
-		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << oo->objectID << endl;
-		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << oo->objectID << endl;
+		} catch (std::out_of_range &err) { cerr << "Geometry out of range " << gt << ": " << std::to_string(oo->objectID) <<"," << err.what() << endl;
+		} catch (boost::bad_get &err) { cerr << "Type error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
+		} catch (geom::inconsistent_turns_exception &err) { cerr << "Inconsistent turns error while processing " << gt << ": " << std::to_string(oo->objectID) << endl;
 		}
 	}
 }
@@ -117,7 +117,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			try {
 				g = buildWayGeometry(osmStore, *oo, bbox);
 			} catch (std::out_of_range &err) {
-				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << oo->objectID <<"," << err.what() << endl;
+				if (verbose) cerr << "Error while processing geometry " << oo->geomType << "," << std::to_string(oo->objectID) <<"," << err.what() << endl;
 				continue;
 			}
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -101,7 +101,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 		OutputObjectRef oo = *jt;
 		if (zoom < oo->minZoom) { continue; }
 
-		if (oo->geomType == POINT) {
+		if (oo->geomType == POINT_) {
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();
 			LatpLon pos = buildNodeGeometry(osmStore, *oo, bbox);
 			featurePtr->add_geometry(9);					// moveTo, repeat x1
@@ -121,18 +121,18 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 				continue;
 			}
 
-			if (oo->geomType == POLYGON && filterArea > 0.0) {
+			if (oo->geomType == POLYGON_ && filterArea > 0.0) {
 				if (geom::area(g)<filterArea) continue;
 			}
 
 			//This may increment the jt iterator
-			if (oo->geomType == LINESTRING && zoom < sharedData.config.combineBelow) {
+			if (oo->geomType == LINESTRING_ && zoom < sharedData.config.combineBelow) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiLinestring>(g));
 				MultiLinestring reordered;
 				ReorderMultiLinestring(boost::get<MultiLinestring>(g), reordered);
 				g = move(reordered);
 				oo = *jt;
-			} else if (oo->geomType == POLYGON && combinePolygons) {
+			} else if (oo->geomType == POLYGON_ && combinePolygons) {
 				CheckNextObjectAndMerge(osmStore, jt, ooSameLayerEnd, bbox, boost::get<MultiPolygon>(g));
 				oo = *jt;
 			}

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -312,6 +312,8 @@ int main(int argc, char* argv[]) {
 		}
 	}
 	
+	// ---- Sort the generated shapes
+	osmStore.shapes_sort(threadNum);
 
 	// ----	Read significant node tags
 


### PR DESCRIPTION
Several optimizations to reduce size of OutputObject:
- Use OsmID instead of handle to lookup generated geometry (OsmID should be 42 bits now)
- Use non-owning reference in tileindex and remove reference count from output object
- Use intrusive pointer for attribute store reference
- Prevent a temporary created in the mmap file in osm store