### PR TITLE
Change example configration compress parameter to "gzip"

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -45,7 +45,7 @@ A typical config file would look like this:
         "maxzoom": 14,
         "basezoom": 14,
         "include_ids": false,
-        "compress": true,
+        "compress": "gzip",
         "name": "Tilemaker example",
         "version": "0.1",
         "description": "Sample vector tiles for tilemaker"


### PR DESCRIPTION
When I tried to run "compress": true, I got below error. "compress" should be any of "gzip","deflate","none" in JSON file.

Previous
```
    {
      "layers": {
        "roads": { "minzoom": 12, "maxzoom": 14 },
        "buildings": { "minzoom": 14, "maxzoom": 14 },
        "pois": { "minzoom": 13, "maxzoom": 14 }
      },
      "settings": {
        "minzoom": 12,
        "maxzoom": 14,
        "basezoom": 14,
        "include_ids": false,
        "compress": true,
        "name": "Tilemaker example",
        "version": "0.1",
        "description": "Sample vector tiles for tilemaker"
      }
    }
```
Thus, I changd  "compress": "gzip",