### PR TITLE
Revert "Use artificial IDs for OutputObject after 1st use"

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -76,9 +76,6 @@ public:
 	 */
 	void setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags);
 
-	// Refresh way ID in case of multiple layers per object
-	void refreshOsmID();
-
 	// ----	Metadata queries called from Lua
 
 	// Get the ID of the current object
@@ -198,13 +195,9 @@ private:
 	class OsmMemTiles &osmMemTiles;
 	AttributeStore &attributeStore;			// key/value store
 
-	uint64_t osmID;							///< ID of OSM object
+	uint64_t osmID;							///< ID of OSM object (relations have decrementing way IDs)
 	int64_t originalOsmID;					///< Original OSM object ID
 	bool isWay, isRelation, isClosed;		///< Way, node, relation?
-	bool osmIDHasBeenUsed;					// whether we've written a layer with this ID yet
-	uint64_t spareWayID = OSMID_WAY | OSMID_MASK;			// if we have >1 layers per OSM object, we need to generate new IDs as keys
-	uint64_t spareNodeID = OSMID_NODE | OSMID_MASK;			//  |
-	uint64_t spareRelationID = OSMID_RELATION | OSMID_MASK;	//  |
 
 	int32_t lon,latp;						///< Node coordinates
 	NodeVec const *nodeVecPtr;

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -316,7 +316,6 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
             if(!CorrectGeometry(p)) return;
 
-			refreshOsmID();
 			osmStore.store_point(osmStore.osm(), osmID, p);
 			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(geomType, 
 							layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
@@ -347,7 +346,6 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
             if(!CorrectGeometry(mp)) return;
 
-			refreshOsmID();
 			osmStore.store_multi_polygon(osmStore.osm(), osmID, mp);
 			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreMultiPolygon(geomType, 
 							layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
@@ -359,7 +357,6 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
             if(!CorrectGeometry(ls)) return;
 
-			refreshOsmID();
 			osmStore.store_linestring(osmStore.osm(), osmID, ls);
 			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreLinestring(geomType, 
 						layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
@@ -395,7 +392,6 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
-	refreshOsmID();
 	osmStore.store_point(osmStore.osm(), osmID, geomp);
 	OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStorePoint(POINT_,
 					layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
@@ -425,14 +421,6 @@ std::vector<double> OsmLuaProcessing::Centroid() {
 	return std::vector<double> { latp2lat(c.y()/10000000.0), c.x()/10000000.0 };
 }
 
-// If we have more than one layer for a single OSM object,
-// we need to generate a new key for the OutputObject
-void OsmLuaProcessing::refreshOsmID() {
-	if (!osmIDHasBeenUsed) { osmIDHasBeenUsed = true; }
-	else if (isWay)        { osmID = spareWayID--; }
-	else if (isRelation)   { osmID = spareRelationID--; }
-	else                   { osmID = spareNodeID--; }
-}
 
 // Set attributes in a vector tile's Attributes table
 void OsmLuaProcessing::Attribute(const string &key, const string &val) { AttributeWithMinZoom(key,val,0); }
@@ -491,7 +479,6 @@ void OsmLuaProcessing::setNode(NodeID id, LatpLon node, const tag_map_t &tags) {
 
 	reset();
 	osmID = (id & OSMID_MASK) | OSMID_NODE;
-	osmIDHasBeenUsed = false;
 	originalOsmID = id;
 	isWay = false;
 	isRelation = false;
@@ -518,7 +505,6 @@ void OsmLuaProcessing::setNode(NodeID id, LatpLon node, const tag_map_t &tags) {
 void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map_t &tags) {
 	reset();
 	osmID = (wayId & OSMID_MASK) | OSMID_WAY;
-	osmIDHasBeenUsed = false;
 	originalOsmID = wayId;
 	isWay = true;
 	isRelation = false;
@@ -595,7 +581,6 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags) {
 	reset();
 	osmID = (relationId & OSMID_MASK) | OSMID_RELATION;
-	osmIDHasBeenUsed = false;
 	originalOsmID = relationId;
 	isWay = true;
 	isRelation = true;


### PR DESCRIPTION
This is proving troublesome and needs further investigation.

Reverts systemed/tilemaker#357