### PR TITLE
Do not write layers with write_to attribute to metadata.json

### DIFF
--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -30,6 +30,7 @@ struct LayerDef {
 	bool indexed;
 	std::string indexName;
 	std::map<std::string, uint> attributeMap;
+	bool writeTo;
 };
 
 ///\brief Defines layers used in map rendering

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -27,10 +27,11 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		const std::string &indexName,
 		const std::string &writeTo)  {
 
+	bool isWriteTo = !writeTo.empty();
 	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
 		filterBelow, filterArea, combinePolygonsBelow,
 		source, sourceColumns, allSourceColumns, indexed, indexName,
-		std::map<std::string,uint>() };
+		std::map<std::string,uint>(), isWriteTo };
 	layers.push_back(layer);
 	uint layerNum = layers.size()-1;
 	layerMap[name] = layerNum;
@@ -56,6 +57,9 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 Value LayerDefinition::serialiseToJSONValue(rapidjson::Document::AllocatorType &allocator) const {
 	Value layerArray(kArrayType);
 	for (auto it = layers.begin(); it != layers.end(); ++it) {
+		if (it->writeTo) {
+			continue;
+		}
 		Value fieldObj(kObjectType);
 		for (auto jt = it->attributeMap.begin(); jt != it->attributeMap.end(); ++jt) {
 			Value k(jt->first.c_str(), allocator);


### PR DESCRIPTION
If I create a vector tile set and write the vector tiles as files (instead into an MBTiles file), Tilemaker generates a `metadata.json` file which contains layers defined in `config.json` but which have the `write_to` property set.

That's wrong because that layer does not exist in the vector tiles, it has been merged into another layer.