### PR TITLE
Use prebuilt Docker image in GitHub action to speed it up

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: '--verbose'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/systemed/tilemaker:master'
   args:
     - --input=${{ inputs.input }}
     - --config=${{ inputs.config }}


### PR DESCRIPTION
Reduces the duration of workflows using this action by 3-5mins, as it doesn't have to build Tilemaker each workflow, it can just pull the Docker image.