### PR TITLE
High-resolution geometries at max zoom level

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,6 +27,7 @@ It also includes these global settings:
 * `compress` - whether to compress vector tiles (Any of "gzip","deflate" or "none"(default))
 * `combine_below` - whether to merge adjacent linestrings of the same type: will be done at zoom levels below that specified here (e.g. `"combine_below": 14` to merge at z1-13)
 * `name`, `version` and `description` - about your project (these are written into the MBTiles file)
+* `high_resolution` (optional) - whether to use extra coordinate precision at the maximum zoom level (makes tiles a bit bigger)
 * `bounding_box` (optional) - the bounding box to output, in [minlon, minlat, maxlon, maxlat] order
 * `default_view` (optional) - the default location for the client to view, in [lon, lat, zoom] order (MBTiles only)
 * `mvt_version` (optional) - the version of the [Mapbox Vector Tile](https://github.com/mapbox/vector-tile-spec) spec to use; defaults to 2

--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -102,9 +102,10 @@ public:
 	double xmargin, ymargin, xscale, yscale;
 	TileCoordinates index;
 	uint zoom;
+	bool hires;
 	Box clippingBox;
 
-	TileBbox(TileCoordinates i, uint z);
+	TileBbox(TileCoordinates i, uint z, bool h);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
 	std::pair<double, double> floorLatpLon(double latp, double lon) const;

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -63,7 +63,7 @@ public:
 	class LayerDefinition layers;
 	uint baseZoom, startZoom, endZoom;
 	uint mvtVersion, combineBelow;
-	bool includeID, compress, gzip;
+	bool includeID, compress, gzip, highResolution;
 	std::string compressOpt;
 	bool clippingBoxFromJSON;
 	double minLon, minLat, maxLon, maxLat;

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -72,9 +72,10 @@ void fillCoveredTiles(unordered_set<TileCoordinates> &tileSet) {
 // ------------------------------------------------------
 // Helper class for dealing with spherical Mercator tiles
 
-TileBbox::TileBbox(TileCoordinates i, uint z) {
+TileBbox::TileBbox(TileCoordinates i, uint z, bool h) {
 	zoom = z;
 	index = i;
+	hires = h;
 	minLon = tilex2lon(i.x  ,zoom);
 	minLat = tiley2lat(i.y+1,zoom);
 	maxLon = tilex2lon(i.x+1,zoom);
@@ -83,8 +84,8 @@ TileBbox::TileBbox(TileCoordinates i, uint z) {
 	maxLatp = lat2latp(maxLat);
 	xmargin = (maxLon -minLon )/200.0;
 	ymargin = (maxLatp-minLatp)/200.0;
-	xscale  = (maxLon -minLon )/4096.0;
-	yscale  = (maxLatp-minLatp)/4096.0;
+	xscale  = (maxLon -minLon )/(hires ? 8192.0 : 4096.0);
+	yscale  = (maxLatp-minLatp)/(hires ? 8192.0 : 4096.0);
 	clippingBox = Box(geom::make<Point>(minLon-xmargin, minLatp-ymargin),
 		              geom::make<Point>(maxLon+xmargin, maxLatp+ymargin));
 }

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -99,7 +99,7 @@ std::string LayerDefinition::serialiseToJSON() const {
 // *****************************************************************
 
 Config::Config() {
-	includeID = false, compress = true, gzip = true;
+	includeID = false, compress = true, gzip = true, highResolution = false;
 	clippingBoxFromJSON = false;
 	baseZoom = 0;
 	combineBelow = 0;
@@ -123,6 +123,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 	startZoom      = jsonConfig["settings"]["minzoom" ].GetUint();
 	endZoom        = jsonConfig["settings"]["maxzoom" ].GetUint();
 	includeID      = jsonConfig["settings"]["include_ids"].GetBool();
+	highResolution = jsonConfig["settings"].HasMember("high_resolution") && jsonConfig["settings"]["high_resolution"].GetBool();
 	if (! jsonConfig["settings"]["compress"].IsString()) {
 		cerr << "\"compress\" should be any of \"gzip\",\"deflate\",\"none\" in JSON file." << endl;
 		exit (EXIT_FAILURE);

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -224,7 +224,7 @@ void ProcessLayer(OSMStore &osmStore,
 	if (vtLayer->features_size()>0) {
 		vtLayer->set_name(layerName);
 		vtLayer->set_version(sharedData.config.mvtVersion);
-		vtLayer->set_extent(4096);
+		vtLayer->set_extent(bbox.hires ? 8192 : 4096);
 		for (uint j=vtLayer->keys_size(); j<keyList.size(); j++) {
 			vtLayer->add_keys(keyList[j]);
 		}
@@ -241,7 +241,7 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 {
 	// Create tile
 	vector_tile::Tile tile;
-	TileBbox bbox(coordinates, zoom);
+	TileBbox bbox(coordinates, zoom, sharedData.config.highResolution && zoom==sharedData.config.endZoom);
 	if (sharedData.config.clippingBoxFromJSON && (sharedData.config.maxLon<=bbox.minLon 
 		|| sharedData.config.minLon>=bbox.maxLon || sharedData.config.maxLat<=bbox.minLat 
 		|| sharedData.config.minLat>=bbox.maxLat)) { return true; }

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -69,13 +69,15 @@ void MergeIntersecting(MultiLinestring &input, MultiLinestring &to_merge) {
 
 // Merge two multipolygons by doing intersection checks for each constituent polygon
 void MergeIntersecting(MultiPolygon &input, MultiPolygon &to_merge) {
-	for (std::size_t i=0; i<input.size(); i++) {
-		if (boost::geometry::intersects(input[i], to_merge)) {
-	        MultiPolygon union_result;
-			boost::geometry::union_(input[i], to_merge, union_result);
-			for (auto output : union_result) input.emplace_back(output);
-			input.erase(input.begin() + i);
-			return;
+	if (boost::geometry::intersects(input, to_merge)) {
+		for (std::size_t i=0; i<input.size(); i++) {
+			if (boost::geometry::intersects(input[i], to_merge)) {
+				MultiPolygon union_result;
+				boost::geometry::union_(input[i], to_merge, union_result);
+				for (auto output : union_result) input.emplace_back(output);
+				input.erase(input.begin() + i);
+				return;
+			}
 		}
 	}
 	for (auto output : to_merge) input.emplace_back(output);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -438,7 +438,7 @@ int main(int argc, char* argv[]) {
 				}
 			
 				if (hasClippingBox) {
-					if(!boost::geometry::intersects(TileBbox(it, zoom).getTileBox(), clippingBox)) 
+					if(!boost::geometry::intersects(TileBbox(it, zoom, false).getTileBox(), clippingBox)) 
 						continue;
 				}
 


### PR DESCRIPTION
This introduces a new `high_resolution` parameter in the global layer config.

When set, this uses an extent/resolution of 8192 at the maximum zoom (typically 14), rather than the usual 4096. The effect of this is that geometries continue to look correct when zoomed in up to (say) z18, rather than taking on a wonky appearance from rounding artefacts.

For a building-heavy city extract this results in an .mbtiles filesize increase of around 4%.

Buildings viewed at z18 without this parameter set (look at the nominally straight edges of the terraced buildings):

![Screenshot 2022-02-13 at 20 38 37](https://user-images.githubusercontent.com/694425/153778768-711eefc1-492e-4b5a-86df-538ea94ab96a.png)

With it set:

![Screenshot 2022-02-13 at 20 38 27](https://user-images.githubusercontent.com/694425/153778763-76208f5b-14a0-4260-b201-81bdf18257ec.png)

(I did experiment with using `round` rather than `floor` at higher zoom levels but, slightly to my surprise, it doesn't appear to make things any better.)