### PR TITLE
Add CORS for metadata and static file request

### DIFF
--- a/server/server.rb
+++ b/server/server.rb
@@ -73,7 +73,7 @@ class MapServer
 
 		elsif path=='metadata'
 			# Serve mbtiles metadata
-			['200', {'Content-Type' => 'application/json', 'Cache-Control' => "max-age=#{@@max_age}" }, [read_metadata.to_json]]
+			['200', {'Content-Type' => 'application/json', 'Cache-Control' => "max-age=#{@@max_age}", 'Access-Control-Allow-Origin' => '*' }, [read_metadata.to_json]]
 
 #		elsif ARGV.include?(path.sub(/\.json$/,'.glug'))
 #			# Convert .glug style to .json
@@ -84,7 +84,7 @@ class MapServer
 		elsif File.exist?(path)
 			# Serve static file
 			ct = path.match(/\.(\w+)$/) ? (CONTENT_TYPES[$1.to_sym] || 'text/html') : 'text/html'
-			['200', {'Content-Type' => ct, 'Cache-Control' => "max-age=#{@@max_age}"}, [File.read(path)]]
+			['200', {'Content-Type' => ct, 'Cache-Control' => "max-age=#{@@max_age}", 'Access-Control-Allow-Origin' => '*'}, [File.read(path)]]
 
 		elsif path=~/font.+\.pbf/
 			# Font not found so send dummy file


### PR DESCRIPTION
When using the demo server as a side party server for another web app, some request are rejected due to CORS policy.
I added the corresponding header ('Access-Control-Allow-Origin' => '*') for the request which were missing it, namely the metadata request and the static file request.