### PR TITLE
Only use polygon->clipping bbox logic at z14

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -116,9 +116,10 @@ public:
 	TileCoordinates index;
 	uint zoom;
 	bool hires;
+	bool endZoom;
 	Box clippingBox;
 
-	TileBbox(TileCoordinates i, uint z, bool h);
+	TileBbox(TileCoordinates i, uint z, bool h, bool e);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
 	MultiPolygon scaleGeometry(MultiPolygon const &src) const;

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -72,10 +72,11 @@ void fillCoveredTiles(unordered_set<TileCoordinates> &tileSet) {
 // ------------------------------------------------------
 // Helper class for dealing with spherical Mercator tiles
 
-TileBbox::TileBbox(TileCoordinates i, uint z, bool h) {
+TileBbox::TileBbox(TileCoordinates i, uint z, bool h, bool e) {
 	zoom = z;
 	index = i;
 	hires = h;
+	endZoom = e;
 	minLon = tilex2lon(i.x  ,zoom);
 	minLat = tiley2lat(i.y+1,zoom);
 	maxLon = tilex2lon(i.x+1,zoom);

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -259,7 +259,7 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 {
 	// Create tile
 	vector_tile::Tile tile;
-	TileBbox bbox(coordinates, zoom, sharedData.config.highResolution && zoom==sharedData.config.endZoom);
+	TileBbox bbox(coordinates, zoom, sharedData.config.highResolution && zoom==sharedData.config.endZoom, zoom==sharedData.config.endZoom);
 	if (sharedData.config.clippingBoxFromJSON && (sharedData.config.maxLon<=bbox.minLon 
 		|| sharedData.config.minLon>=bbox.maxLon || sharedData.config.maxLat<=bbox.minLat 
 		|| sharedData.config.minLat>=bbox.maxLat)) { return true; }

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -448,7 +448,7 @@ int main(int argc, char* argv[]) {
 				}
 			
 				if (hasClippingBox) {
-					if(!boost::geometry::intersects(TileBbox(it, zoom, false).getTileBox(), clippingBox)) 
+					if(!boost::geometry::intersects(TileBbox(it, zoom, false, false).getTileBox(), clippingBox)) 
 						continue;
 				}
 


### PR DESCRIPTION
Currently we use the logic from #234 to create a "smart" bbox at all zoom levels, to avoid tile boundary artefacts from clipping.

In reality we only need it when overzooming from the highest zoom level, so we can save a bit of CPU and reduce the likelihood of cases such as #421 by disabling it at other zoom levels.