### PR TITLE
Use rtree for large polygons

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -9,8 +9,10 @@
 
 #ifdef FAT_TILE_INDEX
 typedef uint32_t TileCoordinate;
+#define TILE_COORDINATE_MAX UINT32_MAX
 #else
 typedef uint16_t TileCoordinate;
+#define TILE_COORDINATE_MAX UINT16_MAX
 #endif
 class TileCoordinates_ {
 

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -14,7 +14,7 @@ public:
 	void CreateNamedLayerIndex(const std::string &layerName);
 
 	// Used in shape file loading
-	OutputObjectRef AddObject(uint_least8_t layerNum,
+	OutputObjectRef StoreShapefileGeometry(uint_least8_t layerNum,
 		const std::string &layerName, 
 		enum OutputGeometryType geomType,
 		Geometry geometry, 

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -23,6 +23,10 @@ public:
 	void AddObject(TileCoordinates const &index, OutputObjectRef const &oo) {
 		tileIndex[index].push_back(oo);
 	}
+	void AddObjectToLargeIndex(Box const &envelope, OutputObjectRef const &oo) {
+		std::lock_guard<std::mutex> lock(mutex);
+		box_rtree.insert(std::make_pair(envelope, oo));
+	}
 	std::vector<uint> QueryMatchingGeometries(const std::string &layerName, bool once, Box &box, 
 		std::function<std::vector<IndexValue>(const RTree &rtree)> indexQuery, 
 		std::function<bool(OutputObject const &oo)> checkQuery) const;

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -20,6 +20,7 @@ protected:
 	TileIndex tileIndex;
 	std::deque<OutputObject> objects;
 	
+	// rtree index of large objects
 	using oo_rtree_param_type = boost::geometry::index::quadratic<128>;
 	boost::geometry::index::rtree< std::pair<Box,OutputObjectRef>, oo_rtree_param_type> box_rtree;
 

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -51,6 +51,11 @@ public:
 		tileIndex[index].push_back(oo);
 	}
 
+	void AddObjectToLargeIndex(Box const &envelope, OutputObjectRef const &oo) {
+		std::lock_guard<std::mutex> lock(mutex);
+		box_rtree.insert(std::make_pair(envelope, oo));
+	}
+
 	void MergeLargeObjects(Box const &box, std::vector<OutputObjectRef> &dstTile);
 
 private:	

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -19,6 +19,9 @@ protected:
 	std::mutex mutex;
 	TileIndex tileIndex;
 	std::deque<OutputObject> objects;
+	
+	using oo_rtree_param_type = boost::geometry::index::quadratic<128>;
+	boost::geometry::index::rtree< std::pair<Box,OutputObjectRef>, oo_rtree_param_type> box_rtree;
 
 	unsigned int baseZoom;
 

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -35,6 +35,8 @@ public:
 		MergeTileCoordsAtZoom(zoom, baseZoom, tileIndex, dstCoords);
 	}
 
+	void MergeLargeCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords);
+
 	///This must be thread safe!
 	void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, std::vector<OutputObjectRef> &dstTile) {
 		MergeSingleTileDataAtZoom(dstIndex, zoom, baseZoom, tileIndex, dstTile);

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -51,6 +51,8 @@ public:
 		tileIndex[index].push_back(oo);
 	}
 
+	void MergeLargeObjects(Box const &box, std::vector<OutputObjectRef> &dstTile);
+
 private:	
 	static void MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, TileCoordinatesSet &dstCoords);
 	static void MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, uint baseZoom, const TileIndex &srcTiles, std::vector<OutputObjectRef> &dstTile);

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -56,7 +56,7 @@ public:
 		box_rtree.insert(std::make_pair(envelope, oo));
 	}
 
-	void MergeLargeObjects(Box const &box, std::vector<OutputObjectRef> &dstTile);
+	void MergeLargeObjects(TileCoordinates dstIndex, uint zoom, std::vector<OutputObjectRef> &dstTile);
 
 private:	
 	static void MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, TileCoordinatesSet &dstCoords);

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -637,11 +637,12 @@ void OsmLuaProcessing::setWay(WayID wayId, LatpLonVec const &llVec, const tag_ma
 				for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 					if (jt->first->geomType != POLYGON_) continue;
 					if (size>= 16) {
-						std::cout << "OSM way " << originalOsmID << " size " << size << " minX " << minTileX << " minY " << minTileY << " maxX " << maxTileX << " maxY " << maxTileY << std::endl;
+						// Larger objects - add to rtree
 						Box box = Box(geom::make<Point>(minTileX, minTileY),
 						              geom::make<Point>(maxTileX, maxTileY));
 						osmMemTiles.AddObjectToLargeIndex(box, jt->first);
 					} else {
+						// Smaller objects - add to each individual tile index
 						if (!tilesetFilled) { fillCoveredTiles(tileSet); tilesetFilled = true; }
 						for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 							TileCoordinates index = *it;
@@ -719,11 +720,14 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 		}
 		for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 			if (tileSet.size()>=16) {
-				std::cout << "OSM relation " << originalOsmID << " size " << tileSet.size() << " minX " << minTileX << " minY " << minTileY << " maxX " << maxTileX << " maxY " << maxTileY << std::endl;
+				// Larger objects - add to rtree
+				// note that the bbox is currently the envelope of the entire multipolygon,
+				// which is suboptimal in shapes like (_) ...... (_) where the outers are significantly disjoint
 				Box box = Box(geom::make<Point>(minTileX, minTileY),
 				              geom::make<Point>(maxTileX, maxTileY));
 				osmMemTiles.AddObjectToLargeIndex(box, jt->first);
 			} else {
+				// Smaller objects - add to each individual tile index
 				for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 					TileCoordinates index = *it;
 					osmMemTiles.AddObject(index, jt->first);

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -691,28 +691,43 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 			return;
 		}		
 
-		unordered_set<TileCoordinates> tileSet;
-		if (mp.size() == 1) {
-			insertIntermediateTiles(mp[0].outer(), this->config.baseZoom, tileSet);
-			fillCoveredTiles(tileSet);
-		} else {
-			for (Polygon poly: mp) {
-				unordered_set<TileCoordinates> tileSetTmp;
-				insertIntermediateTiles(poly.outer(), this->config.baseZoom, tileSetTmp);
-				fillCoveredTiles(tileSetTmp);
-				tileSet.insert(tileSetTmp.begin(), tileSetTmp.end());
-			}
-		}
-
 		for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 			// Store the attributes of the generated geometry
 			jt->first->setAttributeSet(attributeStore.store_set(jt->second));		
 		}
 
+		unordered_set<TileCoordinates> tileSet;
+		bool singleOuter = mp.size()==1;
+		for (Polygon poly: mp) {
+			unordered_set<TileCoordinates> tileSetTmp;
+			insertIntermediateTiles(poly.outer(), this->config.baseZoom, tileSetTmp);
+			fillCoveredTiles(tileSetTmp);
+			if (singleOuter) {
+				tileSet = std::move(tileSetTmp);
+			} else {
+				tileSet.insert(tileSetTmp.begin(), tileSetTmp.end());
+			}
+		}
+		
+		TileCoordinate minTileX = TILE_COORDINATE_MAX, maxTileX = 0, minTileY = TILE_COORDINATE_MAX, maxTileY = 0;
 		for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 			TileCoordinates index = *it;
-			for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
-				osmMemTiles.AddObject(index, jt->first);
+			minTileX = std::min(index.x, minTileX);
+			minTileY = std::min(index.y, minTileY);
+			maxTileX = std::max(index.x, maxTileX);
+			maxTileY = std::max(index.y, maxTileY);
+		}
+		for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
+			if (tileSet.size()>=16) {
+				std::cout << "OSM multipolygon size " << tileSet.size() << std::endl;
+				Box box = Box(geom::make<Point>(minTileX, minTileY),
+				              geom::make<Point>(maxTileX, maxTileY));
+				osmMemTiles.AddObjectToLargeIndex(box, jt->first);
+			} else {
+				for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
+					TileCoordinates index = *it;
+					osmMemTiles.AddObject(index, jt->first);
+				}
 			}
 		}
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -637,7 +637,7 @@ void OsmLuaProcessing::setWay(WayID wayId, LatpLonVec const &llVec, const tag_ma
 				for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 					if (jt->first->geomType != POLYGON_) continue;
 					if (size>= 16) {
-						std::cout << "OSM object size " << size << std::endl;
+						std::cout << "OSM way " << originalOsmID << " size " << size << " minX " << minTileX << " minY " << minTileY << " maxX " << maxTileX << " maxY " << maxTileY << std::endl;
 						Box box = Box(geom::make<Point>(minTileX, minTileY),
 						              geom::make<Point>(maxTileX, maxTileY));
 						osmMemTiles.AddObjectToLargeIndex(box, jt->first);
@@ -719,7 +719,7 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 		}
 		for (auto jt = this->outputs.begin(); jt != this->outputs.end(); ++jt) {
 			if (tileSet.size()>=16) {
-				std::cout << "OSM multipolygon size " << tileSet.size() << std::endl;
+				std::cout << "OSM relation " << originalOsmID << " size " << tileSet.size() << " minX " << minTileX << " minY " << minTileY << " maxX " << maxTileX << " maxY " << maxTileY << std::endl;
 				Box box = Box(geom::make<Point>(minTileX, minTileY),
 				              geom::make<Point>(maxTileX, maxTileY));
 				osmMemTiles.AddObjectToLargeIndex(box, jt->first);

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -177,7 +177,7 @@ void readShapefile(const Box &clippingBox,
 				if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POINT_, p, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
+				OutputObjectRef oo = shpMemTiles.StoreShapefileGeometry(layerNum, layerName, POINT_, p, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}
@@ -199,7 +199,7 @@ void readShapefile(const Box &clippingBox,
 					if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
 
 					auto &attributeStore = osmLuaProcessing.getAttributeStore();
-					OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, LINESTRING_, *it, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
+					OutputObjectRef oo = shpMemTiles.StoreShapefileGeometry(layerNum, layerName, LINESTRING_, *it, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
 
 					addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 				}
@@ -272,7 +272,7 @@ void readShapefile(const Box &clippingBox,
 
 				// create OutputObject
 				auto &attributeStore = osmLuaProcessing.getAttributeStore();
-				OutputObjectRef oo = shpMemTiles.AddObject(layerNum, layerName, POLYGON_, out, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
+				OutputObjectRef oo = shpMemTiles.StoreShapefileGeometry(layerNum, layerName, POLYGON_, out, isIndexed, hasName, name, attributeStore.empty_set(), layer.minzoom);
 
 				addShapefileAttributes(dbf, oo, i, columnMap, columnTypeMap, layers, osmLuaProcessing);
 			}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -123,11 +123,17 @@ void ShpMemTiles::addToTileIndexByBbox(OutputObjectRef &oo, double minLon, doubl
 	uint minTileY = latp2tiley(minLatp, baseZoom);
 	uint maxTileY = latp2tiley(maxLatp, baseZoom);
 	uint size = (maxTileX - minTileX + 1) * (minTileY - maxTileY + 1);
-	if (size>=4) { std::cout << "Shapefile object size " << size << std::endl; }
-	for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
-		for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
-			TileCoordinates index(x, y);
-			AddObject(index, oo);
+	if (size>=16) { 
+		// Larger objects - add to rtree
+		std::cout << "Shapefile object size " << size << std::endl;
+		AddObjectToLargeIndex(Box(Point(minLon, minLatp), Point(maxLon, maxLatp)), oo);
+	} else {
+		// Smaller objects - add to each individual tile index
+		for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
+			for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
+				TileCoordinates index(x, y);
+				AddObject(index, oo);
+			}
 		}
 	}
 }

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -125,7 +125,6 @@ void ShpMemTiles::addToTileIndexByBbox(OutputObjectRef &oo, double minLon, doubl
 	uint size = (maxTileX - minTileX + 1) * (minTileY - maxTileY + 1);
 	if (size>=16) { 
 		// Larger objects - add to rtree
-		std::cout << "Shapefile object size " << size << std::endl;
 		AddObjectToLargeIndex(Box(Point(minTileX, maxTileY), Point(maxTileX, minTileY)), oo);
 	} else {
 		// Smaller objects - add to each individual tile index

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -126,7 +126,7 @@ void ShpMemTiles::addToTileIndexByBbox(OutputObjectRef &oo, double minLon, doubl
 	if (size>=16) { 
 		// Larger objects - add to rtree
 		std::cout << "Shapefile object size " << size << std::endl;
-		AddObjectToLargeIndex(Box(Point(minLon, minLatp), Point(maxLon, maxLatp)), oo);
+		AddObjectToLargeIndex(Box(Point(minTileX, maxTileY), Point(maxTileX, minTileY)), oo);
 	} else {
 		// Smaller objects - add to each individual tile index
 		for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -116,11 +116,14 @@ OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
 }
 
 // Add an OutputObject to all tiles between min/max lat/lon
+// (only used for polygons)
 void ShpMemTiles::addToTileIndexByBbox(OutputObjectRef &oo, double minLon, double minLatp, double maxLon, double maxLatp) {
 	uint minTileX =  lon2tilex(minLon, baseZoom);
 	uint maxTileX =  lon2tilex(maxLon, baseZoom);
 	uint minTileY = latp2tiley(minLatp, baseZoom);
 	uint maxTileY = latp2tiley(maxLatp, baseZoom);
+	uint size = (maxTileX - minTileX + 1) * (minTileY - maxTileY + 1);
+	if (size>=4) { std::cout << "Shapefile object size " << size << std::endl; }
 	for (uint x=min(minTileX,maxTileX); x<=max(minTileX,maxTileX); x++) {
 		for (uint y=min(minTileY,maxTileY); y<=max(minTileY,maxTileY); y++) {
 			TileCoordinates index(x, y);

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -51,7 +51,7 @@ void ShpMemTiles::CreateNamedLayerIndex(const std::string &layerName) {
 	indices[layerName]=RTree();
 }
 
-OutputObjectRef ShpMemTiles::AddObject(uint_least8_t layerNum,
+OutputObjectRef ShpMemTiles::StoreShapefileGeometry(uint_least8_t layerNum,
 	const std::string &layerName, enum OutputGeometryType geomType,
 	Geometry geometry, bool isIndexed, bool hasName, const std::string &name, AttributeStoreRef attributes, uint minzoom) {
 

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -29,6 +29,7 @@ void TileDataSource::MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileI
 	}
 }
 
+// Find the tiles used by the "large objects" from the rtree index
 void TileDataSource::MergeLargeCoordsAtZoom(uint zoom, TileCoordinatesSet &dstCoords) {
 	for(auto const &result: box_rtree) {
 		int scale = pow(2, baseZoom-zoom);

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -29,6 +29,7 @@ void TileDataSource::MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileI
 	}
 }
 
+// Copy objects from the tile at dstIndex (in the dataset srcTiles) into dstTile
 void TileDataSource::MergeSingleTileDataAtZoom(TileCoordinates dstIndex, uint zoom, uint baseZoom, const TileIndex &srcTiles, std::vector<OutputObjectRef> &dstTile) {
 	if (zoom==baseZoom) {
 		// at z14, we can just use tileIndex


### PR DESCRIPTION
This is a revival and reworking of #323.

The bounding boxes of large polygons (e.g. ocean) are stored in an rtree data structure rather than for each individual z14 tile. We then query this rtree when writing out each tile, and add any objects we find.

Tests with a couple of smaller areas (Devon and Maine) suggest little to no performance impact.