### PR TITLE
feat: add CI to build and push docker image to Github package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: "Continuous Integration"
 
 on:
   push:
-  pull_request:
     branches: [ master ]
+  pull_request:
 
 env:
   AREA: liechtenstein
@@ -117,3 +117,39 @@ jobs:
       with:
         input: ${{ env.AREA }}.osm.pbf 
         output: ${{ env.AREA }}.mbtiles
+
+  docker-build:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        if: ${{ github.ref == 'refs/heads/master'}}
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I added a workflow in CI.yml to build docker image and push it to GitHub package's container registry. I believe having an official docker image is useful for developers to use tilemaker easily.

After merging this pull request, every push to master branch trigger this workflow to update docker image in Github.

You should be able to pull docker image as following command
```
docker pull ghcr.io/systemed/tilemaker:master
```

or directly run as follows

```
docker run -v /Users/Local/Downloads/:/srv -i -t --rm ghcr.io/systemed/tilemaker:master /srv/germany-latest.osm.pbf --output=/srv/germany.mbtiles
```

You can try docker image through my forked repo's Github Package (https://github.com/JinIgarashi/tilemaker/pkgs/container/tilemaker)

For this PR, nothing needs to be done in the repository settings.

As you are discussing in https://github.com/systemed/tilemaker/pull/365, there are some restriction of use of Github Packages if this repository is private access. But I believe there is no disadvantage of using it since this is public repo and open source project.