### PR TITLE
Output slow geometry generation and allow user interrupt

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -130,15 +130,20 @@ public:
         if (isRelation && !geom::is_valid(geom,failure)) {
             if (verbose) std::cout << "Relation " << originalOsmID << " has " << boost_validity_error(failure) << std::endl;
         } else if (isWay && !geom::is_valid(geom,failure)) {
-            if (verbose) std::cout << "Way " << originalOsmID << " has " << boost_validity_error(failure) << std::endl;
+            if (verbose && failure!=22) std::cout << "Way " << originalOsmID << " has " << boost_validity_error(failure) << std::endl;
         }
 		
 		if (failure==boost::geometry::failure_spikes)
 			geom::remove_spikes(geom);
         if (failure == boost::geometry::failure_few_points) 
 			return false;
-		if (failure)
+		if (failure) {
+			std::time_t start = std::time(0);
 			make_valid(geom);
+			if (verbose && std::time(0)-start>3) {
+				std::cout << (isRelation ? "Relation " : "Way ") << originalOsmID << " took " << (std::time(0)-start) << " seconds to correct" << std::endl;
+			}
+		}
 #endif
 		return true;
     }

--- a/include/tile_worker.h
+++ b/include/tile_worker.h
@@ -8,4 +8,11 @@
 /// Start function for worker threads
 bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore &osmStore, std::vector<OutputObjectRef> const &data, TileCoordinates coordinates, uint zoom);
 
+// User stop signal
+bool signalStop=false;
+void handleUserSignal(int signum) {
+	std::cout << "User requested break in processing" << std::endl;
+	signalStop=true;
+}
+
 #endif //_TILE_WORKER_H

--- a/include/tile_worker.h
+++ b/include/tile_worker.h
@@ -8,11 +8,4 @@
 /// Start function for worker threads
 bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore &osmStore, std::vector<OutputObjectRef> const &data, TileCoordinates coordinates, uint zoom);
 
-// User stop signal
-bool signalStop=false;
-void handleUserSignal(int signum) {
-	std::cout << "User requested break in processing" << std::endl;
-	signalStop=true;
-}
-
 #endif //_TILE_WORKER_H

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -220,6 +220,12 @@ void ProcessLayer(OSMStore &osmStore,
 	}
 }
 
+bool signalStop=false;
+void handleUserSignal(int signum) {
+	std::cout << "User requested break in processing" << std::endl;
+	signalStop=true;
+}
+
 bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore &osmStore, std::vector<OutputObjectRef> const &data, TileCoordinates coordinates, uint zoom)
 {
 	// Create tile
@@ -239,6 +245,8 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 
 	// Loop through layers
 	signal(SIGUSR1, handleUserSignal);
+	signalStop=false;
+
 	for (auto lt = sharedData.layers.layerOrder.begin(); lt != sharedData.layers.layerOrder.end(); ++lt) {
 		if (signalStop) break;
 		ProcessLayer(osmStore, coordinates, zoom, data, tile, bbox, *lt, sharedData);
@@ -270,4 +278,3 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 
 	return true;
 }
-

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -2,6 +2,7 @@
 #include "tile_worker.h"
 #include <fstream>
 #include <boost/filesystem.hpp>
+#include <signal.h>
 #include "helpers.h"
 #include "write_geometry.h"
 using namespace std;
@@ -244,7 +245,9 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 	}
 
 	// Loop through layers
+#ifndef _WIN32
 	signal(SIGUSR1, handleUserSignal);
+#endif
 	signalStop=false;
 
 	for (auto lt = sharedData.layers.layerOrder.begin(); lt != sharedData.layers.layerOrder.end(); ++lt) {

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -238,7 +238,9 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 	}
 
 	// Loop through layers
+	signal(SIGUSR1, handleUserSignal);
 	for (auto lt = sharedData.layers.layerOrder.begin(); lt != sharedData.layers.layerOrder.end(); ++lt) {
+		if (signalStop) break;
 		ProcessLayer(osmStore, coordinates, zoom, data, tile, bbox, *lt, sharedData);
 	}
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -173,6 +173,7 @@ void ProcessLayer(OSMStore &osmStore,
 	TileCoordinate tileY = index.y;
 
 	// Loop through sub-layers
+	std::time_t start = std::time(0);
 	for (auto mt = ltx.begin(); mt != ltx.end(); ++mt) {
 		uint layerNum = *mt;
 		const LayerDef &ld = sharedData.layers.layers[layerNum];
@@ -197,6 +198,9 @@ void ProcessLayer(OSMStore &osmStore,
 		// Loop through output objects
 		ProcessObjects(osmStore, ooListSameLayer.first, ooListSameLayer.second, sharedData, 
 			simplifyLevel, filterArea, zoom < ld.combinePolygonsBelow, zoom, bbox, vtLayer, keyList, valueList);
+	}
+	if (verbose && std::time(0)-start>3) {
+		std::cout << "Layer " << layerName << " at " << zoom << "/" << index.x << "/" << index.y << " took " << (std::time(0)-start) << " seconds" << std::endl;
 	}
 
 	// If there are any objects, then add tags


### PR DESCRIPTION
When running in `--verbose` mode, this will output the OSM ID of any multipolygon that takes a long time (3s+) to correct, and the tile coordinates of any tile that takes a long time to output.

It also allows the user to interrupt tile generation by sending SIGUSR1 as per #373.