### PR TITLE
Report missing layer the same way other config errors are reported

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -54,6 +54,9 @@ A typical config file would look like this:
 
 The order of layers will be carried forward into the vector tile.
 
+Layers with `write_to` set must appear after the layers they're writing into.
+An incorrect order will result in "the layer to write doesn't exist".
+
 All options are compulsory unless stated otherwise. If tilemaker baulks at the JSON file, check everything's included, and run it through an online JSON validator to check for syntax errors.
 
 By default tilemaker expects to find this file at config.json, but you can specify another filename with the `--config` command-line option.

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -41,7 +41,8 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		layerOrder.push_back(r);
 	} else {
 		if (layerMap.count(writeTo) == 0) {
-			throw out_of_range("ERROR: addLayer(): the layer to write, named as \"" + writeTo + "\", doesn't exist.");
+			cerr << "ERROR: addLayer(): the layer to write, named as \"" + writeTo + "\", doesn't exist." << endl;
+			exit (EXIT_FAILURE);
 		}
 		uint lookingFor = layerMap[writeTo];
 		for (auto it = layerOrder.begin(); it!= layerOrder.end(); ++it) {


### PR DESCRIPTION
Previously, the message was ignored and a vague

> Couldn't find expected details in JSON file.

was printed.

I figured since the rest of the loading code just kills the whole program on failure, this'd be fine too.