### PR TITLE
Use line break when outputting status to non-TTY

### DIFF
--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -226,6 +226,7 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 		nodeKeyPositions.insert(findStringPosition(pb, it.c_str()));
 	}
 
+	bool is_terminal = isatty(1);
 	for (int i=0; i<pb.primitivegroup_size(); i++) {
 		PrimitiveGroup pg;
 		pg = pb.primitivegroup(i);
@@ -234,7 +235,11 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 		{
 			std::ostringstream str;
 			osmStore.reportStoreSize(str);
-			str << "Block " << progress.first << "/" << progress.second << " ways " << pg.ways_size() << " relations " << pg.relations_size() << "        \r";
+			str << "Block " << progress.first << "/" << progress.second << " ways " << pg.ways_size() << " relations " << pg.relations_size();
+			if (is_terminal)
+				str << "        \r";
+			else
+				str << std::endl;
 			std::cout << str.str();
 			std::cout.flush();
 		};
@@ -251,8 +256,12 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 		if(phase == ReadPhase::RelationScan || phase == ReadPhase::All) {
 			osmStore.ensure_used_ways_inited();
 			bool done = ScanRelations(output, pg, pb);
-			if(done) { 
-				std::cout << "(Scanning for ways used in relations: " << (100*progress.first/progress.second) << "%)\r";
+			if(done) {
+				std::cout << "(Scanning for ways used in relations: " << (100*progress.first/progress.second) << "%)";
+				if (isatty(1))
+					std::cout << "\r";
+				else
+					std::cout << std::endl;
 				std::cout.flush();
 				continue;
 			}

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -457,6 +457,7 @@ int main(int argc, char* argv[]) {
 			}
 		}
 
+		bool is_terminal = isatty(1);
 		std::size_t interval = 1;
 		std::size_t zoomDisplay = 0;
 		for(std::size_t start_index = 0; start_index < tile_coordinates.size(); start_index += interval) {
@@ -464,6 +465,8 @@ int main(int argc, char* argv[]) {
 			if (zoom > 10) interval = 10;
 			if (zoom > 11) interval = 100;
 			if (zoom > 12) interval = 1000;
+			if (zoom > 13) interval = 5000;
+			if (zoom > 14) interval = 10000;
 
 			boost::asio::post(pool, [=, &tile_coordinates, &pool, &sharedData, &osmStore, &io_mutex, &tc, &zoomDisplay]() {
 				std::size_t end_index = std::min(tile_coordinates.size(), start_index + interval);
@@ -478,7 +481,12 @@ int main(int argc, char* argv[]) {
 
 				unsigned int zoom = tile_coordinates[end_index-1].first;
 				if (zoom>zoomDisplay) zoomDisplay = zoom;
-				cout << "Zoom level " << zoomDisplay << ", writing tile " << tc << " of " << tile_coordinates.size() << "               \r" << std::flush;
+				cout << "Zoom level " << zoomDisplay << ", writing tile " << tc << " of " << tile_coordinates.size();
+				if (is_terminal)
+					cout << "               \r";
+				else
+					cout << std::endl;
+				cout << std::flush;
 			});
 		}
 		


### PR DESCRIPTION
When using tilemaker in non-interactive scripts, the logs get a little confusing because there are no line breaks between the status statements. This fix changes the output behavior depending on the output of `isatty(1)` (I haven't tried this on windows yet)