### PR TITLE
Use rtree for large polygons

### DIFF
--- a/include/geom.h
+++ b/include/geom.h
@@ -77,6 +77,17 @@ void simplify_combine(C &result, T &&new_element)
     } 
 }
 
+/**
+ * \brief Get the envelope of this geometry
+ */
+template<class Geometry>
+static inline Box getEnvelope(Geometry const &g)
+{
+	Box result;
+	boost::geometry::envelope(g, result);
+	return result;
+}
+
 namespace geom = boost::geometry;
 
 template<class GeometryT>

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -31,11 +31,6 @@ public:
 	{ }
 
 	///This must be thread safe!
-	void MergeTileCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords) {
-		MergeTileCoordsAtZoom(zoom, baseZoom, tileIndex, dstCoords);
-	}
-
-	///This must be thread safe!
 	void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, std::vector<OutputObjectRef> &dstTile) {
 		MergeSingleTileDataAtZoom(dstIndex, zoom, baseZoom, tileIndex, dstTile);
 	}
@@ -64,12 +59,11 @@ public:
 		box_rtree.insert(std::make_pair(envelope, oo));
 	}
 
-private:	
-	static void MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, TileCoordinatesSet &dstCoords);
+	static void MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileCoordinatesSet &srcTiles, TileCoordinatesSet &dstCoords);
 	static void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, uint baseZoom, const TileIndex &srcTiles, std::vector<OutputObjectRef> &dstTile);
 };
 
-TileCoordinatesSet GetTileCoordinates(std::vector<class TileDataSource *> const &sources, unsigned int zoom);
+TileCoordinatesSet GetTileCoordinates(Box const &clippingBox, unsigned int baseZoom, unsigned int zoom);
 
 std::vector<OutputObjectRef> GetTileData(std::vector<class TileDataSource *> const &sources, TileCoordinates coordinates, unsigned int zoom);
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -557,7 +557,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 					TileCoordinates index = *it;
 					for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 						if (jt->first->geomType != POLYGON_) continue;
-						if(tileSet.size() > 2) 
+						if(tileSet.size() > 4) 
 							osmMemTiles.CreateObject(getEnvelope(ls), jt->first);
 						else
 							osmMemTiles.AddObject(index, jt->first);
@@ -623,7 +623,10 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 		for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 			TileCoordinates index = *it;
 			for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-				osmMemTiles.AddObject(index, jt->first);
+				if(tileSet.size() >= 4) 
+					osmMemTiles.CreateObject(getEnvelope(mp), jt->first);
+				else
+					osmMemTiles.AddObject(index, jt->first);
 			}
 		}
 	}

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -534,7 +534,8 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 		// create a list of tiles this way passes through (tileSet)
 		unordered_set<TileCoordinates> tileSet;
 		try {
-			insertIntermediateTiles(osmStore.nodeListLinestring(nodeVecPtr->cbegin(),nodeVecPtr->cend()), this->config.baseZoom, tileSet);
+			Linestring ls = osmStore.nodeListLinestring(nodeVecPtr->cbegin(),nodeVecPtr->cend());
+			insertIntermediateTiles(ls, this->config.baseZoom, tileSet);
 
 			// then, for each tile, store the OutputObject for each layer
 			bool polygonExists = false;
@@ -556,7 +557,10 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 					TileCoordinates index = *it;
 					for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 						if (jt->first->geomType != POLYGON_) continue;
-						osmMemTiles.AddObject(index, jt->first);
+						if(tileSet.size() > 2) 
+							osmMemTiles.CreateObject(getEnvelope(ls), jt->first);
+						else
+							osmMemTiles.AddObject(index, jt->first);
 					}
 				}
 			}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -125,8 +125,7 @@ void ShpMemTiles::addToTileIndexByBbox(OutputObjectRef &oo, double minLon, doubl
 	} else {
 		for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
 			for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
-				TileCoordinates index(x, y);
-				AddObject(index, oo);
+				AddObject(TileCoordinates(x, y), oo);
 			}
 		}
 	}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -119,10 +119,15 @@ void ShpMemTiles::addToTileIndexByBbox(OutputObjectRef &oo, double minLon, doubl
 	uint maxTileX =  lon2tilex(maxLon, baseZoom);
 	uint minTileY = latp2tiley(minLatp, baseZoom);
 	uint maxTileY = latp2tiley(maxLatp, baseZoom);
-	for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
-		for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
-			TileCoordinates index(x, y);
-			AddObject(index, oo);
+
+	if((maxTileX - minTileX) * (maxTileY - minTileY) > 2) {
+		CreateObject(Box(Point(minLon, minLatp), Point(maxLon, maxLatp)), oo);
+	} else {
+		for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
+			for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
+				TileCoordinates index(x, y);
+				AddObject(index, oo);
+			}
 		}
 	}
 }

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -72,9 +72,13 @@ TileCoordinatesSet GetTileCoordinates(std::vector<class TileDataSource *> const 
 
 std::vector<OutputObjectRef> GetTileData(std::vector<class TileDataSource *> const &sources, TileCoordinates coordinates, unsigned int zoom)
 {
+	TileBbox bbox(coordinates, zoom);
 	std::vector<OutputObjectRef> data;
-	for(size_t i=0; i<sources.size(); i++)
+
+	for(size_t i=0; i<sources.size(); i++) {
 		sources[i]->MergeSingleTileDataAtZoom(coordinates, zoom, data);
+		sources[i]->MergeSingleTileDataAtZoom(bbox.getTileBox(), data);
+	}
 
 	boost::sort::pdqsort(data.begin(), data.end());
 	data.erase(unique(data.begin(), data.end()), data.end());

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -9,18 +9,17 @@ using namespace std;
 
 typedef std::pair<OutputObjectsConstIt,OutputObjectsConstIt> OutputObjectsConstItPair;
 
-void TileDataSource::MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, TileCoordinatesSet &dstCoords) {
+void TileDataSource::MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileCoordinatesSet &srcTiles, TileCoordinatesSet &dstCoords) {
 	if (zoom==baseZoom) {
 		// at z14, we can just use tileIndex
 		for (auto it = srcTiles.begin(); it!= srcTiles.end(); ++it) {
-			TileCoordinates index = it->first;
-			dstCoords.insert(index);
+			dstCoords.insert(*it);
 		}
 	} else {
 		// otherwise, we need to run through the z14 list, and assign each way
 		// to a tile at our zoom level
 		for (auto it = srcTiles.begin(); it!= srcTiles.end(); ++it) {
-			TileCoordinates index = it->first;
+			TileCoordinates index = *it;
 			TileCoordinate tilex = index.x / pow(2, baseZoom-zoom);
 			TileCoordinate tiley = index.y / pow(2, baseZoom-zoom);
 			TileCoordinates newIndex(tilex, tiley);
@@ -59,15 +58,29 @@ void TileDataSource::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zo
 	}
 }
 
-TileCoordinatesSet GetTileCoordinates(std::vector<class TileDataSource *> const &sources, unsigned int zoom) {
-	TileCoordinatesSet tileCoordinates;
+TileCoordinatesSet GetTileCoordinates(Box const &clippingBox, unsigned int baseZoom, unsigned int zoom) {
+	TileCoordinatesSet srcCoords;
 
 	// Create list of tiles
-	tileCoordinates.clear();
-	for(size_t i=0; i<sources.size(); i++)
-		sources[i]->MergeTileCoordsAtZoom(zoom, tileCoordinates);
+	auto p1 = clippingBox.min_corner();
+	double min_x = lon2tilexf(p1.get<0>(), baseZoom);
+	double max_y = latp2tileyf(p1.get<1>(), baseZoom);
 
-	return tileCoordinates;
+	auto p2 = clippingBox.max_corner();
+	double max_x = lon2tilexf(p2.get<0>(), baseZoom);
+	double min_y = latp2tileyf(p2.get<1>(), baseZoom);
+
+	for(double x = min_x; x < max_x; x += 1) {
+		for(double y = min_y; y < max_y; y += 1) {
+			TileCoordinate tileX1 = static_cast<TileCoordinate>(x);
+			TileCoordinate tileY1 = static_cast<TileCoordinate>(y);
+			srcCoords.insert(TileCoordinates(tileX1, tileY1));
+		}
+	}
+
+	TileCoordinatesSet dstCoords;
+	TileDataSource::MergeTileCoordsAtZoom(zoom, baseZoom, srcCoords, dstCoords);
+	return dstCoords;
 }
 
 std::vector<OutputObjectRef> GetTileData(std::vector<class TileDataSource *> const &sources, TileCoordinates coordinates, unsigned int zoom)

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -271,9 +271,13 @@ int main(int argc, char* argv[]) {
 		cerr << "Couldn't find expected details in JSON file." << endl;
 		return -1;
 	}
+
 	if (hasClippingBox) {
 		cout << "Bounding box " << clippingBox.min_corner().x() << ", " << latp2lat(clippingBox.min_corner().y()) << ", " << 
 		                           clippingBox.max_corner().x() << ", " << latp2lat(clippingBox.max_corner().y()) << endl;
+	} else {
+		cout << "No bounding box found in input file or command line" << endl;
+		return -1;
 	}
 
 	// For each tile, objects to be used in processing
@@ -426,7 +430,8 @@ int main(int argc, char* argv[]) {
 
 		std::deque< std::pair<unsigned int, TileCoordinates> > tile_coordinates;
 		for (uint zoom=sharedData.config.startZoom; zoom<=sharedData.config.endZoom; zoom++) {
-			auto zoom_result = GetTileCoordinates(sources, zoom);
+			auto zoom_result = GetTileCoordinates(clippingBox, sharedData.config.baseZoom, zoom);
+
 			for(auto&& it: zoom_result) {
 				// If we're constrained to a source tile, check we're within it
 				if (srcZ>-1) {


### PR DESCRIPTION
Use rtree only for polygons that cover large areas. 

I actually got Africa converted with this on my 8G machine, it shows quite a significant saving in memory. It stores polygons in the rtree if the polygon covers more than 2 tiles at basezoom. It can also store linestrings, but I saw that this does impact the performance of the conversion. 