### PR TITLE
Fix Docker dynamic build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS src
+FROM debian:bullseye-slim AS src
 LABEL Description="Tilemaker" Version="1.4.0"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,15 @@ RUN cmake --build .
 RUN strip tilemaker
 
 FROM debian:bullseye-slim
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      liblua5.1-0 \
+      libprotobuf-dev \
+      libshp-dev \
+      libsqlite3-dev \
+      libboost-filesystem-dev \
+      libboost-program-options-dev \
+      libboost-iostreams-dev
 WORKDIR /
 COPY --from=src /build/tilemaker .
 COPY resources /resources


### PR DESCRIPTION
Fixes the dynamically linked Docker image by installing the required libs on the final Docker image as well as the build Docker image. Now that it's not statically linked, they need to be present on the final Docker image as well, so that the Tilemaker executable can access them.

Note that building it like this with dynamic linking and the dependencies installed on the image increases the size of the image to 444MB, undoing some of the work from #363.