### PR TITLE
Fix logic error about id passing for way

### DIFF
--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -503,7 +503,7 @@ void OsmLuaProcessing::setNode(NodeID id, LatpLon node, const tag_map_t &tags) {
 void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map_t &tags) {
 	reset();
 	osmID = (wayId & OSMID_MASK) | OSMID_WAY;
-	originalOsmID = osmID;
+	originalOsmID = wayId;
 	isWay = true;
 	isRelation = false;
 	nodeVecPtr = &nodeVec;


### PR DESCRIPTION
Shame it took me a while to figure out why way IDs are invalid in generated MVT.

@kleunen 
Looks like this issue appears after a9a54f9 (#307):
```diff
 void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map_t &tags) {
        reset();
-       osmID = wayId;
+       osmID = (wayId & OSMID_MASK) | OSMID_WAY;
        originalOsmID = osmID;  <================== osmID is not the original way id
```