### PR TITLE
feat: Add tilemaker to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,6 @@ COPY --from=src /build/tilemaker .
 COPY resources /resources
 COPY process.lua .
 COPY config.json .
+RUN ln -s /tilemaker /usr/bin/tilemaker
 
 ENTRYPOINT ["/tilemaker"]


### PR DESCRIPTION
By creating a symlink from `/tilemaker` to `/usr/bin/tilemaker`, one can execute the `tilemaker` command e.g. from within a shell.

This makes it possible to use the built tilemaker binary as if it was "installed". If one does a Docker multistep build that uses the tilemaker Docker image, one can then simly use `RUN tilemaker ...` and does not need to know where the binary is actually stored.