### PR TITLE
Report OSM ID on Lua processing error

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -191,6 +191,8 @@ public:
 
 	inline AttributeStore &getAttributeStore() { return attributeStore; }
 
+	struct luaProcessingException :std::exception {};
+
 private:
 	/// Internal: clear current cached state
 	inline void reset() {
@@ -247,7 +249,6 @@ private:
 	
 	std::deque<std::pair<OutputObjectRef, AttributeStoreRef>> outputs;			///< All output objects that have been created
 	boost::container::flat_map<std::string, std::string> currentTags;
-
 };
 
 #endif //_OSM_LUA_PROCESSING_H


### PR DESCRIPTION
This improves error handling from Lua profiles to:

- Report the ID of the OSM object on which the error occurred
- Output a stack trace if using Lua 5.2+
- No longer b0rk with a misleading "Type mismatch" every time