### PR TITLE
Support type=boundary relations as native multipolygons

### DIFF
--- a/docs/RELATIONS.md
+++ b/docs/RELATIONS.md
@@ -7,7 +7,9 @@ Note that relation support is in its early stages and behaviour may change betwe
 
 ### Multipolygon relations
 
-Multipolygon and boundary relations are supported natively by tilemaker; you do not need to write special Lua code for them. When a multipolygon or boundary is read, tilemaker constructs the geometry as normal, and passes the tags to `way_function` just as it would a simple area.
+Multipolygon relations are supported natively by tilemaker; you do not need to write special Lua code for them. When a multipolygon is read, tilemaker constructs the geometry as normal, and passes the tags to `way_function` just as it would a simple area.
+
+Boundary relations also have automatic handling of inner/outer ways, but are otherwise processed as relations. This means that you can choose to treat boundaries as properties on ways (see "Stage 2" below) or as complete geometries (see "Writing relation geometries"). You will typically want the properties-on-ways approach for administrative boundaries, and the complete-geometries approach for filled areas such as forests or nature reserves.
 
 
 ### Reading relation memberships

--- a/docs/RELATIONS.md
+++ b/docs/RELATIONS.md
@@ -1,13 +1,13 @@
 ## Relations
 
-Tilemaker has (as yet not complete) support for reading relations in the Lua process scripts. This means you can support route and boundary relations when creating your vector tiles.
+Tilemaker has (as yet not complete) support for reading relations in the Lua process scripts. This means you can support objects like route relations when creating your vector tiles.
 
 Note that relation support is in its early stages and behaviour may change between point versions.
 
 
 ### Multipolygon relations
 
-Multipolygon relations are supported natively by tilemaker; you do not need to write special Lua code for them. When a multipolygon is read, tilemaker constructs the geometry as normal, and passes the tags to `way_function` just as it would a simple area.
+Multipolygon and boundary relations are supported natively by tilemaker; you do not need to write special Lua code for them. When a multipolygon or boundary is read, tilemaker constructs the geometry as normal, and passes the tags to `way_function` just as it would a simple area.
 
 
 ### Reading relation memberships

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -81,7 +81,7 @@ public:
 	 * (note that we store relations as ways with artificial IDs, and that
 	 *  we use decrementing positive IDs to give a bit more space for way IDs)
 	 */
-	void setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags, bool isNativeMP);
+	void setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags, bool isNativeMP, bool isInnerOuter);
 
 	// ----	Metadata queries called from Lua
 

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -336,6 +336,7 @@ private:
 };
 
 // relation store
+// (this isn't currently used as we don't need to store relations for later processing, but may be needed for nested relations)
 
 class RelationStore {
 
@@ -384,7 +385,7 @@ private:
 	OSMStore will be mainly used for geometry generation. Geometry generation logic is implemented in this class.
 	These functions are used by osm_output, and can be used by OsmLuaProcessing to provide the geometry information to Lua.
 
-	Internal data structures are encapsulated in NodeStore, WayStore and RelationStore classes.
+	Internal data structures are encapsulated in NodeStore, WayStore and [unused] RelationStore classes.
 	These store can be altered for efficient memory use without global code changes.
 	Such data structures have to return const ForwardInputIterators (only *, ++ and == should be supported).
 
@@ -429,7 +430,7 @@ protected:
 	bool require_integrity = true;
 
 	WayStore ways;
-	RelationStore relations;
+	RelationStore relations; // unused
 	UsedWays used_ways;
 	RelationScanStore scanned_relations;
 

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -53,6 +53,14 @@ private:
 	bool ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb);
 	bool ReadRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb);
 
+	inline bool RelationIsType(Relation const &rel, int typeKey, int val) {
+		if (typeKey==-1 || val==-1) return false;
+		auto typeI = std::find(rel.keys().begin(), rel.keys().end(), typeKey);
+		if (typeI==rel.keys().end()) return false;
+		int typePos = typeI - rel.keys().begin();
+		return rel.vals().Get(typePos) == val;
+	}
+
 	/// Find a string in the dictionary
 	static int findStringPosition(PrimitiveBlock const &pb, char const *str);
 	

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -207,9 +207,6 @@ waterwayClasses = Set { "stream", "river", "canal", "drain", "ditch" }
 -- Scan relations for use in ways
 
 function relation_scan_function(relation)
-	if relation:Find("type")=="boundary" and relation:Find("boundary")=="administrative" then
-		relation:Accept()
-	end
 end
 
 -- Process way tags
@@ -246,25 +243,10 @@ function way_function(way)
 	if landuse == "field" then landuse = "farmland" end
 	if landuse == "meadow" and way:Find("meadow")=="agricultural" then landuse="farmland" end
 
-	-- Boundaries within relations
-	local admin_level = 11
-	local isBoundary = false
-	while true do
-		local rel = way:NextRelation()
-		if not rel then break end
-		isBoundary = true
-		admin_level = math.min(admin_level, tonumber(way:FindInRelation("admin_level")) or 11)
-	end
-
-	-- Boundaries in ways
-	if boundary=="administrative" then
-		admin_level = math.min(admin_level, tonumber(way:Find("admin_level")) or 11)
-		isBoundary = true
-	end
-	
 	-- Administrative boundaries
 	-- https://openmaptiles.org/schema/#boundary
-	if isBoundary and not (way:Find("maritime")=="yes") then
+	if boundary=="administrative" and isClosed and not (way:Find("maritime")=="yes") then
+		local admin_level = math.min(11, tonumber(way:Find("admin_level")) or 11)
 		local mz = 0
 		if     admin_level>=3 and admin_level<5 then mz=4
 		elseif admin_level>=5 and admin_level<7 then mz=8

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -127,11 +127,11 @@ bool PbfReader::ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 
 	int typeKey = findStringPosition(pb, "type");
 	int mpKey   = findStringPosition(pb, "multipolygon");
+	int boundaryKey = findStringPosition(pb, "boundary");
 
 	for (int j=0; j<pg.relations_size(); j++) {
 		Relation pbfRelation = pg.relations(j);
-		bool isMultiPolygon = (find(pbfRelation.keys().begin(), pbfRelation.keys().end(), typeKey) != pbfRelation.keys().end()) &&
-		                      (find(pbfRelation.vals().begin(), pbfRelation.vals().end(), mpKey  ) != pbfRelation.vals().end());
+		bool isMultiPolygon = RelationIsType(pbfRelation, typeKey, mpKey) || RelationIsType(pbfRelation, typeKey, boundaryKey);
 		bool isAccepted = false;
 		WayID relid = static_cast<WayID>(pbfRelation.id());
 		if (!isMultiPolygon) {
@@ -160,13 +160,13 @@ bool PbfReader::ReadRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 
 		int typeKey = findStringPosition(pb, "type");
 		int mpKey   = findStringPosition(pb, "multipolygon");
+		int boundaryKey = findStringPosition(pb, "boundary");
 		int innerKey= findStringPosition(pb, "inner");
 		//int outerKey= findStringPosition(pb, "outer");
 		if (typeKey >-1 && mpKey>-1) {
 			for (int j=0; j<pg.relations_size(); j++) {
 				Relation pbfRelation = pg.relations(j);
-				bool isMultiPolygon = (find(pbfRelation.keys().begin(), pbfRelation.keys().end(), typeKey) != pbfRelation.keys().end()) &&
-				                      (find(pbfRelation.vals().begin(), pbfRelation.vals().end(), mpKey  ) != pbfRelation.vals().end());
+				bool isMultiPolygon = RelationIsType(pbfRelation, typeKey, mpKey) || RelationIsType(pbfRelation, typeKey, boundaryKey);
 				if (!isMultiPolygon && !output.canWriteRelations()) continue;
 
 				// Read relation members

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -131,15 +131,17 @@ bool PbfReader::ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 
 	for (int j=0; j<pg.relations_size(); j++) {
 		Relation pbfRelation = pg.relations(j);
-		bool isMultiPolygon = RelationIsType(pbfRelation, typeKey, mpKey) || RelationIsType(pbfRelation, typeKey, boundaryKey);
+		bool isMultiPolygon = RelationIsType(pbfRelation, typeKey, mpKey);
+		bool isBoundary = RelationIsType(pbfRelation, typeKey, boundaryKey);
 		bool isAccepted = false;
 		WayID relid = static_cast<WayID>(pbfRelation.id());
 		if (!isMultiPolygon) {
-			if (!output.canReadRelations()) continue;
-			tag_map_t tags;
-			readTags(pbfRelation, pb, tags);
-			isAccepted = output.scanRelation(relid, tags);
-			if (!isAccepted) continue;
+			if (output.canReadRelations()) {
+				tag_map_t tags;
+				readTags(pbfRelation, pb, tags);
+				isAccepted = output.scanRelation(relid, tags);
+			}
+			if (!isAccepted && !isBoundary) continue;
 		}
 		int64_t lastID = 0;
 		for (int n=0; n < pbfRelation.memids_size(); n++) {
@@ -162,22 +164,23 @@ bool PbfReader::ReadRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 		int mpKey   = findStringPosition(pb, "multipolygon");
 		int boundaryKey = findStringPosition(pb, "boundary");
 		int innerKey= findStringPosition(pb, "inner");
-		//int outerKey= findStringPosition(pb, "outer");
+		int outerKey= findStringPosition(pb, "outer");
 		if (typeKey >-1 && mpKey>-1) {
 			for (int j=0; j<pg.relations_size(); j++) {
 				Relation pbfRelation = pg.relations(j);
-				bool isMultiPolygon = RelationIsType(pbfRelation, typeKey, mpKey) || RelationIsType(pbfRelation, typeKey, boundaryKey);
-				if (!isMultiPolygon && !output.canWriteRelations()) continue;
+				bool isMultiPolygon = RelationIsType(pbfRelation, typeKey, mpKey);
+				bool isBoundary = RelationIsType(pbfRelation, typeKey, boundaryKey);
+				if (!isMultiPolygon && !isBoundary && !output.canWriteRelations()) continue;
 
 				// Read relation members
 				WayVec outerWayVec, innerWayVec;
 				int64_t lastID = 0;
+				bool isInnerOuter = isBoundary || isMultiPolygon;
 				for (int n=0; n < pbfRelation.memids_size(); n++) {
 					lastID += pbfRelation.memids(n);
 					if (pbfRelation.types(n) != Relation_MemberType_WAY) { continue; }
 					int32_t role = pbfRelation.roles_sid(n);
-					// if (role != innerKey && role != outerKey) { continue; }
-					// ^^^^ commented out so that we don't die horribly when a relation has no outer way
+					if (role==innerKey || role==outerKey) isInnerOuter=true;
 					WayID wayId = static_cast<WayID>(lastID);
 					(role == innerKey ? innerWayVec : outerWayVec).push_back(wayId);
 				}
@@ -185,14 +188,7 @@ bool PbfReader::ReadRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 				try {
 					tag_map_t tags;
 					readTags(pbfRelation, pb, tags);
-
-					// Store the relation members in the global relation store
-					relations.push_back(std::make_pair(pbfRelation.id(), 
-						std::make_pair(
-							RelationStore::wayid_vector_t(outerWayVec.begin(), outerWayVec.end()),
-							RelationStore::wayid_vector_t(innerWayVec.begin(), innerWayVec.end()))));
-
-					output.setRelation(pbfRelation.id(), outerWayVec, innerWayVec, tags, isMultiPolygon);
+					output.setRelation(pbfRelation.id(), outerWayVec, innerWayVec, tags, isMultiPolygon, isInnerOuter);
 
 				} catch (std::out_of_range &err) {
 					// Relation is missing a member?

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -127,12 +127,10 @@ bool PbfReader::ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 
 	int typeKey = findStringPosition(pb, "type");
 	int mpKey   = findStringPosition(pb, "multipolygon");
-	int boundaryKey = findStringPosition(pb, "boundary");
 
 	for (int j=0; j<pg.relations_size(); j++) {
 		Relation pbfRelation = pg.relations(j);
 		bool isMultiPolygon = RelationIsType(pbfRelation, typeKey, mpKey);
-		bool isBoundary = RelationIsType(pbfRelation, typeKey, boundaryKey);
 		bool isAccepted = false;
 		WayID relid = static_cast<WayID>(pbfRelation.id());
 		if (!isMultiPolygon) {
@@ -141,7 +139,7 @@ bool PbfReader::ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, Prim
 				readTags(pbfRelation, pb, tags);
 				isAccepted = output.scanRelation(relid, tags);
 			}
-			if (!isAccepted && !isBoundary) continue;
+			if (!isAccepted) continue;
 		}
 		int64_t lastID = 0;
 		for (int n=0; n < pbfRelation.memids_size(); n++) {


### PR DESCRIPTION
This enables boundary relations to benefit from multipolygon inner/outer processing.

You can now treat boundary relations in one of two ways:

- as properties on a way, iterated through with `NextRelation` (this is good for administrative boundaries which are often coterminous)
- as discrete geometries, processed with `relation_function` (this is good for nature reserves, forests and other polygons)

An example of the latter would be:

````lua
function relation_scan_function(relation)
  if relation:Find("type")=="boundary" then
    relation:Accept()
  end
end

function relation_function(relation)
  if relation:Find("type")=="boundary" and relation:Find("boundary")=="protected_area" then
    relation:Layer("park",true)
    relation:Attribute("class", "public_park")
    SetNameAttributes(relation)
  end
end
````

In essence, any relation with inner/outer roles will be processed as a multipolygon by `relation_function`, apart from `type=multipolygon` which is processed by `way_function`. To process relations other than `type=multipolygon`, writing a `relation_scan_function` is still required.