### PR TITLE
Allow to sort by large numbers

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -149,6 +149,7 @@ public:
 	void AttributeBooleanWithMinZoom(const std::string &key, const bool val, const char minzoom);
 	void MinZoom(const unsigned z);
 	void ZOrder(const int z);
+	void SortableNumber(const int num);
 
 	// Write error if in verbose mode
 	void ProcessingError(const std::string &errStr) {

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -61,7 +61,7 @@ public:
 	}
 
 	void setSortableNumber(const int num) {
-		if (num <= std::numeric_limits<uint32_t>::min() || num >= std::numeric_limits<uint32_t>::max()) {
+		if (num < std::numeric_limits<uint32_t>::min() || num > std::numeric_limits<uint32_t>::max()) {
 			throw std::runtime_error("sortable_number is limited to 4 byte unsigned integer.");
 		}
 		sortable_number = num;

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -38,7 +38,7 @@ class OutputObject {
 
 protected:	
 	OutputObject(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes) 
-		: objectID(id), geomType(type), layer(l), z_order(0),
+		: objectID(id), geomType(type), layer(l), z_order(0), sortable_number(0),
 		  minZoom(0), attributes(attributes)
 	{ }
 
@@ -47,6 +47,7 @@ public:
 	NodeID objectID 			: 42;					// id of way (linestring/polygon) or node (point)
 	uint_least8_t layer 		: 8;					// what layer is it in?
 	int8_t z_order				: 8;					// z_order: used for sorting features within layers
+	uint32_t sortable_number    : 32;                   // a numeric value the features of a layer should be sorted by in reverse order (e.g. area or population)
 	OutputGeometryType geomType : 2;					// point, linestring, polygon
 	unsigned minZoom 			: 4;
 
@@ -57,6 +58,13 @@ public:
 			throw std::runtime_error("z_order is limited to 1 byte signed integer.");
 		}
 		z_order = z;
+	}
+
+	void setSortableNumber(const int num) {
+		if (num <= std::numeric_limits<uint32_t>::min() || num >= std::numeric_limits<uint32_t>::max()) {
+			throw std::runtime_error("sortable_number is limited to 4 byte unsigned integer.");
+		}
+		sortable_number = num;
 	}
 
 	void setMinZoom(unsigned z) {

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -56,6 +56,7 @@ OsmLuaProcessing::OsmLuaProcessing(
 		.addOverloadedFunctions("AttributeBoolean", &OsmLuaProcessing::AttributeBoolean, &OsmLuaProcessing::AttributeBooleanWithMinZoom)
 		.addFunction("MinZoom", &OsmLuaProcessing::MinZoom)
 		.addFunction("ZOrder", &OsmLuaProcessing::ZOrder)
+		.addFunction("SortableNumber", &OsmLuaProcessing::SortableNumber)
 	);
 	if (luaState["attribute_function"]) {
 		supportsRemappingShapefiles = true;
@@ -459,6 +460,12 @@ void OsmLuaProcessing::MinZoom(const unsigned z) {
 void OsmLuaProcessing::ZOrder(const int z) {
 	if (outputs.size()==0) { ProcessingError("Can't set z_order if no Layer set"); return; }
 	outputs.back().first->setZOrder(z);
+}
+
+// Set sortable_number
+void OsmLuaProcessing::SortableNumber(const int num) {
+	if (outputs.size()==0) { ProcessingError("Can't set sortable_number if no Layer set"); return; }
+	outputs.back().first->setSortableNumber(num);
 }
 
 // Record attribute name/type for vector_layers table

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -209,6 +209,7 @@ bool operator==(const OutputObjectRef x, const OutputObjectRef y) {
 	return
 		x->layer == y->layer &&
 		x->z_order == y->z_order &&
+		x->sortable_number == y->sortable_number &&
 		x->geomType == y->geomType &&
 		x->attributes == y->attributes &&
 		x->objectID == y->objectID;
@@ -223,6 +224,10 @@ bool operator<(const OutputObjectRef x, const OutputObjectRef y) {
 	if (x->layer > y->layer) return false;
 	if (x->z_order < y->z_order) return true;
 	if (x->z_order > y->z_order) return false;
+	// Comparison inverted for area because large features should appear first in the vector tile
+	// if the area was set.
+	if (x->sortable_number > y->sortable_number) return true;
+	if (x->sortable_number < y->sortable_number) return false;
 	if (x->geomType < y->geomType) return true;
 	if (x->geomType > y->geomType) return false;
 	if (x->attributes.get() < y->attributes.get()) return true;


### PR DESCRIPTION
# Description

At Geofabrik, we create raster tiles from vector tiles using Mapnik and its OGR input plugin which cannot sort the features. However, some features should be sorted. Cities by population (e.g. Frankfurt am Main vs. Offenbach am Main), areas by their size (lacking usage of multipolygons by mappers) are common examples.

This pull request adds a callback function to store a number (32 bit unsigned integer) which can be calculated by the Lua script. I decided to use 32 bit only because it is sufficient for most use cases and therefore a good compromise between memory and perfection. For areas, it' wise to convert the sizes from square metre to hectar to get the number smaller by the factor of 10^4. For cities.

# Performance Tests

Performance tests with 64 cores, 504 GB RAM, cache on NVMe (if enabled), configuration from [geofabrik-basicvt-tilemaker commit fbbe9a66d30cacb3314a6d43d5e5a37e95254b8e](https://github.com/geofabrik/geofabrik-basicvt-tilemaker/tree/fbbe9a66d30cacb3314a6d43d5e5a37e95254b8e):

`tilemaker --input /planet/current-planet.osm.pbf --output /mnt/vectortiles/gf-vt-basic-planet/ --store /nvme/michael/tilemaker-cache.dat --config config.json --process process.lua --bbox -180,-86,180,86`

* this branch: 15 hours 45 minutes, 328 GB RAM
* master branch (calls to `SortableNumber` commented out): 16 hours 18 seconds, 326 GB RAM

Performance tests without `--store` for the whole planet are still running.

`tilemaker --input /extracts/europe/germany.osm.pbf --output /mnt/vectortiles/gf-vt-basic-germany/ --store /nvme/michael/tilemaker-cache.dat --config config.json --process process.lua`

* this branch: 14 minutes 8 seconds, 27.5 GB RAM
* master branch (calls to `SortableNumber` commented out): 14 minutes 8 seconds, 27.2 GB RAM

`tilemaker --input /extracts/europe/germany.osm.pbf --output /mnt/vectortiles/gf-vt-basic-germany --config config.json --process process.lua`:

* this branch: 14 minutes 2 seconds, 36 GB RAM
* master branch (calls to `SortableNumber` commented out): 13 minutes 57 seconds, 36 GB RAM