### PR TITLE
Add unit test for compression

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+/build/
+/cmake-build-debug/
+/server/
+/test/cmake-build-debug/
+/include/osmformat.pb.o
+/include/osmformat.pb.h
+/include/vector_tile.pb.h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
 
     - name: Build dependencies
       run: |
-        vcpkg install --triplet=x64-windows-static-md lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort rapidjson
+        vcpkg install --triplet=x64-windows-static-md lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort boost-test rapidjson
 
     - name: Build tilemaker
       run: |
         mkdir ${{ github.workspace }}\build        
         cd ${{ github.workspace }}\build && cmake -DTILEMAKER_BUILD_STATIC=ON -DVCPKG_TARGET_TRIPLET="x64-windows-static-md" -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake"  ..
-        cd ${{ github.workspace }}\build && cmake --build . --config RelWithDebInfo
+        cd ${{ github.workspace }}\build && cmake --build . --config RelWithDebInfo --target tilemaker
 
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
@@ -78,14 +78,14 @@ jobs:
 
     - name: Build dependencies
       run: |
-        vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort rapidjson
+        vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort boost-test rapidjson
 
     - name: Build tilemaker
       run: |
         mkdir build        
         cd build        
         cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DCMAKE_CXX_COMPILER=g++ ..
-        cmake --build . 
+        cmake --build . --target tilemaker
         strip tilemaker
 
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ tilemaker
 # protocol buffers generated headers
 include/osmformat.pb.h
 include/vector_tile.pb.h
+
+# cmake directories
+cmake-build-debug/
+test/cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,13 +105,49 @@ file(GLOB tilemaker_src_files
 	src/shp_mem_tiles.cpp
 	src/tilemaker.cpp
 	src/write_geometry.cpp
-  )
+)
 add_executable(tilemaker vector_tile.pb.cc osmformat.pb.cc ${tilemaker_src_files})
-target_link_libraries(tilemaker ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUAJIT_LIBRARY} ${LUA_LIBRARIES} ${ZLIB_LIBRARY} ${THREAD_LIB} ${CMAKE_DL_LIBS}
-	Boost::system Boost::filesystem Boost::program_options Boost::iostreams)
+target_link_libraries(tilemaker
+	${PROTOBUF_LIBRARY}
+	${LIBSHP_LIBRARIES}
+	${SQLITE3_LIBRARIES}
+	${LUAJIT_LIBRARY}
+	${LUA_LIBRARIES}
+	${ZLIB_LIBRARY}
+	${THREAD_LIB}
+	${CMAKE_DL_LIBS}
+	Boost::system
+	Boost::filesystem
+	Boost::program_options
+	Boost::iostreams
+)
 
 if(MSVC)
     target_link_libraries(tilemaker unofficial::sqlite3::sqlite3)
 endif()
 
 install(TARGETS tilemaker RUNTIME DESTINATION bin)
+
+# Unit tests
+add_library(libtilemaker SHARED STATIC
+	src/helpers.cpp
+	include/helpers.h
+	vector_tile.pb.cc
+	osmformat.pb.cc
+)
+target_link_libraries(libtilemaker
+	${PROTOBUF_LIBRARY}
+	${LIBSHP_LIBRARIES}
+	${SQLITE3_LIBRARIES}
+	${LUAJIT_LIBRARY}
+	${LUA_LIBRARIES}
+	${ZLIB_LIBRARY}
+	${THREAD_LIB}
+	${CMAKE_DL_LIBS}
+	Boost::system
+	Boost::filesystem
+	Boost::program_options
+	Boost::iostreams
+)
+
+add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(tilemaker_test)
+
+set(CMAKE_CXX_STANDARD 14)
+
+# Project settings
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
+
+# Dependencies
+find_package(Boost COMPONENTS filesystem system unit_test_framework REQUIRED)
+
+# Assign the include directories
+include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${UNIT_TESTS_INCLUDES})
+
+# Build unit tests
+add_executable(tilemaker_test test_helpers.cpp)
+target_link_libraries(tilemaker_test ${Boost_LIBRARIES} libtilemaker)
+
+enable_testing()
+add_test(tilemaker_test tilemaker_test)

--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -1,0 +1,15 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include "../include/helpers.h"
+
+BOOST_AUTO_TEST_SUITE(HelpersSuite)
+
+BOOST_AUTO_TEST_CASE(CompressDecompress) {
+    std::string original = "hello world";
+    std::string compressed = compress_string(original, 9);
+    BOOST_REQUIRE_EQUAL(decompress_string(compressed, false), original);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds the first unit test. I am totally new to cmake. Let me know how I can improve that!

I think next step would be to extract enough function to be able to generate a full mbtiles given a osm.pbf and use it in one test.