### PR TITLE
clear UsedWays sooner

### DIFF
--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -505,6 +505,7 @@ public:
 	void ensure_used_ways_inited() {
 		if (!used_ways.inited) used_ways.reserve(use_compact_nodes, nodes_size());
 	}
+	void clear_used_ways() { used_ways.clear(); }
 	
 	using tag_map_t = boost::container::flat_map<std::string, std::string>;
 	void relation_contains_way(WayID relid, WayID wayid) { scanned_relations.relation_contains_way(relid,wayid); }

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -22,7 +22,7 @@ class OsmLuaProcessing;
 class PbfReader
 {
 public:	
-	enum class ReadPhase { Nodes = 1, Ways = 2, Relations = 4, RelationScan = 8, All = 15 };
+	enum class ReadPhase { Nodes = 1, Ways = 2, Relations = 4, RelationScan = 8 };
 
 	PbfReader(OSMStore &osmStore);
 
@@ -46,7 +46,7 @@ public:
 
 private:
 	bool ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::pair<std::size_t, std::size_t> progress, std::size_t datasize, 
-	               std::unordered_set<std::string> const &nodeKeys, bool locationsOnWays, ReadPhase phase = ReadPhase::All);
+	               std::unordered_set<std::string> const &nodeKeys, bool locationsOnWays, ReadPhase phase);
 	bool ReadNodes(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb, const std::unordered_set<int> &nodeKeyPositions);
 
 	bool ReadWays(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb, bool locationsOnWays);

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -236,7 +236,7 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 			std::cout.flush();
 		};
 
-		if(phase == ReadPhase::Nodes || phase == ReadPhase::All) {
+		if(phase == ReadPhase::Nodes) {
 			bool done = ReadNodes(output, pg, pb, nodeKeyPositions);
 			if(done) { 
 				output_progress();
@@ -245,7 +245,7 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 			}
 		}
 
-		if(phase == ReadPhase::RelationScan || phase == ReadPhase::All) {
+		if(phase == ReadPhase::RelationScan) {
 			osmStore.ensure_used_ways_inited();
 			bool done = ScanRelations(output, pg, pb);
 			if(done) { 
@@ -255,7 +255,7 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 			}
 		}
 	
-		if(phase == ReadPhase::Ways || phase == ReadPhase::All) {
+		if(phase == ReadPhase::Ways) {
 			bool done = ReadWays(output, pg, pb, locationsOnWays);
 			if(done) { 
 				output_progress();
@@ -264,7 +264,7 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 			}
 		}
 
-		if(phase == ReadPhase::Relations || phase == ReadPhase::All) {
+		if(phase == ReadPhase::Relations) {
 			bool done = ReadRelations(output, pg, pb);
 			if(done) { 
 				output_progress();
@@ -352,6 +352,7 @@ int PbfReader::ReadPbfFile(unordered_set<string> const &nodeKeys, unsigned int t
 			osmStore.nodes_sort(threadNum);
 		}
 		if(phase == ReadPhase::Ways) {
+			osmStore.clear_used_ways();
 			osmStore.ways_sort(threadNum);
 		}
 	}


### PR DESCRIPTION
This is only a small improvement.

Previously, the memory for UsedWays is freed after all phases. This PR changes it to be freed before the final phase. For non-renumbered PBFs, UsedWays takes up 256MB, so giving that back is somewhat meaningful.

It may not make a practical difference in being able to process a larger PBF--I haven't dug too much into the memory use of the `Relations` phase to know if it uses much incremental memory.

This PR also removes the `ReadPhase::All` phase, which seems to be unused. I'm not sure if it's still in the code as a useful debugging thing, so please correct me if removing it was bad.