### PR TITLE
shard the node store to reduce memory usage

### DIFF
--- a/include/geom.h
+++ b/include/geom.h
@@ -47,6 +47,10 @@ typedef boost::variant<Point,Linestring,MultiLinestring,MultiPolygon> Geometry;
 typedef std::pair<Box, uint> IndexValue;
 typedef boost::geometry::index::rtree< IndexValue, boost::geometry::index::quadratic<16> > RTree;
 
+// A 36-bit integer can store all OSM node IDs; we represent this as 16 collections
+// of 32-bit integers.
+#define NODE_SHARDS 16
+typedef uint32_t ShardedNodeID;
 typedef uint64_t NodeID;
 typedef uint64_t WayID;
 

--- a/src/osm_store.cpp
+++ b/src/osm_store.cpp
@@ -262,10 +262,12 @@ void void_mmap_allocator::destroy(void *p)
 
 void NodeStore::sort(unsigned int threadNum) { 
 	std::lock_guard<std::mutex> lock(mutex);
-	boost::sort::block_indirect_sort(
-		mLatpLons->begin(), mLatpLons->end(), 
-		[](auto const &a, auto const &b) { return a.first < b.first; }, 
-		threadNum);
+	for (auto i = 0; i < NODE_SHARDS; i++) {
+		boost::sort::block_indirect_sort(
+			mLatpLons[i]->begin(), mLatpLons[i]->end(), 
+			[](auto const &a, auto const &b) { return a.first < b.first; }, 
+			threadNum);
+	}
 }
 
 void WayStore::sort(unsigned int threadNum) { 


### PR DESCRIPTION
It looks like PR #499 adopts 36 bits as the max size of an OSM ID.

The NodeStore currently uses a full 64 bits for these IDs. This PR changes it to shard the nodes across 16 collections (4 bits) and then store only the last 32 bits in the collection itself.

This reduces memory usage for the NodeStore by 25%, without much impact on runtime.

The CompactNodeStore is still much better, as it has no overhead and constant time lookups -- but I'm often lazy and not using a renumbered PBF file.