### PR TITLE
free SHPObject when done with it

### DIFF
--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -165,7 +165,10 @@ void readShapefile(const Box &clippingBox,
 		if (shapeBox.min_corner().get<0>() > clippingBox.max_corner().get<0>() ||
 		    shapeBox.max_corner().get<0>() < clippingBox.min_corner().get<0>() ||
 		    shapeBox.min_corner().get<1>() > clippingBox.max_corner().get<1>() ||
-		    shapeBox.max_corner().get<1>() < clippingBox.min_corner().get<1>()) { continue; }
+		    shapeBox.max_corner().get<1>() < clippingBox.min_corner().get<1>()) {
+			SHPDestroyObject(shape);
+			continue;
+		}
 
 		if (shapeType==1) {
 			// Points
@@ -281,6 +284,7 @@ void readShapefile(const Box &clippingBox,
 			// Not supported
 			cerr << "Shapefile entity #" << i << " type " << shapeType << " not supported" << endl;
 		}
+		SHPDestroyObject(shape);
 	}
 
 	SHPClose(shp);


### PR DESCRIPTION
It looks like Tilemaker converts shapefile objects into its own representation, after which point I think we can safely free the shape objects. I don't think `SHPClose` is sufficient to free the individual objects.

For the shapefiles used by the Shortbread tile set (1.4GB of coastline .shp files), this seems to decrease peak memory usage by ~1.7G