### PR TITLE
Scale before simplifying

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -121,15 +121,12 @@ public:
 	TileBbox(TileCoordinates i, uint z, bool h);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
+	MultiPolygon scaleGeometry(MultiPolygon const &src) const;
 	std::pair<double, double> floorLatpLon(double latp, double lon) const;
 
 	Box getTileBox() const;
 	Box getExtendBox() const;
 };
-
-// Round coordinates to integer coordinates of bbox
-// TODO: This should be self-intersection aware!!
-MultiPolygon round_coordinates(TileBbox const &bbox, MultiPolygon const &mp);
 
 #endif //_COORDINATES_H
 

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -104,11 +104,14 @@ MultiPolygon TileBbox::scaleGeometry(MultiPolygon const &src) const {
 		// Copy the outer ring
 		Ring outer;
 		std::vector<Point> points;
+		int lastx=INT_MAX, lasty=INT_MAX;
 		for(auto &i: poly.outer()) {
 			auto scaled = scaleLatpLon(i.y(), i.x());
 			Point pt(scaled.second, scaled.first);
-			points.push_back(pt);
+			if (scaled.second!=lastx || scaled.first!=lasty) points.push_back(pt);
+			lastx=scaled.second; lasty=scaled.first;
 		}
+		if (points.size()<4) continue;
 		geom::append(outer,points);
 		geom::append(p,outer);
 
@@ -117,11 +120,14 @@ MultiPolygon TileBbox::scaleGeometry(MultiPolygon const &src) const {
 		for(auto &r: poly.inners()) {
 			Ring inner;
 			points.clear();
+			lastx=INT_MAX, lasty=INT_MAX;
 			for(auto &i: r) {
 				auto scaled = scaleLatpLon(i.y(), i.x());
 				Point pt(scaled.second, scaled.first);
-				points.push_back(pt);
+				if (scaled.second!=lastx || scaled.first!=lasty) points.push_back(pt);
+				lastx=scaled.second; lasty=scaled.first;
 			}
+			if (points.size()<4) continue;
 			geom::append(inner,points);
 			num_rings++;
 			geom::interior_rings(p).resize(num_rings);

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -96,6 +96,44 @@ pair<int,int> TileBbox::scaleLatpLon(double latp, double lon) const {
 	return pair<int,int>(x,y);
 }
 
+MultiPolygon TileBbox::scaleGeometry(MultiPolygon const &src) const {
+	MultiPolygon dst;
+	for(auto poly: src) {
+		Polygon p;
+
+		// Copy the outer ring
+		Ring outer;
+		std::vector<Point> points;
+		for(auto &i: poly.outer()) {
+			auto scaled = scaleLatpLon(i.y(), i.x());
+			Point pt(scaled.second, scaled.first);
+			points.push_back(pt);
+		}
+		geom::append(outer,points);
+		geom::append(p,outer);
+
+		// Copy the inner rings
+		int num_rings = 0;
+		for(auto &r: poly.inners()) {
+			Ring inner;
+			points.clear();
+			for(auto &i: r) {
+				auto scaled = scaleLatpLon(i.y(), i.x());
+				Point pt(scaled.second, scaled.first);
+				points.push_back(pt);
+			}
+			geom::append(inner,points);
+			num_rings++;
+			geom::interior_rings(p).resize(num_rings);
+			geom::append(p, inner, num_rings-1);
+		}
+
+		// Add to multipolygon
+		dst.push_back(p);
+	}
+	return dst;
+}
+
 pair<double, double> TileBbox::floorLatpLon(double latp, double lon) const {
 	auto p = scaleLatpLon(latp, lon);
 	return std::make_pair( -(p.second * yscale - maxLatp), p.first * xscale + minLon);
@@ -111,28 +149,6 @@ Box TileBbox::getExtendBox() const {
 	return Box(
     	geom::make<Point>( minLon-(maxLon-minLon)*2.0, minLatp-(maxLatp-minLatp)*(8191.0/8192.0)), 
 		geom::make<Point>( maxLon+(maxLon-minLon)*(8191.0/8192.0), maxLatp+(maxLatp-minLatp)*2.0));
-}
-
-MultiPolygon round_coordinates(TileBbox const &bbox, MultiPolygon const &mp) 
-{
-	MultiPolygon combined_mp;
-	for(auto new_p: mp) {
-		for(auto &i: new_p.outer()) {
-			auto round_i = bbox.floorLatpLon(i.y(), i.x());
-			i = Point(round_i.second, round_i.first);
-		}
-
-		for(auto &r: new_p.inners()) {
-			for(auto &i: r) {
-				auto round_i = bbox.floorLatpLon(i.y(), i.x());
-				i = Point(round_i.second, round_i.first);
-			}
-		}
-
-		boost::geometry::remove_spikes(new_p);
-		simplify_combine(combined_mp, std::move(new_p));
-	}
-	return combined_mp;
 }
 
 template<typename T>

--- a/src/write_geometry.cpp
+++ b/src/write_geometry.cpp
@@ -30,6 +30,7 @@ void WriteGeometryVisitor::operator()(const Point &p) const {
 void WriteGeometryVisitor::operator()(const MultiPolygon &mp) const {
 	MultiPolygon current = bboxPtr->scaleGeometry(mp);
 	if (simplifyLevel>0) { current = simplify(current, simplifyLevel/bboxPtr->xscale); }
+	if (geom::is_empty(current)) return;
 
 #if BOOST_VERSION >= 105800
 	geom::validity_failure_type failure;


### PR DESCRIPTION
Previously we scaled multipolygons down from latp/lon to tile coordinates after simplifying them. This could on rare occasions reintroduce self-intersections.

This PR moves scaling to take place before simplification. This means the self-intersection-aware simplify code is the last transformation to be run. Effect on filesize and processing time appears minimal.

Should fix #415 when merged.