### PR TITLE
Remove spikes after simplification

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -116,9 +116,10 @@ public:
 	TileCoordinates index;
 	uint zoom;
 	bool hires;
+	bool endZoom;
 	Box clippingBox;
 
-	TileBbox(TileCoordinates i, uint z, bool h);
+	TileBbox(TileCoordinates i, uint z, bool h, bool e);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
 	MultiPolygon scaleGeometry(MultiPolygon const &src) const;

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -72,10 +72,11 @@ void fillCoveredTiles(unordered_set<TileCoordinates> &tileSet) {
 // ------------------------------------------------------
 // Helper class for dealing with spherical Mercator tiles
 
-TileBbox::TileBbox(TileCoordinates i, uint z, bool h) {
+TileBbox::TileBbox(TileCoordinates i, uint z, bool h, bool e) {
 	zoom = z;
 	index = i;
 	hires = h;
+	endZoom = e;
 	minLon = tilex2lon(i.x  ,zoom);
 	minLat = tiley2lat(i.y+1,zoom);
 	maxLon = tilex2lon(i.x+1,zoom);

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -259,7 +259,7 @@ bool outputProc(boost::asio::thread_pool &pool, SharedData &sharedData, OSMStore
 {
 	// Create tile
 	vector_tile::Tile tile;
-	TileBbox bbox(coordinates, zoom, sharedData.config.highResolution && zoom==sharedData.config.endZoom);
+	TileBbox bbox(coordinates, zoom, sharedData.config.highResolution && zoom==sharedData.config.endZoom, zoom==sharedData.config.endZoom);
 	if (sharedData.config.clippingBoxFromJSON && (sharedData.config.maxLon<=bbox.minLon 
 		|| sharedData.config.minLon>=bbox.maxLon || sharedData.config.maxLat<=bbox.minLat 
 		|| sharedData.config.minLat>=bbox.maxLat)) { return true; }

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -448,7 +448,7 @@ int main(int argc, char* argv[]) {
 				}
 			
 				if (hasClippingBox) {
-					if(!boost::geometry::intersects(TileBbox(it, zoom, false).getTileBox(), clippingBox)) 
+					if(!boost::geometry::intersects(TileBbox(it, zoom, false, false).getTileBox(), clippingBox)) 
 						continue;
 				}
 

--- a/src/write_geometry.cpp
+++ b/src/write_geometry.cpp
@@ -29,7 +29,7 @@ void WriteGeometryVisitor::operator()(const Point &p) const {
 // Multipolygon
 void WriteGeometryVisitor::operator()(const MultiPolygon &mp) const {
 	MultiPolygon current = bboxPtr->scaleGeometry(mp);
-	if (simplifyLevel>0) { current = simplify(current, simplifyLevel/bboxPtr->xscale); }
+	if (simplifyLevel>0) { current = simplify(current, simplifyLevel/bboxPtr->xscale); geom::remove_spikes(current); }
 	if (geom::is_empty(current)) return;
 
 #if BOOST_VERSION >= 105800


### PR DESCRIPTION
Simplifying polygons can result in zero-width "spikes". A quick call to `geom::remove_spikes` after simplification fixes this.

Before:

![Screenshot 2022-09-28 at 14 19 18](https://user-images.githubusercontent.com/694425/192789152-408f96fe-1560-4ecd-8c18-6cbbba4cb5e7.png)

After:

![Screenshot 2022-09-28 at 14 19 26](https://user-images.githubusercontent.com/694425/192789181-6e5ac405-52fb-4f96-85c5-209c6de0ca65.png)

Impact on processing time is small: a timing run on Great Britain was 0.1% slower with this included.