### PR TITLE
Fixed geometry type signed (enum) to unsigned (field) conversion leading to invalid geometry type

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -126,7 +126,7 @@ public:
     bool CorrectGeometry(GeometryT &geom)
     {
 #if BOOST_VERSION >= 105800
-        geom::validity_failure_type failure;
+        geom::validity_failure_type failure = geom::validity_failure_type::no_failure;
         if (isRelation && !geom::is_valid(geom,failure)) {
             if (verbose) std::cout << "Relation " << originalOsmID << " has " << boost_validity_error(failure) << std::endl;
         } else if (isWay && !geom::is_valid(geom,failure)) {

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -15,14 +15,14 @@
 #include "osmformat.pb.h"
 #include "vector_tile.pb.h"
 
-enum OutputGeometryType { POINT_, LINESTRING_, MULTILINESTRING_, POLYGON_ };
+enum OutputGeometryType : unsigned int { POINT_, LINESTRING_, MULTILINESTRING_, POLYGON_ };
 
 #define OSMID_TYPE_OFFSET	40
-#define OSMID_MASK 		((1L<<OSMID_TYPE_OFFSET)-1)
-#define OSMID_SHAPE 	(0L<<OSMID_TYPE_OFFSET)
-#define OSMID_NODE 		(1L<<OSMID_TYPE_OFFSET)
-#define OSMID_WAY 		(2L<<OSMID_TYPE_OFFSET)
-#define OSMID_RELATION 	(3L<<OSMID_TYPE_OFFSET)
+#define OSMID_MASK 		((1ULL<<OSMID_TYPE_OFFSET)-1)
+#define OSMID_SHAPE 	(0ULL<<OSMID_TYPE_OFFSET)
+#define OSMID_NODE 		(1ULL<<OSMID_TYPE_OFFSET)
+#define OSMID_WAY 		(2ULL<<OSMID_TYPE_OFFSET)
+#define OSMID_RELATION 	(3ULL<<OSMID_TYPE_OFFSET)
 
 //\brief Display the geometry type
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);


### PR DESCRIPTION
OSMID_MASK shifts a L literal, which is 32 bit long, by 40 positions. This leads to undefined behavoir (MSVC warning C4293). Fixed with ULL specifier, since NodeID is unsigned.

OutputGeometryType enumeration type, if not specified it defaults to (signed) int. buildWayGeometry function fails with the switch over  oo.geomType executing default case and throwing a std:runtime_error that (silently) stops the running thread (uncaught exception in worker thread causes call to std::terminate). Invalid memory conversion occurs with POLYGON_ geometry type when OutputObjectRef or OutputObject members (bit fields) is assigned to a variable of type OutputGeometryType. Fixed by specifying unsigned int OutputGeometryType enumeration type (supported by C++11, project already requires C++14).

geom::validity_failure_type failure might be uninitialized in CorrectGeometry function, when geometry type is POINT_. This caused a runtime error in debug mode. Since the function does essentially nothing when geometry is Point, the function call might also be skipped entirely.