### PR TITLE
In-place multipolygon combine

### DIFF
--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -69,13 +69,15 @@ void MergeIntersecting(MultiLinestring &input, MultiLinestring &to_merge) {
 
 // Merge two multipolygons by doing intersection checks for each constituent polygon
 void MergeIntersecting(MultiPolygon &input, MultiPolygon &to_merge) {
-	for (std::size_t i=0; i<input.size(); i++) {
-		if (boost::geometry::intersects(input[i], to_merge)) {
-	        MultiPolygon union_result;
-			boost::geometry::union_(input[i], to_merge, union_result);
-			for (auto output : union_result) input.emplace_back(output);
-			input.erase(input.begin() + i);
-			return;
+	if (boost::geometry::intersects(input, to_merge)) {
+		for (std::size_t i=0; i<input.size(); i++) {
+			if (boost::geometry::intersects(input[i], to_merge)) {
+				MultiPolygon union_result;
+				boost::geometry::union_(input[i], to_merge, union_result);
+				for (auto output : union_result) input.emplace_back(output);
+				input.erase(input.begin() + i);
+				return;
+			}
 		}
 	}
 	for (auto output : to_merge) input.emplace_back(output);


### PR DESCRIPTION
This is a simple implementation of the in-place union described in #270, with the aim of improving performance of `combine_polygons_below`. On a city extract:

Current master, no `combine_polygons_below`:

    real        83.52
    user       223.10
    sys          7.26

Current master with `combine_polygons_below`:

    real      1203.93
    user      1729.73
    sys         31.19

This branch with `combine_polygons_below`:

    real       162.89
    user       327.07
    sys          9.49

So it's still significantly slower than not combining, but ~90% faster than the previous code.

This branch doesn't catch _quite_ as many potential intersections as boost::geometry::union_ but it's not far off. This branch:

![Screenshot 2022-02-13 at 16 26 25](https://user-images.githubusercontent.com/694425/153766546-52f2c7fd-76a9-4bd4-bec3-1bca0fdb9aad.png)

Pure boost::geometry::union_:

![Screenshot 2022-02-13 at 16 26 34](https://user-images.githubusercontent.com/694425/153766563-26c005cf-b5d4-4e21-83dd-8c85574d3cda.png)

(Source data: https://www.openstreetmap.org/#map=19/-37.79030/144.98065 )