### PR TITLE
Support osmium locations-on-ways format

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -49,6 +49,19 @@ struct LatpLon {
 	int32_t latp;
 	int32_t lon;
 };
+inline bool operator==(const LatpLon &a, const LatpLon &b) { return a.latp==b.latp && a.lon==b.lon; }
+namespace std {
+	/// Hashing function so we can use an unordered_set
+	template<>
+	struct hash<LatpLon> {
+		size_t operator()(const LatpLon &ll) const {
+			return std::hash<int32_t>()(ll.latp) ^ std::hash<int32_t>()(ll.lon);
+		}
+	};
+}
+
+typedef std::vector<LatpLon> LatpLonVec;
+typedef std::deque<LatpLon> LatpLonDeque;
 
 double deg2rad(double deg);
 double rad2deg(double rad);

--- a/include/geom.h
+++ b/include/geom.h
@@ -43,9 +43,7 @@ typedef boost::geometry::index::rtree< IndexValue, boost::geometry::index::quadr
 typedef uint64_t NodeID;
 typedef uint64_t WayID;
 
-typedef std::vector<NodeID> NodeVec;
 typedef std::vector<WayID> WayVec;
-typedef std::deque<NodeID> NodeDeque;
 
 // Perform self-intersection aware simplification of geometry types
 Linestring simplify(Linestring const &ls, double max_distance);

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -75,7 +75,7 @@ public:
 	void setNode(NodeID id, LatpLon node, const tag_map_t &tags);
 
 	/// \brief We are now processing a way
-	void setWay(WayID wayId, NodeVec const &nodeVec, const tag_map_t &tags);
+	void setWay(WayID wayId, LatpLonVec const &llVec, const tag_map_t &tags);
 
 	/** \brief We are now processing a relation
 	 * (note that we store relations as ways with artificial IDs, and that
@@ -194,7 +194,7 @@ private:
 	/// Internal: clear current cached state
 	inline void reset() {
 		outputs.clear();
-		nodeVecPtr = nullptr;
+		llVecPtr = nullptr;
 		outerWayVecPtr = nullptr;
 		innerWayVecPtr = nullptr;
 		linestringInited = false;
@@ -228,7 +228,7 @@ private:
 	int relationSubscript = -1;				// in processWay, position in the relation list
 
 	int32_t lon,latp;						///< Node coordinates
-	NodeVec const *nodeVecPtr;
+	LatpLonVec const *llVecPtr;
 	WayVec const *outerWayVecPtr;
 	WayVec const *innerWayVecPtr;
 

--- a/include/osmformat.proto
+++ b/include/osmformat.proto
@@ -200,6 +200,8 @@ message Way {
    optional Info info = 4;
 
    repeated sint64 refs = 8 [packed = true];  // DELTA coded
+   repeated sint64 lats = 9  [packed = true];
+   repeated sint64 lons = 10 [packed = true];
 }
 
 message Relation {

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -45,10 +45,11 @@ public:
 	}
 
 private:
-	bool ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::pair<std::size_t, std::size_t> progress, std::size_t datasize, std::unordered_set<std::string> const &nodeKeys, ReadPhase phase = ReadPhase::All);
+	bool ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::pair<std::size_t, std::size_t> progress, std::size_t datasize, 
+	               std::unordered_set<std::string> const &nodeKeys, bool locationsOnWays, ReadPhase phase = ReadPhase::All);
 	bool ReadNodes(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb, const std::unordered_set<int> &nodeKeyPositions);
 
-	bool ReadWays(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb);
+	bool ReadWays(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb, bool locationsOnWays);
 	bool ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb);
 	bool ReadRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb);
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -281,7 +281,7 @@ double OsmLuaProcessing::Length() {
 const Linestring &OsmLuaProcessing::linestringCached() {
 	if (!linestringInited) {
 		linestringInited = true;
-		linestringCache = osmStore.nodeListLinestring(nodeVecPtr->cbegin(),nodeVecPtr->cend());
+		linestringCache = osmStore.llListLinestring(llVecPtr->cbegin(),llVecPtr->cend());
 	}
 	return linestringCache;
 }
@@ -297,7 +297,7 @@ const MultiLinestring &OsmLuaProcessing::multiLinestringCached() {
 const Polygon &OsmLuaProcessing::polygonCached() {
 	if (!polygonInited) {
 		polygonInited = true;
-		polygonCache = osmStore.nodeListPolygon(nodeVecPtr->cbegin(), nodeVecPtr->cend());
+		polygonCache = osmStore.llListPolygon(llVecPtr->cbegin(), llVecPtr->cend());
 	}
 	return polygonCache;
 }
@@ -561,13 +561,13 @@ void OsmLuaProcessing::setNode(NodeID id, LatpLon node, const tag_map_t &tags) {
 }
 
 // We are now processing a way
-void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map_t &tags) {
+void OsmLuaProcessing::setWay(WayID wayId, LatpLonVec const &llVec, const tag_map_t &tags) {
 	reset();
 	osmID = (wayId & OSMID_MASK) | OSMID_WAY;
 	originalOsmID = wayId;
 	isWay = true;
 	isRelation = false;
-	nodeVecPtr = &nodeVec;
+	llVecPtr = &llVec;
 	outerWayVecPtr = nullptr;
 	innerWayVecPtr = nullptr;
 	linestringInited = polygonInited = multiPolygonInited = false;
@@ -579,7 +579,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 	}
 
 	try {
-		isClosed = nodeVecPtr->front()==nodeVecPtr->back();
+		isClosed = llVecPtr->front()==llVecPtr->back();
 
 	} catch (std::out_of_range &err) {
 		std::stringstream ss;
@@ -608,7 +608,7 @@ void OsmLuaProcessing::setWay(WayID wayId, NodeVec const &nodeVec, const tag_map
 		// create a list of tiles this way passes through (tileSet)
 		unordered_set<TileCoordinates> tileSet;
 		try {
-			insertIntermediateTiles(osmStore.nodeListLinestring(nodeVecPtr->cbegin(),nodeVecPtr->cend()), this->config.baseZoom, tileSet);
+			insertIntermediateTiles(osmStore.llListLinestring(llVecPtr->cbegin(),llVecPtr->cend()), this->config.baseZoom, tileSet);
 
 			// then, for each tile, store the OutputObject for each layer
 			bool polygonExists = false;
@@ -651,7 +651,7 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 	isRelation = true;
 	isClosed = isNativeMP;
 
-	nodeVecPtr = nullptr;
+	llVecPtr = nullptr;
 	outerWayVecPtr = &outerWayVec;
 	innerWayVecPtr = &innerWayVec;
 	currentTags = tags;


### PR DESCRIPTION
This adds support for osmium's .osm.pbf extension where files are preprocessed to add node co-ordinates to ways. The preprocessing is run like this:

    osmium add-locations-to-ways great-britain-latest.osm.pbf -o great-britain-locs.osm.pbf

You can then run tilemaker in the normal way. It will notice the "LocationsOnWays" flag that osmium has inserted, and process the ways accordingly.

For tilemaker, this means that it has to read many fewer nodes into the node store. That said, in my testing so far it only makes a small difference to memory consumption - approx. 2% improvement on a GB extract. This is running in `--compact` mode on an already-renumbered extract, so it might make more of a difference in normal operation. I'll do some more testing and would be interested to hear anyone else's experience.

The main difference in the code is that we replace the NodeVec structure (a vector of node IDs) with a LatpLonVec (a vector of projected lat/lons). Memory usage is the same, as NodeID and LatpLon are each 64 bits. 