### PR TITLE
Fix JSON loading in Ruby server

### DIFF
--- a/server/server.rb
+++ b/server/server.rb
@@ -14,6 +14,8 @@
 
 require 'sqlite3'
 require 'cgi'
+require 'json'
+
 begin; require 'glug'	# Optional glug dependency
 rescue LoadError; end 	#  |
 


### PR DESCRIPTION
Otherwise the Ruby server stops on its own , could be because of my Ruby environment because I'm not a Ruby expert

```
ruby server.rb output.mbtiles

Starting local server
[2022-01-05 17:13:54] INFO  WEBrick 1.7.0
[2022-01-05 17:13:54] INFO  ruby 2.7.2 (2020-10-01) [x86_64-darwin19]
[2022-01-05 17:13:54] INFO  WEBrick::HTTPServer#start: pid=82425 port=8080
::1 - - [05/Jan/2022:17:13:57 CET] "GET / HTTP/1.1" 200 2023
- -> /
[2022-01-05 17:13:57] ERROR NameError: uninitialized constant MapServer::JSON
	server.rb:51:in `block in read_metadata'
	server.rb:49:in `each'
	server.rb:49:in `read_metadata'
	server.rb:76:in `call'
	server.rb:117:in `block in <class:MapServer>'
	<path>/ruby-2.7.2/gems/rack-2.2.3/lib/rack/handler/webrick.rb:95:in `service'
	<path>/ruby-2.7.2/gems/webrick-1.7.0/lib/webrick/httpserver.rb:140:in `service'
	<path>/ruby-2.7.2/gems/webrick-1.7.0/lib/webrick/httpserver.rb:96:in `run'
	<path>/ruby-2.7.2/gems/webrick-1.7.0/lib/webrick/server.rb:310:in `block in start_thread'
::1 - - [05/Jan/2022:14:13:57 CET] "GET /metadata HTTP/1.1" 500 318
http://localhost:8080/ -> /metadata
^C[2022-01-05 17:14:04] FATAL Interrupt:
	<path>/ruby-2.7.2/gems/webrick-1.7.0/lib/webrick/server.rb:173:in `select'
	<path>/ruby-2.7.2/gems/webrick-1.7.0/lib/webrick/server.rb:173:in `block in start'
	<path>/ruby-2.7.2/gems/webrick-1.7.0/lib/webrick/server.rb:32:in `start'
	<path>/ruby-2.7.2/gems/webrick-1.7.0/lib/webrick/server.rb:160:in `start'
	<path>/ruby-2.7.2/gems/rack-2.2.3/lib/rack/handler/webrick.rb:41:in `run'
	server.rb:118:in `<class:MapServer>'
	server.rb:22:in `<main>'
[2022-01-05 17:14:04] INFO  going to shutdown ...
[2022-01-05 17:14:04] INFO  WEBrick::HTTPServer#start done.
```