### PR TITLE
Configurable sort order

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,6 +73,7 @@ You can add optional parameters to layers:
 * `filter_below` - filter areas by minimum size below this zoom level
 * `filter_area` - minimum size (in square degrees of longitude) for the zoom level `filter_below-1`
 * `combine_polygons_below` - merge adjacent polygons with the same attributes below this zoom level
+* `z_order_ascending` - sort features in ascending order by a numeric value set in the Lua processing script (defaults to `true`: specify `false` for descending order)
 
 Use these options to combine different layer specs within one outputted layer. For example:
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -156,14 +156,6 @@ LatpLon buildNodeGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 
 bool operator==(const OutputObjectRef x, const OutputObjectRef y);
 
-/**
- * Do lexicographic comparison, with the order of: layer, geomType, attributes, and objectID.
- * Note that attributes is preferred to objectID.
- * It is to arrange objects with the identical attributes continuously.
- * Such objects will be merged into one object, to reduce the size of output.
- */
-bool operator<(const OutputObjectRef x, const OutputObjectRef y);
-
 namespace vector_tile {
 	bool operator==(const vector_tile::Tile_Value &x, const vector_tile::Tile_Value &y);
 	bool operator<(const vector_tile::Tile_Value &x, const vector_tile::Tile_Value &y);

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -24,6 +24,7 @@ struct LayerDef {
 	uint filterBelow;
 	double filterArea;
 	uint combinePolygonsBelow;
+	bool sortZOrderAscending;
 	std::string source;
 	std::vector<std::string> sourceColumns;
 	bool allSourceColumns;
@@ -44,14 +45,14 @@ public:
 	// Define a layer (as read from the .json file)
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,
 			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
-			uint filterBelow, double filterArea, uint combinePolygonsBelow,
+			uint filterBelow, double filterArea, uint combinePolygonsBelow, bool sortZOrderAscending,
 			const std::string &source,
 			const std::vector<std::string> &sourceColumns,
 			bool allSourceColumns,
 			bool indexed,
 			const std::string &indexName,
 			const std::string &writeTo);
-
+	std::vector<bool> getSortOrders();
 	rapidjson::Value serialiseToJSONValue(rapidjson::Document::AllocatorType &allocator) const;
 	std::string serialiseToJSON() const;
 };

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -68,7 +68,9 @@ private:
 
 TileCoordinatesSet GetTileCoordinates(std::vector<class TileDataSource *> const &sources, unsigned int zoom);
 
-std::vector<OutputObjectRef> GetTileData(std::vector<class TileDataSource *> const &sources, TileCoordinates coordinates, unsigned int zoom);
+std::vector<OutputObjectRef> GetTileData(std::vector<class TileDataSource *> const &sources,
+                                         std::vector<bool> const &sortOrders, 
+                                         TileCoordinates coordinates, unsigned int zoom);
 
 OutputObjectsConstItPair GetObjectsAtSubLayer(std::vector<OutputObjectRef> const &data, uint_least8_t layerNum);
 

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -222,23 +222,6 @@ bool operator==(const OutputObjectRef x, const OutputObjectRef y) {
 		x->objectID == y->objectID;
 } 
 
-// Do lexicographic comparison, with the order of: layer, geomType, attributes, and objectID.
-// Note that attributes is preffered to objectID.
-// It is to arrange objects with the identical attributes continuously.
-// Such objects will be merged into one object, to reduce the size of output.
-bool operator<(const OutputObjectRef x, const OutputObjectRef y) {
-	if (x->layer < y->layer) return true;
-	if (x->layer > y->layer) return false;
-	if (x->z_order < y->z_order) return true;
-	if (x->z_order > y->z_order) return false;
-	if (x->geomType < y->geomType) return true;
-	if (x->geomType > y->geomType) return false;
-	if (x->attributes.get() < y->attributes.get()) return true;
-	if (x->attributes.get() > y->attributes.get()) return false;
-	if (x->objectID < y->objectID) return true;
-	return false;
-} 
-
 namespace vector_tile {
 	bool operator==(const vector_tile::Tile_Value &x, const vector_tile::Tile_Value &y) {
 		std::string strx = x.SerializeAsString();

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -19,7 +19,7 @@ SharedData::~SharedData() { }
 // Define a layer (as read from the .json file)
 uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
-		uint filterBelow, double filterArea, uint combinePolygonsBelow,
+		uint filterBelow, double filterArea, uint combinePolygonsBelow, bool sortZOrderAscending,
 		const std::string &source,
 		const std::vector<std::string> &sourceColumns,
 		bool allSourceColumns,
@@ -29,7 +29,7 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 
 	bool isWriteTo = !writeTo.empty();
 	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
-		filterBelow, filterArea, combinePolygonsBelow,
+		filterBelow, filterArea, combinePolygonsBelow, sortZOrderAscending,
 		source, sourceColumns, allSourceColumns, indexed, indexName,
 		std::map<std::string,uint>(), isWriteTo };
 	layers.push_back(layer);
@@ -54,6 +54,11 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 	return layerNum;
 }
 
+std::vector<bool> LayerDefinition::getSortOrders() {
+	std::vector<bool> orders;
+	for (auto &layer : layers) { orders.emplace_back(layer.sortZOrderAscending); }
+	return orders;
+}
 
 Value LayerDefinition::serialiseToJSONValue(rapidjson::Document::AllocatorType &allocator) const {
 	Value layerArray(kArrayType);
@@ -191,6 +196,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		int    filterBelow    = it->value.HasMember("filter_below"   ) ? it->value["filter_below"   ].GetInt()    : 0;
 		double filterArea     = it->value.HasMember("filter_area"    ) ? it->value["filter_area"    ].GetDouble() : 0.5;
 		int    combinePolyBelow=it->value.HasMember("combine_polygons_below") ? it->value["combine_polygons_below"].GetInt() : 0;
+		bool sortZOrderAscending = it->value.HasMember("z_order_ascending") ? it->value["z_order_ascending"].GetBool() : true;
 		string source = it->value.HasMember("source") ? it->value["source"].GetString() : "";
 		vector<string> sourceColumns;
 		bool allSourceColumns = false;
@@ -210,7 +216,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 
 		layers.addLayer(layerName, minZoom, maxZoom,
 				simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
-				filterBelow, filterArea, combinePolyBelow,
+				filterBelow, filterArea, combinePolyBelow, sortZOrderAscending,
 				source, sourceColumns, allSourceColumns, indexed, indexName,
 				writeTo);
 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -326,6 +326,7 @@ int main(int argc, char* argv[]) {
 	// ----	Read all PBFs
 	
 	PbfReader pbfReader(osmStore);
+	std::vector<bool> sortOrders = layers.getSortOrders();
 
 	if (!mapsplit) {
 		for (auto inputFile : inputFiles) {
@@ -469,7 +470,7 @@ int main(int argc, char* argv[]) {
 				for(std::size_t i = start_index; i < end_index; ++i) {
 					unsigned int zoom = tile_coordinates[i].first;
 					TileCoordinates coords = tile_coordinates[i].second;
-					outputProc(pool, sharedData, osmStore, GetTileData(sources, coords, zoom), coords, zoom);
+					outputProc(pool, sharedData, osmStore, GetTileData(sources, sortOrders, coords, zoom), coords, zoom);
 				}
 
 				const std::lock_guard<std::mutex> lock(io_mutex);


### PR DESCRIPTION
This is the first part of integrating #393 and implements the option to control whether features are sorted in ascending/descending z-order, as utilised by Shortbread.

Differences from #393:

- The parameter is called `z_order_ascending` rather than `sort_z_level_ascending`. We call it z order throughout tilemaker (as opposed to z index or z level) so this is consistent. (You can of course set both properties in the JSON for backward compatibility if you want to!)
- We store the flag in the layer and don't persist it into the output objects. Instead, we have a small vector of flags which we use in the sort routine. This requires converting the sort to a lambda so that we can access the vector.

I'll look at the other half of #393 next (sorting by large numbers).

cc @Nakaner @woodpeck