### PR TITLE
Fix id generation (#466)

### DIFF
--- a/include/geom.h
+++ b/include/geom.h
@@ -25,6 +25,13 @@ using uint = unsigned int;
 #include <boost/interprocess/managed_external_buffer.hpp>
 #include <boost/interprocess/allocators/node_allocator.hpp>
 
+#define OSMID_TYPE_OFFSET 40
+#define OSMID_MASK      ((1L<<OSMID_TYPE_OFFSET)-1)
+#define OSMID_SHAPE     (0L<<OSMID_TYPE_OFFSET)
+#define OSMID_NODE      (1L<<OSMID_TYPE_OFFSET)
+#define OSMID_WAY       (2L<<OSMID_TYPE_OFFSET)
+#define OSMID_RELATION  (3L<<OSMID_TYPE_OFFSET)
+
 namespace bi = boost::interprocess;
 
 typedef boost::geometry::model::d2::point_xy<double> Point; 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -17,13 +17,6 @@
 
 enum OutputGeometryType { POINT_, LINESTRING_, MULTILINESTRING_, POLYGON_ };
 
-#define OSMID_TYPE_OFFSET	40
-#define OSMID_MASK 		((1L<<OSMID_TYPE_OFFSET)-1)
-#define OSMID_SHAPE 	(0L<<OSMID_TYPE_OFFSET)
-#define OSMID_NODE 		(1L<<OSMID_TYPE_OFFSET)
-#define OSMID_WAY 		(2L<<OSMID_TYPE_OFFSET)
-#define OSMID_RELATION 	(3L<<OSMID_TYPE_OFFSET)
-
 //\brief Display the geometry type
 std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -152,7 +152,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			featurePtr->set_type(vector_tile::Tile_GeomType_POINT);
 
 			oo->writeAttributes(&keyList, &valueList, featurePtr, zoom);
-			if (sharedData.config.includeID) { featurePtr->set_id(oo->objectID); }
+			if (sharedData.config.includeID) { featurePtr->set_id(oo->objectID & OSMID_MASK); }
 		} else {
 			Geometry g;
 			try {
@@ -184,7 +184,7 @@ void ProcessObjects(OSMStore &osmStore, OutputObjectsConstIt ooSameLayerBegin, O
 			boost::apply_visitor(w, g);
 			if (featurePtr->geometry_size()==0) { vtLayer->mutable_features()->RemoveLast(); continue; }
 			oo->writeAttributes(&keyList, &valueList, featurePtr, zoom);
-			if (sharedData.config.includeID) { featurePtr->set_id(oo->objectID); }
+			if (sharedData.config.includeID) { featurePtr->set_id(oo->objectID & OSMID_MASK); }
 
 		}
 	}


### PR DESCRIPTION
This applies the id mask when writing out ids with the `include_ids` option.