### PR TITLE
Re-use ifstream and OSMLuaProcessing

### DIFF
--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -26,8 +26,8 @@ public:
 
 	PbfReader(OSMStore &osmStore);
 
-	using pbfreader_generate_output = std::function< std::unique_ptr<OsmLuaProcessing> () >;
-	using pbfreader_generate_stream = std::function< std::unique_ptr<std::istream> () >;
+	using pbfreader_generate_output = std::function< std::shared_ptr<OsmLuaProcessing> () >;
+	using pbfreader_generate_stream = std::function< std::shared_ptr<std::istream> () >;
 
 	int ReadPbfFile(std::unordered_set<std::string> const &nodeKeys, unsigned int threadNum, 
 			pbfreader_generate_stream const &generate_stream,

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -336,10 +336,12 @@ int main(int argc, char* argv[]) {
 			
 			int ret = pbfReader.ReadPbfFile(nodeKeys, threadNum, 
 				[&]() { 
-					return std::make_unique<ifstream>(inputFile, ios::in | ios::binary);
+					thread_local std::shared_ptr<ifstream> pbfStream(new ifstream(inputFile, ios::in | ios::binary));
+					return pbfStream;
 				},
 				[&]() {
-					return std::make_unique<OsmLuaProcessing>(osmStore, config, layers, luaFile, shpMemTiles, osmMemTiles, attributeStore);
+					thread_local std::shared_ptr<OsmLuaProcessing> osmLuaProcessing(new OsmLuaProcessing(osmStore, config, layers, luaFile, shpMemTiles, osmMemTiles, attributeStore));
+					return osmLuaProcessing;
 				});	
 			if (ret != 0) return ret;
 		} 


### PR DESCRIPTION
Previously, these were generated four times per block.

Now they're thread-locals, so they're generated once per phase, independent of the number of blocks.

This seems to be important for PBFs from Geofabrik, which have many, small blocks vs BBBike:

- Geofabrik GB extract: 26,000 blocks, 65KB/block
- BBBike partial USA extract: 33 blocks, 16,000KB/block

When processing Geofabrik extracts, I noticed that my CPU was idler than I'd expect during the PBF reading phase. strace suggested that Lua initialization takes an expensive lock, blocking other readers who are also trying to initialize Lua.

PBF reading for Great Britain is a bit faster with this change:

Before:

real 1m48.685s
user 21m10.017s
sys 1m36.528s

After:

real 1m36.549s
user 19m52.995s
sys 0m54.015s