### PR TITLE
Dockerfile: reduce the size of the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,19 @@ ARG DEBIAN_FRONTEND=noninteractive
 # install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential liblua5.1-0 liblua5.1-0-dev libprotobuf-dev libsqlite3-dev protobuf-compiler shapelib libshp-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-iostreams-dev rapidjson-dev
+      build-essential \
+      liblua5.1-0 \
+      liblua5.1-0-dev \
+      libprotobuf-dev \
+      libsqlite3-dev \
+      protobuf-compiler \
+      shapelib \
+      libshp-dev \
+      libboost-program-options-dev \
+      libboost-filesystem-dev \
+      libboost-system-dev \
+      libboost-iostreams-dev \
+      rapidjson-dev
 
 COPY . /
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS src
 LABEL Description="Tilemaker" Version="1.4.0"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -18,15 +18,25 @@ RUN apt-get update && \
       libboost-filesystem-dev \
       libboost-system-dev \
       libboost-iostreams-dev \
-      rapidjson-dev
+      rapidjson-dev \
+      cmake
 
-COPY . /
+COPY CMakeLists.txt /
+COPY cmake /cmake
+COPY src /src
+COPY include /include
+
+WORKDIR /build
+
+RUN cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ ..
+RUN cmake --build .
+RUN strip tilemaker
+
+FROM debian:bullseye-slim
 WORKDIR /
+COPY --from=src /build/tilemaker .
+COPY resources /resources
+COPY process.lua .
+COPY config.json .
 
-RUN make && \
-    make install && \
-    # clean up, remove build-time only dependencies
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get purge -y --auto-remove build-essential liblua5.1-0-dev
-
-ENTRYPOINT ["tilemaker"]
+ENTRYPOINT ["/tilemaker"]


### PR DESCRIPTION
By statically compile and using multi-cache build, the size of the image is now 88MB.
Previously, it was around 700MB.

(I took the cmake lines from the CI. I don't know if they are correct here)