### PR TITLE
Use faster bbox-specialised clipping algorithm

### DIFF
--- a/include/geom.h
+++ b/include/geom.h
@@ -89,5 +89,10 @@ void make_valid(GeometryT &geom) { }
 
 void make_valid(MultiPolygon &mp);
 
+Point intersect_edge(Point const &a, Point const &b, char edge, Box const &bbox);
+char bit_code(Point const &p, Box const &bbox);
+void fast_clip(Ring &points, Box const &bbox);
+void fast_clip(MultiPolygon &mp, Box const &bbox);
+
 #endif //_GEOM_TYPES_H
 


### PR DESCRIPTION
When writing tiles, we spend a lot of time in `boost::geometry::intersection`. This is an all-purpose polygon intersection routine. Our needs are more specialised: we just want to clip polygons to a rectangular bounding box.

This PR replaces the call to `boost::geometry::intersection` with a simpler and (hopefully) faster clipping routine - the Sutherland-Hodgman algorithm, ported from https://github.com/mapbox/lineclip.

Comparative timings:

- Devon: 88s (master) -> 30s (this branch)
- Maine: 34m37 -> 4m23
- Antarctica: 7hr29 -> 2hr10 _(on HDD: looks IO-bound so could be sped up further)_
- Europe: 8hr12 (v2.0) -> 4hr34 (with --store)

File size is similar and as yet I haven't spotted any rendering artefacts.