### PR TITLE
Add libatomic when needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,12 @@ add_executable(tilemaker vector_tile.pb.cc osmformat.pb.cc ${tilemaker_src_files
 target_link_libraries(tilemaker ${PROTOBUF_LIBRARY} ${LIBSHP_LIBRARIES} ${SQLITE3_LIBRARIES} ${LUAJIT_LIBRARY} ${LUA_LIBRARIES} ${ZLIB_LIBRARY} ${THREAD_LIB} ${CMAKE_DL_LIBS}
 	Boost::system Boost::filesystem Boost::program_options Boost::iostreams)
 
+include(CheckCxxAtomic)
+if(NOT HAVE_CXX11_ATOMIC)
+	string(APPEND CMAKE_CXX_STANDARD_LIBRARIES
+	" ${LIBATOMIC_LINK_FLAGS}")
+endif()
+
 if(MSVC)
     target_link_libraries(tilemaker unofficial::sqlite3::sqlite3)
 endif()

--- a/cmake/CheckCxxAtomic.cmake
+++ b/cmake/CheckCxxAtomic.cmake
@@ -1,0 +1,66 @@
+# some platforms do not offer support for atomic primitive for all integer
+# types, in that case we need to link against libatomic
+
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+
+function(check_cxx_atomics var)
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+    check_cxx_source_compiles("
+#include <atomic>
+#include <cstdint>
+#include <cstddef>
+#if defined(__SIZEOF_INT128__)
+// Boost needs 16-byte atomics for tagged pointers.
+// These are implemented via inline instructions on the platform
+// if 16-byte alignment can be proven, and are delegated to libatomic
+// library routines otherwise.  Whether or not alignment is provably
+// OK for a std::atomic unfortunately depends on compiler version and
+// optimization levels, and also on the details of the expression.
+// We specifically test access via an otherwise unknown pointer here
+// to ensure we get the most complex case.  If this access can be
+// done without libatomic, then all accesses can be done.
+struct tagged_ptr {
+  int* ptr;
+  std::size_t tag;
+};
+void atomic16(std::atomic<tagged_ptr> *ptr)
+{
+  tagged_ptr p{nullptr, 1};
+  ptr->store(p);
+  tagged_ptr f = ptr->load();
+  tagged_ptr new_tag{nullptr, 0};
+  ptr->compare_exchange_strong(f, new_tag);
+}
+#endif
+int main() {
+#if defined(__SIZEOF_INT128__)
+  std::atomic<tagged_ptr> ptr;
+  atomic16(&ptr);
+#endif
+  std::atomic<uint8_t> w1;
+  std::atomic<uint16_t> w2;
+  std::atomic<uint32_t> w4;
+  std::atomic<uint64_t> w8;
+  return w1 + w2 + w4 + w8;
+}
+" ${var})
+endfunction(check_cxx_atomics)
+
+cmake_push_check_state()
+check_cxx_atomics(HAVE_CXX11_ATOMIC)
+cmake_pop_check_state()
+
+if(NOT HAVE_CXX11_ATOMIC)
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_LIBRARIES "atomic")
+  check_cxx_atomics(HAVE_LIBATOMIC)
+  cmake_pop_check_state()
+  if(HAVE_LIBATOMIC)
+    set(LIBATOMIC_LINK_FLAGS "-latomic")
+  else()
+    message(FATAL_ERROR
+      "Host compiler ${CMAKE_CXX_COMPILER} requires libatomic, but it is not found")
+  endif()
+endif()


### PR DESCRIPTION
I'm the maintainer of tilemaker in Debian and have recently run into a few problems building tilemaker for the not-so-common ARMel, mips64el, and powerpc architectures:
```
[100%] Linking CXX executable tilemaker
/usr/bin/cmake -E cmake_link_script CMakeFiles/tilemaker.dir/link.txt --verbose=1
/usr/bin/c++ -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -DTM_VERSION=2.2.0 -Wdate-time -D_FORTIFY_SOURCE=2 -Wl,-z,relro -Wl,-z,now -rdynamic CMakeFiles/tilemaker.dir/vector_tile.pb.cc.o CMakeFiles/tilemaker.dir/osmformat.pb.cc.o CMakeFiles/tilemaker.dir/src/attribute_store.cpp.o CMakeFiles/tilemaker.dir/src/coordinates.cpp.o CMakeFiles/tilemaker.dir/src/geom.cpp.o CMakeFiles/tilemaker.dir/src/helpers.cpp.o CMakeFiles/tilemaker.dir/src/mbtiles.cpp.o CMakeFiles/tilemaker.dir/src/osm_lua_processing.cpp.o CMakeFiles/tilemaker.dir/src/osm_mem_tiles.cpp.o CMakeFiles/tilemaker.dir/src/osm_store.cpp.o CMakeFiles/tilemaker.dir/src/output_object.cpp.o CMakeFiles/tilemaker.dir/src/pbf_blocks.cpp.o CMakeFiles/tilemaker.dir/src/read_pbf.cpp.o CMakeFiles/tilemaker.dir/src/read_shp.cpp.o CMakeFiles/tilemaker.dir/src/shared_data.cpp.o CMakeFiles/tilemaker.dir/src/shp_mem_tiles.cpp.o CMakeFiles/tilemaker.dir/src/tile_data.cpp.o CMakeFiles/tilemaker.dir/src/tile_worker.cpp.o CMakeFiles/tilemaker.dir/src/tilemaker.cpp.o CMakeFiles/tilemaker.dir/src/write_geometry.cpp.o -o tilemaker  -lprotobuf -lshp -lsqlite3 -llua5.1 -lm -lz -lpthread -ldl /usr/lib/arm-linux-gnueabi/libboost_system.so.1.74.0 /usr/lib/arm-linux-gnueabi/libboost_filesystem.so.1.74.0 /usr/lib/arm-linux-gnueabi/libboost_program_options.so.1.74.0 /usr/lib/arm-linux-gnueabi/libboost_iostreams.so.1.74.0 
/usr/bin/ld: CMakeFiles/tilemaker.dir/src/osm_lua_processing.cpp.o: undefined reference to symbol '__atomic_fetch_sub_8@@LIBATOMIC_1.0'
/usr/bin/ld: /usr/lib/arm-linux-gnueabi/libatomic.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[3]: *** [CMakeFiles/tilemaker.dir/build.make:428: tilemaker] Error 1
make[3]: Leaving directory '/<<PKGBUILDDIR>>/obj-arm-linux-gnueabi'
make[2]: *** [CMakeFiles/Makefile2:86: CMakeFiles/tilemaker.dir/all] Error 2
make[2]: Leaving directory '/<<PKGBUILDDIR>>/obj-arm-linux-gnueabi'
make[1]: *** [Makefile:139: all] Error 2
make[1]: Leaving directory '/<<PKGBUILDDIR>>/obj-arm-linux-gnueabi'
dh_auto_build: error: cd obj-arm-linux-gnueabi && make -j4 "INSTALL=install --strip-program=true" VERBOSE=1 returned exit code 2
make: *** [debian/rules:16: build-arch] Error 25
```

These do not support atomic operations, instead relying on emulation provided by libatomic. Therefore, "-latomic" should be added to the command. This PR introduces a check to verify if libatomic needs to be added and adds them if necessary. 