### PR TITLE
Move centroid error to verbose mode only

### DIFF
--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -415,7 +415,7 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		cout << "Couldn't find " << (isRelation ? "relation " : isWay ? "way " : "node " ) << originalOsmID << ": " << err.what() << endl;
 		return;
 	} catch (geom::centroid_exception &err) {
-		cerr << "Problem geometry " << (isRelation ? "relation " : isWay ? "way " : "node " ) << originalOsmID << ": " << err.what() << endl;
+		if (verbose) cerr << "Problem geometry " << (isRelation ? "relation " : isWay ? "way " : "node " ) << originalOsmID << ": " << err.what() << endl;
 		return;
 	} catch (std::invalid_argument &err) {
 		cerr << "Error in OutputObjectOsmStore constructor for " << (isRelation ? "relation " : isWay ? "way " : "node " ) << originalOsmID << ": " << err.what() << endl;


### PR DESCRIPTION
This doesn't really affect any functionality, but people keep thinking the centroid error is more significant than it really is, so let's put it behind `--verbose`.