### PR TITLE
Use custom correct (make_valid) for clipping

### DIFF
--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -171,6 +171,7 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			geom::assign(mp, input);
 			fast_clip(mp, box);
 			geom::correct(mp);
+			if (!geom::is_valid(mp)) make_valid(mp);
 			return mp;
 		}
 


### PR DESCRIPTION
This uses the custom dissolve/correct from #249 after clipping multipolygons to tile boundaries. This should remove issues with 0-width borders which upset Maplibre GL Native (#574).

Unfortunately there is a performance impact to this: great-britain-latest.osm.pbf on my setup goes from 7m03 to 7m26. This is a shame but probably unavoidable.