### PR TITLE
Avoid git during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ endif
 prefix = /usr/local
 
 MANPREFIX := /usr/share/man
-TM_VERSION := $(shell git describe --tags --abbrev=0)
+TM_VERSION ?= $(shell git describe --tags --abbrev=0)
 CXXFLAGS := -O3 -Wall -Wno-unknown-pragmas -Wno-sign-compare -std=c++14 -pthread -fPIE -DTM_VERSION=$(TM_VERSION) $(CONFIG)
 LIB := -L/usr/local/lib -lz $(LUA_LIBS) -lboost_program_options -lsqlite3 -lboost_filesystem -lboost_system -lboost_iostreams -lprotobuf -lshp
 INC := -I/usr/local/include -isystem ./include -I./src $(LUA_CFLAGS)


### PR DESCRIPTION
Follow up to #298.

This should introduce the least intrusive way of getting rid of the `git` dependency in the Makefile (which is not nice as the release files don't contain the necessary git information).

It allows at least to provide a `TM_VERSION` environment variable before building, to avoid the Makefile running into issues with the failing git command.