### PR TITLE
OpenMapTiles implementation: Add missing attributes, use correct classes/subclasses

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -197,6 +197,8 @@ poiClasses      = { townhall="town_hall", public_building="town_hall", courthous
 					bag="clothing_store", clothes="clothing_store",
 					swimming_area="swimming", swimming="swimming",
 					castle="castle", ruins="castle" }
+-- POI classes where class is the matching value and subclass is the value of a separate key
+poiSubClasses = { information="information", place_of_worship="religion", pitch="sport" }
 poiClassRanks   = { hospital=1, railway=2, bus=3, attraction=4, harbor=5, college=6,
 					school=7, stadium=8, zoo=9, town_hall=10, campsite=11, cemetery=12,
 					park=13, library=14, police=15, post=16, golf=17, shop=18, grocery=19,
@@ -649,6 +651,11 @@ function GetPOIRank(obj)
 			v = obj:Find(k)	-- k/v are the OSM tag pair
 			class = poiClasses[v] or k
 			rank  = poiClassRanks[class] or 25
+			subclassKey = poiSubClasses[v]
+			if subclassKey then
+				class = v
+				v = obj:Find(subclassKey)
+			end
 			return rank, class, v
 		end
 	end

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -584,6 +584,15 @@ function WritePOI(obj,class,subclass,rank)
 	obj:AttributeNumeric("rank", rank)
 	obj:Attribute("class", class)
 	obj:Attribute("subclass", subclass)
+	-- layer defaults to 0
+	obj:AttributeNumeric("layer", tonumber(obj:Find("layer")) or 0)
+	-- indoor defaults to false
+	obj:AttributeBoolean("indoor", (obj:Find("indoor") == "yes"))
+	-- level has no default
+	local level = tonumber(obj:Find("level"))
+	if level then
+		obj:AttributeNumeric("level", level)
+	end
 end
 
 -- Set name attributes on any object


### PR DESCRIPTION
For `tourism=information`, `amenity=place_of_worship` and `leisure=pitch`, other values are used for `class` and `subclass`.

This pull request also adds the missing attributes.