### PR TITLE
Skip 0-length ways

### DIFF
--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -98,6 +98,7 @@ bool PbfReader::ReadWays(OsmLuaProcessing &output, PrimitiveGroup &pg, Primitive
 					}
 				}
 			}
+			if (llVec.empty()) continue;
 
 			try {
 				tag_map_t tags;


### PR DESCRIPTION
This stops tilemaker segfaulting on openstreetmap.fr extracts.