### PR TITLE
(Non-multipolygon) relation support

### DIFF
--- a/docs/RELATIONS.md
+++ b/docs/RELATIONS.md
@@ -1,0 +1,66 @@
+## Relations
+
+Tilemaker has (as yet not complete) support for reading relations in the Lua process scripts. This means you can support route and boundary relations when creating your vector tiles.
+
+Note that relation support is in its early stages and behaviour may change between point versions.
+
+
+### Multipolygon relations
+
+Multipolygon relations are supported natively by tilemaker; you do not need to write special Lua code for them. When a multipolygon is read, tilemaker constructs the geometry as normal, and passes the tags to `way_function` just as it would a simple area.
+
+
+### Reading relation memberships
+
+You can set your Lua script so that `way_function` is able to access the relations that the way is a member of. You would use this, for example, if you wanted to read road numbers from a relation, or to colour roads that are part of a bus route differently.
+
+This is a two-stage process: first, when reading relations, indicate that these should be considered ("accepted"); then, when reading ways in `way_function`, you can access the relation tags.
+
+#### Stage 1: accepting relations
+
+To define which relations should be accepted, add a `relation_scan_function`:
+
+    function relation_scan_function(relation)
+      if relation:Find("type")=="route" and relation:Find("route")=="bicycle" then
+        local network = relation:Find("network")
+        if network=="ncn" then relation:Accept() end
+      end
+    end
+
+This function takes the relation as its sole argument. Examine the tags using `relation:Find(key)` as normal. (You can also use `relation:Holds(key)` and `relation:Id()`.) If you want to use this relation, call `relation:Accept()`.
+
+#### Stage 2: accessing relations from ways
+
+Now that you've accepted the relations, they will be available from `way_function`. They are accessed using an iterator (`way:NextRelation()`) which reads each relation for that way in turn, returning nil when there are no more relations available. Once you have accessed a relation with the iterator, you can read its tags with `way:FindInRelation(key)`. For example:
+
+    while true do
+      local rel = way:NextRelation()
+      if not rel then break end
+      print ("Part of route "..way:FindInRelation("ref"))
+    end
+
+
+### Writing relation geometries
+
+You can also construct complete multi-linestring geometries from relations. Use this if, for example, you want a geometry for a bike or bus route that you can show at lower zoom levels, or draw with a continuous pattern.
+
+First, make sure that you have accepted the relations using `relation_scan_function` as above.
+
+Then write a `relation_function`, which works in the same way as `way_function` would:
+
+    function relation_function(relation)
+      if relation:Find("type")=="route" and relation:Find("route")=="bicycle" then
+        relation:Layer("bike_routes", false)
+        relation:Attribute("class", relation:Find("network"))
+        relation:Attribute("ref", relation:Find("ref"))
+      end
+    end
+
+
+### Not supported
+
+Tilemaker does not yet support:
+
+- relation roles
+- nested relations
+- nodes in relations

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -81,7 +81,7 @@ public:
 	 * (note that we store relations as ways with artificial IDs, and that
 	 *  we use decrementing positive IDs to give a bit more space for way IDs)
 	 */
-	void setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags);
+	void setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags, bool isNativeMP);
 
 	// Refresh way ID in case of multiple layers per object
 	void refreshOsmID();
@@ -182,6 +182,8 @@ public:
 
 	const Polygon &polygonCached();
 
+	const MultiLinestring &multiLinestringCached();
+
 	const MultiPolygon &multiPolygonCached();
 
 	inline AttributeStore &getAttributeStore() { return attributeStore; }
@@ -194,6 +196,7 @@ private:
 		outerWayVecPtr = nullptr;
 		innerWayVecPtr = nullptr;
 		linestringInited = false;
+		multiLinestringInited = false;
 		polygonInited = false;
 		multiPolygonInited = false;
 		relationAccepted = false;
@@ -235,6 +238,8 @@ private:
 	bool linestringInited;
 	Polygon polygonCache;
 	bool polygonInited;
+	MultiLinestring multiLinestringCache;
+	bool multiLinestringInited;
 	MultiPolygon multiPolygonCache;
 	bool multiPolygonInited;
 

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -54,6 +54,10 @@ public:
 
 	// Has this object been assigned to any layers?
 	bool empty();
+	
+	// Do we have Lua routines for non-MP relations?
+	bool canReadRelations();
+	bool canWriteRelations();
 
 	// Shapefile tag remapping
 	bool canRemapShapefiles();
@@ -63,6 +67,9 @@ public:
 	// ----	Data loading methods
 
 	using tag_map_t = boost::container::flat_map<std::string, std::string>;
+
+	// Scan non-MP relation
+	bool scanRelation(WayID id, const tag_map_t &tags);
 
 	/// \brief We are now processing a significant node
 	void setNode(NodeID id, LatpLon node, const tag_map_t &tags);
@@ -152,6 +159,11 @@ public:
 	void AttributeBooleanWithMinZoom(const std::string &key, const bool val, const char minzoom);
 	void MinZoom(const double z);
 	void ZOrder(const double z);
+	
+	// Relation scan support
+	kaguya::optional<int> NextRelation();
+	std::string FindInRelation(const std::string &key);
+	void Accept();
 
 	// Write error if in verbose mode
 	void ProcessingError(const std::string &errStr) {
@@ -184,6 +196,8 @@ private:
 		linestringInited = false;
 		polygonInited = false;
 		multiPolygonInited = false;
+		relationAccepted = false;
+		relationSubscript = -1;
 	}
 
 	const inline Point getPoint() {
@@ -194,6 +208,8 @@ private:
 
 	kaguya::State luaState;
 	bool supportsRemappingShapefiles;
+	bool supportsReadingRelations;
+	bool supportsWritingRelations;
 	const class ShpMemTiles &shpMemTiles;
 	class OsmMemTiles &osmMemTiles;
 	AttributeStore &attributeStore;			// key/value store
@@ -205,6 +221,10 @@ private:
 	uint64_t spareWayID = OSMID_WAY | OSMID_MASK;			// if we have >1 layers per OSM object, we need to generate new IDs as keys
 	uint64_t spareNodeID = OSMID_NODE | OSMID_MASK;			//  |
 	uint64_t spareRelationID = OSMID_RELATION | OSMID_MASK;	//  |
+
+	bool relationAccepted;					// in scanRelation, whether we're using a non-MP relation
+	std::vector<WayID> relationList;		// in processWay, list of relations this way is in
+	int relationSubscript = -1;				// in processWay, position in the relation list
 
 	int32_t lon,latp;						///< Node coordinates
 	NodeVec const *nodeVecPtr;

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -15,7 +15,7 @@
 #include "osmformat.pb.h"
 #include "vector_tile.pb.h"
 
-enum OutputGeometryType { POINT_, LINESTRING_, POLYGON_ };
+enum OutputGeometryType { POINT_, LINESTRING_, MULTILINESTRING_, POLYGON_ };
 
 #define OSMID_TYPE_OFFSET	40
 #define OSMID_MASK 		((1L<<OSMID_TYPE_OFFSET)-1)
@@ -102,6 +102,17 @@ public:
 		assert(type == LINESTRING_);
 	}
 };
+
+class OutputObjectOsmStoreMultiLinestring : public OutputObject
+{
+public:
+	OutputObjectOsmStoreMultiLinestring(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeStoreRef attributes, uint minzoom)
+		: OutputObject(type, l, id, attributes, minzoom)
+	{ 
+		assert(type == MULTILINESTRING_);
+	}
+};
+
 
 class OutputObjectOsmStoreMultiPolygon : public OutputObject
 {

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -33,6 +33,17 @@ public:
 			pbfreader_generate_stream const &generate_stream,
 			pbfreader_generate_output const &generate_output);
 
+	// Read tags into a map from a way/node/relation
+	using tag_map_t = boost::container::flat_map<std::string, std::string>;
+	template<typename T>
+	void readTags(T &pbfObject, PrimitiveBlock const &pb, tag_map_t &tags) {
+		auto keysPtr = pbfObject.mutable_keys();
+		auto valsPtr = pbfObject.mutable_vals();
+		for (uint n=0; n < pbfObject.keys_size(); n++) {
+			tags[pb.stringtable().s(keysPtr->Get(n))] = pb.stringtable().s(valsPtr->Get(n));
+		}
+	}
+
 private:
 	bool ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::pair<std::size_t, std::size_t> progress, std::size_t datasize, std::unordered_set<std::string> const &nodeKeys, ReadPhase phase = ReadPhase::All);
 	bool ReadNodes(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb, const std::unordered_set<int> &nodeKeyPositions);
@@ -43,7 +54,7 @@ private:
 
 	/// Find a string in the dictionary
 	static int findStringPosition(PrimitiveBlock const &pb, char const *str);
-
+	
 	OSMStore &osmStore;
 };
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -126,6 +126,7 @@ string OsmLuaProcessing::Find(const string& key) const {
 
 vector<string> OsmLuaProcessing::FindIntersecting(const string &layerName) {
 	if      (!isWay   ) { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, getPoint())); }
+	else if (!isClosed && isRelation) { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, multiLinestringCached())); }
 	else if (!isClosed) { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, linestringCached())); }
 	else if (isRelation){ return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, multiPolygonCached())); }
 	else                { return shpMemTiles.namesOfGeometries(intersectsQuery(layerName, false, polygonCached())); }
@@ -134,6 +135,7 @@ vector<string> OsmLuaProcessing::FindIntersecting(const string &layerName) {
 bool OsmLuaProcessing::Intersects(const string &layerName) {
 	if      (!isWay   ) { return !intersectsQuery(layerName, true, getPoint()).empty(); }
 	else if (!isClosed) { return !intersectsQuery(layerName, true, linestringCached()).empty(); }
+	else if (!isClosed && isRelation) { return !intersectsQuery(layerName, true, multiLinestringCached()).empty(); }
 	else if (isRelation){ return !intersectsQuery(layerName, true, multiPolygonCached()).empty(); }
 	else                { return !intersectsQuery(layerName, true, polygonCached()).empty(); }
 }
@@ -141,6 +143,7 @@ bool OsmLuaProcessing::Intersects(const string &layerName) {
 vector<string> OsmLuaProcessing::FindCovering(const string &layerName) {
 	if      (!isWay   ) { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, getPoint())); }
 	else if (!isClosed) { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, linestringCached())); }
+	else if (!isClosed && isRelation) { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, multiLinestringCached())); }
 	else if (isRelation){ return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, multiPolygonCached())); }
 	else                { return shpMemTiles.namesOfGeometries(coveredQuery(layerName, false, polygonCached())); }
 }
@@ -148,6 +151,7 @@ vector<string> OsmLuaProcessing::FindCovering(const string &layerName) {
 bool OsmLuaProcessing::CoveredBy(const string &layerName) {
 	if      (!isWay   ) { return !coveredQuery(layerName, true, getPoint()).empty(); }
 	else if (!isClosed) { return !coveredQuery(layerName, true, linestringCached()).empty(); }
+	else if (!isClosed && isRelation) { return !coveredQuery(layerName, true, multiLinestringCached()).empty(); }
 	else if (isRelation){ return !coveredQuery(layerName, true, multiPolygonCached()).empty(); }
 	else                { return !coveredQuery(layerName, true, polygonCached()).empty(); }
 }
@@ -215,7 +219,6 @@ std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool o
 // Returns whether it is closed polygon
 bool OsmLuaProcessing::IsClosed() const {
 	if (!isWay) return false; // nonsense: it isn't a way
-	if (isRelation) return true; // TODO: check it when non-multipolygon are supported
 	return isClosed;
 }
 
@@ -278,17 +281,17 @@ double OsmLuaProcessing::Length() {
 const Linestring &OsmLuaProcessing::linestringCached() {
 	if (!linestringInited) {
 		linestringInited = true;
-
-		if (isRelation) {
-			//A relation is being treated as a linestring, which might be
-			//caused by bug in the Lua script
-			linestringCache = OSMStore::wayListLinestring(osmStore.wayListMultiPolygon(
-				outerWayVecPtr->cbegin(), outerWayVecPtr->cend(), innerWayVecPtr->begin(), innerWayVecPtr->cend()));
-		} else if (isWay) {
-			linestringCache = osmStore.nodeListLinestring(nodeVecPtr->cbegin(),nodeVecPtr->cend());
-		}
+		linestringCache = osmStore.nodeListLinestring(nodeVecPtr->cbegin(),nodeVecPtr->cend());
 	}
 	return linestringCache;
+}
+
+const MultiLinestring &OsmLuaProcessing::multiLinestringCached() {
+	if (!multiLinestringInited) {
+		multiLinestringInited = true;
+		multiLinestringCache = osmStore.wayListMultiLinestring(outerWayVecPtr->cbegin(), outerWayVecPtr->cend());
+	}
+	return multiLinestringCache;
 }
 
 const Polygon &OsmLuaProcessing::polygonCached() {
@@ -318,7 +321,8 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 	}
 
 	uint layerMinZoom = layers.layers[layers.layerMap[layerName]].minzoom;
-	OutputGeometryType geomType = isWay ? (area ? POLYGON_ : LINESTRING_) : POINT_;
+	OutputGeometryType geomType = isRelation ? (area ? POLYGON_ : MULTILINESTRING_ ) :
+	                                   isWay ? (area ? POLYGON_ : LINESTRING_) : POINT_;
 	try {
 		if (geomType==POINT_) {
 			Point p = Point(lon, latp);
@@ -359,6 +363,22 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 			refreshOsmID();
 			osmStore.store_multi_polygon(osmStore.osm(), osmID, mp);
 			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreMultiPolygon(geomType, 
+							layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
+			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
+		}
+		else if (geomType==MULTILINESTRING_) {
+			// multilinestring
+			MultiLinestring mls;
+			try {
+				mls = multiLinestringCached();
+			} catch(std::out_of_range &err) {
+				cout << "In relation " << originalOsmID << ": " << err.what() << endl;
+				return;
+			}
+			if (!CorrectGeometry(mls)) return;
+			refreshOsmID();
+			osmStore.store_multi_linestring(osmStore.osm(), osmID, mls);
+			OutputObjectRef oo = osmMemTiles.CreateObject(OutputObjectOsmStoreMultiLinestring(geomType, 
 							layers.layerMap[layerName], osmID, attributeStore.empty_set(), layerMinZoom));
 			outputs.push_back(std::make_pair(oo, attributeStore.empty_set()));
 		}
@@ -638,14 +658,14 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 // We are now processing a relation
 // (note that we store relations as ways with artificial IDs, and that
 //  we use decrementing positive IDs to give a bit more space for way IDs)
-void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags) {
+void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags, bool isNativeMP) {
 	reset();
 	osmID = (relationId & OSMID_MASK) | OSMID_RELATION;
 	osmIDHasBeenUsed = false;
 	originalOsmID = relationId;
 	isWay = true;
 	isRelation = true;
-	isClosed = true; // TODO: change this when we support route relations
+	isClosed = isNativeMP;
 
 	nodeVecPtr = nullptr;
 	outerWayVecPtr = &outerWayVec;
@@ -655,10 +675,13 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 	bool ok = true;
 	if (ok) {
 		//Start Lua processing for relation
-		luaState["way_function"](this);
+		luaState[isNativeMP ? "way_function" : "relation_function"](this);
 	}
+	
+	if (this->empty()) return;
 
-	if (!this->empty()) {								
+	// Assemble multipolygon
+	if (isClosed) {
 		MultiPolygon mp;
 		try {
 			// for each tile the relation may cover, put the output objects.
@@ -690,6 +713,33 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 			TileCoordinates index = *it;
 			for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 				osmMemTiles.AddObject(index, jt->first);
+			}
+		}
+
+	// Assemble multilinestring
+	} else {
+		MultiLinestring mls;
+		try {
+			mls = osmStore.wayListMultiLinestring(outerWayVecPtr->cbegin(), outerWayVecPtr->cend());
+		} catch(std::out_of_range &err) {
+			cout << "In relation " << originalOsmID << ": " << err.what() << endl;
+			return;
+		}
+
+		// Store attributes
+		for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
+			jt->first->setAttributeSet(attributeStore.store_set(jt->second));		
+		}
+
+		// Calculate tileset and then insert outputobject for each one
+		for (Linestring ls : mls) {
+			unordered_set<TileCoordinates> tileSet;
+			insertIntermediateTiles(ls, this->config.baseZoom, tileSet);
+			for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
+				TileCoordinates index = *it;
+				for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
+					osmMemTiles.AddObject(index, jt->first);
+				}
 			}
 		}
 	}

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -19,6 +19,9 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
 		case LINESTRING_:
 			os << "LINESTRING";
 			break;
+		case MULTILINESTRING_:
+			os << "MULTILINESTRING";
+			break;
 		case POLYGON_:
 			os << "POLYGON";
 			break;
@@ -103,6 +106,15 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 
 			MultiLinestring result;
 			geom::intersection(out, bbox.getExtendBox(), result);
+			return result;
+		}
+
+		case MULTILINESTRING_:
+		{
+			auto const &mls = osmStore.retrieve_multi_linestring((oo.objectID >> OSMID_TYPE_OFFSET) > 0 ? osmStore.osm() : osmStore.shp(), oo.objectID);
+			// investigate whether filtering the constituent linestrings improves performance
+			MultiLinestring result;
+			geom::intersection(mls, bbox.getExtendBox(), result);
 			return result;
 		}
 

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -85,12 +85,8 @@ bool PbfReader::ReadWays(OsmLuaProcessing &output, PrimitiveGroup &pg, Primitive
 			}
 
 			try {
-				auto keysPtr = pbfWay.mutable_keys();
-				auto valsPtr = pbfWay.mutable_vals();
-				boost::container::flat_map<std::string, std::string> tags;
-				for (uint n=0; n < pbfWay.keys_size(); n++) {
-					tags[pb.stringtable().s(keysPtr->Get(n))] = pb.stringtable().s(valsPtr->Get(n));
-				}
+				tag_map_t tags;
+				readTags(pbfWay, pb, tags);
 
 				// If we need it for later, store the way's nodes in the global way store
 				if (osmStore.way_is_used(wayId)) {
@@ -113,7 +109,6 @@ bool PbfReader::ReadWays(OsmLuaProcessing &output, PrimitiveGroup &pg, Primitive
 
 bool PbfReader::ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb) {
 	// Scan relations to see which ways we need to save
-	// as with ReadRelations, we currently just parse multipolygons
 	if (pg.relations_size()==0) return false;
 
 	int typeKey = findStringPosition(pb, "type");
@@ -121,13 +116,23 @@ bool PbfReader::ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 
 	for (int j=0; j<pg.relations_size(); j++) {
 		Relation pbfRelation = pg.relations(j);
-		if (find(pbfRelation.keys().begin(), pbfRelation.keys().end(), typeKey) == pbfRelation.keys().end()) { continue; }
-		if (find(pbfRelation.vals().begin(), pbfRelation.vals().end(), mpKey  ) == pbfRelation.vals().end()) { continue; }
+		bool isMultiPolygon = (find(pbfRelation.keys().begin(), pbfRelation.keys().end(), typeKey) != pbfRelation.keys().end()) &&
+		                      (find(pbfRelation.vals().begin(), pbfRelation.vals().end(), mpKey  ) != pbfRelation.vals().end());
+		bool isAccepted = false;
+		WayID relid = static_cast<WayID>(pbfRelation.id());
+		if (!isMultiPolygon) {
+			tag_map_t tags;
+			readTags(pbfRelation, pb, tags);
+			isAccepted = output.scanRelation(relid, tags);
+			if (!isAccepted) continue;
+			std::cout << " - accepted" << std::endl;
+		}
 		int64_t lastID = 0;
 		for (int n=0; n < pbfRelation.memids_size(); n++) {
 			lastID += pbfRelation.memids(n);
 			if (pbfRelation.types(n) != Relation_MemberType_WAY) { continue; }
 			osmStore.mark_way_used(static_cast<WayID>(lastID));
+			if (isAccepted) { osmStore.relation_contains_way(relid, lastID); }
 		}
 	}
 	return true;
@@ -135,7 +140,6 @@ bool PbfReader::ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 
 bool PbfReader::ReadRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb) {
 	// ----	Read relations
-	//		(just multipolygons for now; we should do routes in time)
 
 	if (pg.relations_size() > 0) {
 		std::vector<RelationStore::element_t> relations;
@@ -147,42 +151,44 @@ bool PbfReader::ReadRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 		if (typeKey >-1 && mpKey>-1) {
 			for (int j=0; j<pg.relations_size(); j++) {
 				Relation pbfRelation = pg.relations(j);
-				if (find(pbfRelation.keys().begin(), pbfRelation.keys().end(), typeKey) == pbfRelation.keys().end()) { continue; }
-				if (find(pbfRelation.vals().begin(), pbfRelation.vals().end(), mpKey  ) == pbfRelation.vals().end()) { continue; }
+				bool isMultiPolygon = (find(pbfRelation.keys().begin(), pbfRelation.keys().end(), typeKey) != pbfRelation.keys().end()) &&
+				                      (find(pbfRelation.vals().begin(), pbfRelation.vals().end(), mpKey  ) != pbfRelation.vals().end());
 
-				// Read relation members
-				WayVec outerWayVec, innerWayVec;
-				int64_t lastID = 0;
-				for (int n=0; n < pbfRelation.memids_size(); n++) {
-					lastID += pbfRelation.memids(n);
-					if (pbfRelation.types(n) != Relation_MemberType_WAY) { continue; }
-					int32_t role = pbfRelation.roles_sid(n);
-					// if (role != innerKey && role != outerKey) { continue; }
-					// ^^^^ commented out so that we don't die horribly when a relation has no outer way
-					WayID wayId = static_cast<WayID>(lastID);
-					(role == innerKey ? innerWayVec : outerWayVec).push_back(wayId);
-				}
-
-				try {
-					auto keysPtr = pbfRelation.mutable_keys();
-					auto valsPtr = pbfRelation.mutable_vals();
-					boost::container::flat_map<std::string, std::string> tags;
-					for (uint n=0; n < pbfRelation.keys_size(); n++) {
-						tags[pb.stringtable().s(keysPtr->Get(n))] = pb.stringtable().s(valsPtr->Get(n));
-
+				// Multipolygon relation handling
+				if (isMultiPolygon) {
+					// Read relation members
+					WayVec outerWayVec, innerWayVec;
+					int64_t lastID = 0;
+					for (int n=0; n < pbfRelation.memids_size(); n++) {
+						lastID += pbfRelation.memids(n);
+						if (pbfRelation.types(n) != Relation_MemberType_WAY) { continue; }
+						int32_t role = pbfRelation.roles_sid(n);
+						// if (role != innerKey && role != outerKey) { continue; }
+						// ^^^^ commented out so that we don't die horribly when a relation has no outer way
+						WayID wayId = static_cast<WayID>(lastID);
+						(role == innerKey ? innerWayVec : outerWayVec).push_back(wayId);
 					}
 
-					// Store the relation members in the global relation store
-					relations.push_back(std::make_pair(pbfRelation.id(), 
-						std::make_pair(
-							RelationStore::wayid_vector_t(outerWayVec.begin(), outerWayVec.end()),
-							RelationStore::wayid_vector_t(innerWayVec.begin(), innerWayVec.end()))));
+					try {
+						tag_map_t tags;
+						readTags(pbfRelation, pb, tags);
 
-					output.setRelation(pbfRelation.id(), outerWayVec, innerWayVec, tags);
+						// Store the relation members in the global relation store
+						relations.push_back(std::make_pair(pbfRelation.id(), 
+							std::make_pair(
+								RelationStore::wayid_vector_t(outerWayVec.begin(), outerWayVec.end()),
+								RelationStore::wayid_vector_t(innerWayVec.begin(), innerWayVec.end()))));
 
-				} catch (std::out_of_range &err) {
-					// Relation is missing a member?
-					cerr << endl << err.what() << endl;
+						output.setRelation(pbfRelation.id(), outerWayVec, innerWayVec, tags);
+
+					} catch (std::out_of_range &err) {
+						// Relation is missing a member?
+						cerr << endl << err.what() << endl;
+					}
+				}
+				
+				// Other relation handling
+				else if (output.canWriteRelations()) {
 				}
 
 			}
@@ -353,6 +359,7 @@ int PbfReader::findStringPosition(PrimitiveBlock const &pb, char const *str) {
 	}
 	return -1;
 }
+
 
 // *************************************************
 


### PR DESCRIPTION
This PR enables tilemaker to take account of relations in Lua scripts. There are two new (but linked) pieces of functionality:

- `relation_scan_function` reads relation tags and memberships into memory, so that they can be considered by member ways in `way_function`
- `relation_function` constructs discrete geometries from entire relations, including as multilinestrings

This means tilemaker can now support route and boundary relations, among others. Support for boundary relations is added to the OMT-compatible Lua script in this PR. The new functions are documented in a separate RELATIONS.md file.

Each relation type is sui generis so I anticipate this won't be the end of the story! As this evolves we may need to change the Lua interface for relations (semver purists look away now ;) ). But this should cope with the majority of cases.

The following aren't supported in this PR and could be considered at a later date:

- relation roles (moderately easy, may require changing the Lua interface)
- nested relations (quite hard)
- nodes in relations (moderately easy)
