### PR TITLE
Support for a tile-relative "rank" attribute

### DIFF
--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -55,9 +55,9 @@ struct AttributeStore
 		switch(lhs_id) {
 			case Index::BOOL:
 				return lhs.bool_value() < rhs.bool_value();
-			case Index::FLOAT:	
+			case Index::FLOAT:
 				return lhs.float_value() < rhs.float_value();
-			case Index::STRING:	
+			case Index::STRING:
 				return lhs.string_value() < rhs.string_value();
 		}
 
@@ -111,7 +111,7 @@ struct AttributeStore
 
 	key_value_set_ref_t empty_set() const { return new key_value_set(); }
 
-    key_value_set_ref_t store_set(key_value_set_ref_t attributes) {
+	key_value_set_ref_t store_set(key_value_set_ref_t attributes) {
 		auto idx = attributes->values.size();
 		for(auto const &i: attributes->values) {
 			boost::hash_combine(idx, i.minzoom);

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -157,6 +157,7 @@ public:
 	void AttributeWithMinZoom(const std::string &key, const std::string &val, const char minzoom);
 	void AttributeNumeric(const std::string &key, const float val);
 	void AttributeNumericWithMinZoom(const std::string &key, const float val, const char minzoom);
+	void SetRank(const float val);
 	void AttributeBoolean(const std::string &key, const bool val);
 	void AttributeBooleanWithMinZoom(const std::string &key, const bool val, const char minzoom);
 	void MinZoom(const double z);

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -57,6 +57,7 @@ public:
 	unsigned minZoom 			: 4;
 
 	AttributeStoreRef attributes;
+	float_t rankValue = std::numeric_limits<float_t>::infinity();
 
 	void setZOrder(const ZOrder z) {
 #ifndef FLOAT_Z_ORDER
@@ -75,9 +76,12 @@ public:
 		this->attributes = attributes;
 	}
 
+	void setRankValue(const float_t value);
+
 	//\brief Write attribute key/value pairs (dictionary-encoded)
 	void writeAttributes(std::vector<std::string> *keyList, 
-		std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Feature *featurePtr, char zoom) const;
+		std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Feature *featurePtr, 
+		AttributeStoreRef extraAttributes, char zoom) const;
 	
 	/**
 	 * \brief Find a value in the value dictionary

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -31,6 +31,7 @@ struct LayerDef {
 	bool indexed;
 	std::string indexName;
 	std::map<std::string, uint> attributeMap;
+	uint64_t rankMax;
 	bool writeTo;
 };
 
@@ -51,6 +52,7 @@ public:
 			bool allSourceColumns,
 			bool indexed,
 			const std::string &indexName,
+			const uint64_t rankMax,
 			const std::string &writeTo);
 	std::vector<bool> getSortOrders();
 	rapidjson::Value serialiseToJSONValue(rapidjson::Document::AllocatorType &allocator) const;

--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -1,10 +1,10 @@
 {
 	"layers": {
-		"place":            { "minzoom":  0, "maxzoom": 14 },
+		"place":            { "minzoom":  0, "maxzoom": 14, "rank_max": 32 },
 		"boundary":         { "minzoom":  0, "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003, "simplify_ratio": 2 },
 
-		"poi":              { "minzoom": 12, "maxzoom": 14 },
-		"poi_detail":       { "minzoom": 14, "maxzoom": 14, "write_to": "poi"},
+		"poi":              { "minzoom": 12, "maxzoom": 14, "rank_max": 64 },
+		"poi_detail":       { "minzoom": 14, "maxzoom": 14, "rank_max": 64, "write_to": "poi"},
 
 		"housenumber":      { "minzoom": 14, "maxzoom": 14 },
 

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -76,15 +76,14 @@ function node_function(node)
 	--   we could potentially approximate it for cities based on the population tag
 	local place = node:Find("place")
 	if place ~= "" then
-		local rank = nil
 		local mz = 13
 		local pop = tonumber(node:Find("population")) or 0
 
 		if     place == "continent"     then mz=0
 		elseif place == "country"       then
-			if     pop>50000000 then rank=1; mz=1
-			elseif pop>20000000 then rank=2; mz=2
-			else                     rank=3; mz=3 end
+			if     pop>50000000 then           mz=1
+			elseif pop>20000000 then           mz=2
+			else                               mz=3 end
 		elseif place == "state"         then mz=4
 		elseif place == "city"          then mz=5
 		elseif place == "town" and pop>8000 then mz=7
@@ -100,7 +99,7 @@ function node_function(node)
 		node:Layer("place", false)
 		node:Attribute("class", place)
 		node:MinZoom(mz)
-		if rank then node:AttributeNumeric("rank", rank) end
+		node:SetRank(pop)
 		if place=="country" then node:Attribute("iso_a2", node:Find("ISO3166-1:alpha2")) end
 		SetNameAttributes(node)
 		return
@@ -579,7 +578,7 @@ function WritePOI(obj,class,subclass,rank)
 	if rank>4 then layer="poi_detail" end
 	obj:LayerAsCentroid(layer)
 	SetNameAttributes(obj)
-	obj:AttributeNumeric("rank", rank)
+	obj:SetRank(rank)
 	obj:Attribute("class", class)
 	obj:Attribute("subclass", subclass)
 end

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -30,42 +30,49 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType)
 	return os;
 }
 
+void OutputObject::setRankValue(const float_t value) {
+	rankValue = value;
+}
 
 // Write attribute key/value pairs (dictionary-encoded)
 void OutputObject::writeAttributes(
 	vector<string> *keyList, 
 	vector<vector_tile::Tile_Value> *valueList, 
 	vector_tile::Tile_Feature *featurePtr,
+	AttributeStoreRef extraAttributes,
 	char zoom) const {
 
-	for(auto const &it: attributes->values) {
-		if (it.minzoom > zoom) continue;
+	auto attributeList = { attributes, extraAttributes };
+	for (auto const attributes: attributeList) {
+		for(auto const &it: attributes->values) {
+			if (it.minzoom > zoom) continue;
 
-		// Look for key
-		std::string const &key = it.key;
-		auto kt = find(keyList->begin(), keyList->end(), key);
-		if (kt != keyList->end()) {
-			uint32_t subscript = kt - keyList->begin();
-			featurePtr->add_tags(subscript);
-		} else {
-			uint32_t subscript = keyList->size();
-			keyList->push_back(key);
-			featurePtr->add_tags(subscript);
-		}
-		
-		// Look for value
-		vector_tile::Tile_Value const &value = it.value;
-		int subscript = findValue(valueList, value);
-		if (subscript>-1) {
-			featurePtr->add_tags(subscript);
-		} else {
-			uint32_t subscript = valueList->size();
-			valueList->push_back(value);
-			featurePtr->add_tags(subscript);
-		}
+			// Look for key
+			std::string const &key = it.key;
+			auto kt = find(keyList->begin(), keyList->end(), key);
+			if (kt != keyList->end()) {
+				uint32_t subscript = kt - keyList->begin();
+				featurePtr->add_tags(subscript);
+			} else {
+				uint32_t subscript = keyList->size();
+				keyList->push_back(key);
+				featurePtr->add_tags(subscript);
+			}
+			
+			// Look for value
+			vector_tile::Tile_Value const &value = it.value;
+			int subscript = findValue(valueList, value);
+			if (subscript>-1) {
+				featurePtr->add_tags(subscript);
+			} else {
+				uint32_t subscript = valueList->size();
+				valueList->push_back(value);
+				featurePtr->add_tags(subscript);
+			}
 
-		//if(value.has_string_value())
-		//	std::cout << "Write attr: " << key << " " << value.string_value() << std::endl;	
+			//if(value.has_string_value())
+			//	std::cout << "Write attr: " << key << " " << value.string_value() << std::endl;	
+		}
 	}
 }
 

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -25,13 +25,14 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		bool allSourceColumns,
 		bool indexed,
 		const std::string &indexName,
+		const uint64_t rankMax,
 		const std::string &writeTo)  {
 
 	bool isWriteTo = !writeTo.empty();
 	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
 		filterBelow, filterArea, combinePolygonsBelow, sortZOrderAscending,
 		source, sourceColumns, allSourceColumns, indexed, indexName,
-		std::map<std::string,uint>(), isWriteTo };
+		std::map<std::string,uint>(), rankMax, isWriteTo };
 	layers.push_back(layer);
 	uint layerNum = layers.size()-1;
 	layerMap[name] = layerNum;
@@ -221,11 +222,17 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		}
 		string indexName = it->value.HasMember("index_column") ? it->value["index_column"].GetString() : "";
 
+		uint64_t rankMax = std::numeric_limits<uint64_t>::max();
+		if (it->value.HasMember("rank_max")) {
+			rankMax = it->value["rank_max"].GetUint64();
+			if (rankMax == 0) rankMax = std::numeric_limits<uint64_t>::max();
+		}
+
 		layers.addLayer(layerName, minZoom, maxZoom,
 				simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
 				filterBelow, filterArea, combinePolyBelow, sortZOrderAscending,
 				source, sourceColumns, allSourceColumns, indexed, indexName,
-				writeTo);
+				rankMax, writeTo);
 
 		cout << "Layer " << layerName << " (z" << minZoom << "-" << maxZoom << ")";
 		if (it->value.HasMember("write_to")) { cout << " -> " << it->value["write_to"].GetString(); }


### PR DESCRIPTION
I started [a discussion a year or so ago with no reaction about this feature](https://github.com/systemed/tilemaker/discussions/409), so I decided to try to implement it.

The original motivation behind creating this feature was to cut down on tile size / rendering speed by removing objects in the vector tile that wouldn't be displayed. OpenMapTiles uses postgres to reorder and dynamically set the rank attribute, while Tilemaker currently uses static values set in process.lua. For example, hardcoded min/max zoom and ranks for cities based on population can be fine for country or area level exports, but it's hard to create a general rule when trying to make tiles for a wide area that have different standards for city size / area, etc.

This feature introduces a new Lua function, `node:SetRank(x)` where `x` is the value in which the object is sorted. In the layer config, a new property `rank_max` is introduced that controls how many objects of the given layer are output in each tile. The calculated `rank` attribute is relative per map tile.

I'm setting this PR as a draft because while I got it working as a quick demo, I want to know if this is a feature that should be in tilemaker in the first place before continuing further (that said, this is something I really want personally so I think I'll be maintaining a fork until there's something comparable...). 

This is my first time writing C++ at this scale, so it would be great if someone could look over all my beginner mistakes! Thanks!