### PR TITLE
Initialise OutputObjects with layer minzoom

### DIFF
--- a/include/output_object.h
+++ b/include/output_object.h
@@ -37,9 +37,9 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
 class OutputObject {
 
 protected:	
-	OutputObject(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes) 
+	OutputObject(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes, uint mz) 
 		: objectID(id), geomType(type), layer(l), z_order(0),
-		  minZoom(0), attributes(attributes)
+		  minZoom(mz), attributes(attributes)
 	{ }
 
 
@@ -86,8 +86,8 @@ public:
 class OutputObjectOsmStorePoint : public OutputObject
 {
 public:
-	OutputObjectOsmStorePoint(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes)
-		: OutputObject(type, l, id, attributes)
+	OutputObjectOsmStorePoint(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes, uint minzoom)
+		: OutputObject(type, l, id, attributes, minzoom)
 	{ 
 		assert(type == POINT_);
 	}
@@ -96,8 +96,8 @@ public:
 class OutputObjectOsmStoreLinestring : public OutputObject
 {
 public:
-	OutputObjectOsmStoreLinestring(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes)
-		: OutputObject(type, l, id, attributes)
+	OutputObjectOsmStoreLinestring(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes, uint minzoom)
+		: OutputObject(type, l, id, attributes, minzoom)
 	{ 
 		assert(type == LINESTRING_);
 	}
@@ -106,8 +106,8 @@ public:
 class OutputObjectOsmStoreMultiPolygon : public OutputObject
 {
 public:
-	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes)
-		: OutputObject(type, l, id, attributes)
+	OutputObjectOsmStoreMultiPolygon(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes, uint minzoom)
+		: OutputObject(type, l, id, attributes, minzoom)
 	{ 
 		assert(type == POLYGON_);
 	}

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -16,7 +16,7 @@ public:
 		const std::string &layerName, 
 		enum OutputGeometryType geomType,
 		Geometry geometry, 
-		bool isIndexed, bool hasName, const std::string &name, AttributeStoreRef attributes);
+		bool isIndexed, bool hasName, const std::string &name, AttributeStoreRef attributes, uint minzoom);
 
 	void AddObject(TileCoordinates const &index, OutputObjectRef const &oo) {
 		tileIndex[index].push_back(oo);

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -308,6 +308,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 		throw out_of_range("ERROR: Layer(): a layer named as \"" + layerName + "\" doesn't exist.");
 	}
 
+	uint layerMinZoom = layers.layers[layers.layerMap[layerName]].minzoom;
 	OutputGeometryType geomType = isWay ? (area ? POLYGON_ : LINESTRING_) : POINT_;
 	try {
 		if (geomType==POINT_) {
@@ -317,7 +318,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
 			osmStore.store_point(osmStore.osm(), osmID, p);
 			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(geomType, 
-							layers.layerMap[layerName], osmID, attributeStore.empty_set()));
+							layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
             return;
 		}
@@ -347,7 +348,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
 			osmStore.store_multi_polygon(osmStore.osm(), osmID, mp);
 			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreMultiPolygon(geomType, 
-							layers.layerMap[layerName], osmID, attributeStore.empty_set()));
+							layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 		}
 		else if (geomType==LINESTRING_) {
@@ -358,7 +359,7 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
 			osmStore.store_linestring(osmStore.osm(), osmID, ls);
 			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreLinestring(geomType, 
-						layers.layerMap[layerName], osmID, attributeStore.empty_set()));
+						layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 		}
 	} catch (std::invalid_argument &err) {
@@ -371,7 +372,8 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		throw out_of_range("ERROR: LayerAsCentroid(): a layer named as \"" + layerName + "\" doesn't exist.");
 	}	
 
-    Point geomp;
+	uint layerMinZoom = layers.layers[layers.layerMap[layerName]].minzoom;
+	Point geomp;
 	try {
 		geomp = calculateCentroid();
 		if(geom::is_empty(geomp)) {
@@ -392,7 +394,7 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 
 	osmStore.store_point(osmStore.osm(), osmID, geomp);
 	OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(POINT_,
-					layers.layerMap[layerName], osmID, attributeStore.empty_set()));
+					layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
 	outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 }
 

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -177,7 +177,7 @@ void readShapefile(const Box &clippingBox,
 				if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT_, p, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT_, p, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}
@@ -199,7 +199,7 @@ void readShapefile(const Box &clippingBox,
 					if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 					auto &attributeStore = osmLuaProcessing.getAttributeStore();
-					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING_, *it, isIndexed, hasName, name, attributeStore.empty_set());
+					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING_, *it, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
 
 					addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 				}
@@ -272,7 +272,7 @@ void readShapefile(const Box &clippingBox,
 
 				// create OutputObject
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON_, out, isIndexed, hasName, name, attributeStore.empty_set());
+				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON_, out, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -52,7 +52,7 @@ void ShpMemTiles::CreateNamedLayerIndex(const std::string &layerName) {
 
 OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 	const std::string &layerName, enum OutputGeometryType geomType,
-	Geometry geometry, bool isIndexed, bool hasName, const std::string &name, AttributeStoreRef attributes) {		
+	Geometry geometry, bool isIndexed, bool hasName, const std::string &name, AttributeStoreRef attributes, uint minzoom) {
 
 	geom::model::box<Point> box;
 	geom::envelope(geometry, box);
@@ -74,7 +74,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 	
 				osmStore.store_point(osmStore.shp(), id, *p);
 				oo = CreateObject(OutputObjectOsmStorePoint(
-					geomType, layerNum, id, attributes));
+					geomType, layerNum, id, attributes, minzoom));
 				cachedGeometries.push_back(oo);
 
 				tilex =  lon2tilex(p->x(), baseZoom);
@@ -87,7 +87,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 		{
 			osmStore.store_linestring(osmStore.shp(), id, boost::get<Linestring>(geometry));
 			oo = CreateObject(OutputObjectOsmStoreLinestring(
-						geomType, layerNum, id, attributes));
+						geomType, layerNum, id, attributes, minzoom));
 			cachedGeometries.push_back(oo);
 
 			addToTileIndexPolyline(oo, &geometry);
@@ -97,7 +97,7 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 		{
 			osmStore.store_multi_polygon(osmStore.shp(), id, boost::get<MultiPolygon>(geometry));
 			oo = CreateObject(OutputObjectOsmStoreMultiPolygon(
-						geomType, layerNum, id, attributes));
+						geomType, layerNum, id, attributes, minzoom));
 			cachedGeometries.push_back(oo);
 			
 			// add to tile index


### PR DESCRIPTION
At present an object's `minZoom` property can be either a zoom level, or 0 to mean "use the minzoom for the layer".

When we assemble a list of OutputObjectRefs for a tile, we filter by object minzoom (in `TileDataSource::MergeSingleTileDataAtZoom`), but not by layer minzoom. We only look at the latter when writing the object.

Consequently the list of OutputObjectRefs for a low-zoom tile can contain many that we won't end up writing. For a planet-sized extract at the lowest zoom levels, this can be several GB.

This PR initialises each OutputObject with the minzoom for its layer, rather than 0, so that they can be filtered earlier. When running for most of the planet, this cuts peak memory consumption from ~115GB to ~110GB (test run using #323 too).

There's still a big memory spike when we start to write out tiles. I think this might be because we're creating lists of OutputObjectRefs for 16 big tiles at once (at z0 and z1). We could perhaps offer an option to generate z0/z1/z2(?) single-threaded, which would be a little slower but would minimise the memory spike.