### PR TITLE
Avoid copying strings/tag maps

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -92,7 +92,7 @@ public:
 	bool Holds(const std::string& key) const;
 
 	// Get an OSM tag for a given key (or return empty string if none)
-	std::string Find(const std::string& key) const;
+	const std::string& Find(const std::string& key) const;
 
 	// ----	Spatial queries called from Lua
 
@@ -249,7 +249,7 @@ private:
 	class LayerDefinition &layers;
 	
 	std::deque<std::pair<OutputObjectRef, AttributeStoreRef>> outputs;			///< All output objects that have been created
-	boost::container::flat_map<std::string, std::string> currentTags;
+	const boost::container::flat_map<std::string, std::string>* currentTags;
 };
 
 #endif //_OSM_LUA_PROCESSING_H

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -37,6 +37,7 @@ public:
 	using tag_map_t = boost::container::flat_map<std::string, std::string>;
 	template<typename T>
 	void readTags(T &pbfObject, PrimitiveBlock const &pb, tag_map_t &tags) {
+		tags.reserve(pbfObject.keys_size());
 		auto keysPtr = pbfObject.mutable_keys();
 		auto valsPtr = pbfObject.mutable_vals();
 		for (uint n=0; n < pbfObject.keys_size(); n++) {

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -7,6 +7,7 @@ using namespace std;
 
 thread_local kaguya::State *g_luaState = nullptr;
 bool supportsRemappingShapefiles = false;
+const std::string EMPTY_STRING = "";
 
 int lua_error_handler(int errCode, const char *errMessage)
 {
@@ -30,6 +31,7 @@ OsmLuaProcessing::OsmLuaProcessing(
 	osmMemTiles(osmMemTiles),
 	attributeStore(attributeStore),
 	config(configIn),
+	currentTags(NULL),
 	layers(layers) {
 
 	// ----	Initialise Lua
@@ -114,13 +116,13 @@ string OsmLuaProcessing::Id() const {
 
 // Check if there's a value for a given key
 bool OsmLuaProcessing::Holds(const string& key) const {
-	return currentTags.find(key) != currentTags.end();
+	return currentTags->find(key) != currentTags->end();
 }
 
 // Get an OSM tag for a given key (or return empty string if none)
-string OsmLuaProcessing::Find(const string& key) const {
-	auto it = currentTags.find(key);
-	if(it == currentTags.end()) return "";
+const string& OsmLuaProcessing::Find(const string& key) const {
+	auto it = currentTags->find(key);
+	if(it == currentTags->end()) return EMPTY_STRING;
 	return it->second;
 }
 
@@ -546,7 +548,7 @@ bool OsmLuaProcessing::scanRelation(WayID id, const tag_map_t &tags) {
 	originalOsmID = id;
 	isWay = false;
 	isRelation = true;
-	currentTags = tags;
+	currentTags = &tags;
 	try {
 		luaState["relation_scan_function"](this);
 	} catch(luaProcessingException &e) {
@@ -568,7 +570,7 @@ void OsmLuaProcessing::setNode(NodeID id, LatpLon node, const tag_map_t &tags) {
 	isRelation = false;
 	lon = node.lon;
 	latp= node.latp;
-	currentTags = tags;
+	currentTags = &tags;
 
 	//Start Lua processing for node
 	try {
@@ -617,7 +619,7 @@ void OsmLuaProcessing::setWay(WayID wayId, LatpLonVec const &llVec, const tag_ma
 		throw std::out_of_range(ss.str());
 	}
 
-	currentTags = tags;
+	currentTags = &tags;
 
 	bool ok = true;
 	if (ok) {
@@ -705,7 +707,7 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 	llVecPtr = nullptr;
 	outerWayVecPtr = &outerWayVec;
 	innerWayVecPtr = &innerWayVec;
-	currentTags = tags;
+	currentTags = &tags;
 
 	// Start Lua processing for relation
 	if (!isNativeMP && !supportsWritingRelations) return;

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -44,12 +44,14 @@ bool PbfReader::ReadNodes(OsmLuaProcessing &output, PrimitiveGroup &pg, Primitiv
 				}
 				kvPos++;
 			}
-			// For tagged nodes, call Lua, then save the OutputObject
-			boost::container::flat_map<std::string, std::string> tags;
 
 			nodes.push_back(std::make_pair(static_cast<NodeID>(nodeId), node));
 
 			if (significant) {
+				// For tagged nodes, call Lua, then save the OutputObject
+				boost::container::flat_map<std::string, std::string> tags;
+				tags.reserve(kvPos / 2);
+
 				for (uint n=kvStart; n<kvPos-1; n+=2) {
 					tags[pb.stringtable().s(dense.keys_vals(n))] = pb.stringtable().s(dense.keys_vals(n+1));
 				}


### PR DESCRIPTION
`OSMLuaProcessing`'s `Find`, `setWay`, `setNode` and `setRelation` functions are called a lot, so avoiding copies is helpful. Avoiding these copies results in a savings of ~1.5% of the time from startup to ready-to-write-output for my usage.

I believe the changes are safe: the tag map is only accessed for the duration of `setWay`, `setNode` and `setRelation`, so the pointer to the map in the caller's scope is fine.

I believe returning a reference from `::Find` is also OK: for `std::string`, the relevant code in Kaguya is: https://github.com/satoren/kaguya/blob/9d77cad73846f5d8481f3f7e86e8c53c4891c2fb/include/kaguya/type.hpp#L654-L657, which uses `lua_pushlstring` to pass it to Lua code.

And according to https://www.lua.org/pil/24.2.1.html:

> Lua never keeps pointers to external strings (or to any other object, except to C functions, which are always static). For any string that it has to keep, Lua either makes an internal copy or reuses one. Therefore, you can free or modify your buffer as soon as these functions return.