### PR TITLE
AttributeStore memory tweaks

### DIFF
--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -411,7 +411,7 @@ struct AttributeStore {
 	int lookups=0;
 
 	AttributeIndex add(AttributeSet &attributes);
-	std::set<AttributePair, AttributePairStore::key_value_less> get(AttributeIndex index) const;
+	std::vector<AttributePair> get(AttributeIndex index) const;
 	void reportSize() const;
 	void doneReading();
 

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -3,6 +3,7 @@
 #define _ATTRIBUTE_STORE_H
 
 #include <mutex>
+#include <deque>
 #include <iostream>
 #include <boost/functional/hash.hpp>
 #include <boost/container/flat_map.hpp>

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -370,6 +370,7 @@ struct AttributeSet {
 	}
 
 	void addPair(uint32_t index);
+	void removePairWithKey(const AttributePairStore& pairStore, uint32_t keyIndex);
 private:
 	void setValueAtIndex(size_t index, uint32_t value) {
 		if (useVector) {

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -162,7 +162,7 @@ struct AttributePair {
 		if (has_float_value()) {
 			float v = float_value();
 
-			if (v >= 0 && v <= 9 && (v == 0 || v == 1 || v == 2 || v == 3 || v == 4 || v == 5 || v == 6 || v == 7 || v == 8 || v == 9))
+			if (ceil(v) == v && v >= 0 && v <= 25)
 				return true;
 		}
 

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -414,7 +414,7 @@ struct AttributeStore {
 	int lookups=0;
 
 	AttributeIndex add(AttributeSet &attributes);
-	std::vector<AttributePair> get(AttributeIndex index) const;
+	std::vector<const AttributePair*> get(AttributeIndex index) const;
 	void reportSize() const;
 	void doneReading();
 

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -16,20 +16,61 @@ typedef uint32_t AttributeIndex; // check this is enough
 
 // AttributePair is a key/value pair (with minzoom)
 struct AttributePair {
-	std::string key;
 	vector_tile::Tile_Value value;
+	short keyIndex;
 	char minzoom;
 
 	AttributePair(std::string const &key, vector_tile::Tile_Value const &value, char minzoom)
-		: key(key), value(value), minzoom(minzoom)
+		: keyIndex(key2index(key)), value(value), minzoom(minzoom)
 	{ }
 
 	bool operator==(const AttributePair &other) const {
-		if (minzoom!=other.minzoom || key!=other.key) return false;
+		if (minzoom!=other.minzoom || keyIndex!=other.keyIndex) return false;
 		if (value.has_string_value()) return other.value.has_string_value() && other.value.string_value()==value.string_value();
 		if (value.has_bool_value())   return other.value.has_bool_value()   && other.value.bool_value()  ==value.bool_value();
 		if (value.has_float_value())  return other.value.has_float_value()  && other.value.float_value() ==value.float_value();
 		throw std::runtime_error("Invalid type in attribute store");
+	}
+
+	const std::string& key() const {
+		// To be thread-safe, you must only read the actual string value after all
+		// attribute sets have been constructed, e.g. when writing output values.
+		//
+		// In general, prefer to use keyIndex for equality checking when building
+		// up the sets of AttributePairs.
+		return keys[keyIndex];
+	}
+
+private:
+	static std::map<std::string, uint16_t> keys2index;
+	static std::vector<std::string> keys;
+	static std::mutex rw_mutex;
+
+	// TODO: the set of unique keys is relatively stable, like ~50 or so.
+	//
+	// Forcing all readers to take a lock might be expensive. Currently,
+	// other locks dominate processing. Once PR #578 lands, revisit to see
+	// if this is a bottleneck.
+	//
+	// If it is, re-write to have lock-free reads: publish a pointer to
+	// an immutable map/vector for lookups.
+	//
+	// If a reader fails to find the key it wants, it could then grab a lock,
+	// clone the map/vector, check again for its entry, insert if missing,
+	// and swap the pointer to the immutable map/vector.
+	static uint16_t key2index(const std::string& key) {
+		std::lock_guard<std::mutex> lock(rw_mutex);
+
+		try {
+			return keys2index.at(key);
+		} catch (std::out_of_range &err) {
+			uint32_t newIndex = keys.size();
+			if (newIndex > 65535)
+				throw std::out_of_range("more than 65,536 unique keys");
+			keys2index[key] = newIndex;
+			keys.push_back(key);
+			return newIndex;
+		}
 	}
 };
 
@@ -52,7 +93,7 @@ struct AttributeSet {
     struct key_value_less {
         bool operator()(AttributePair const &lhs, AttributePair const& rhs) const {            
 			return (lhs.minzoom != rhs.minzoom) ? (lhs.minzoom < rhs.minzoom)
-			     : (lhs.key != rhs.key) ? (lhs.key < rhs.key)
+			     : (lhs.keyIndex != rhs.keyIndex) ? (lhs.keyIndex < rhs.keyIndex)
 			     : compare(lhs.value, rhs.value);
         }
     }; 
@@ -69,7 +110,7 @@ struct AttributeSet {
 			auto idx = attributes.values.size();
 			for(auto const &i: attributes.values) {
 				boost::hash_combine(idx, i.minzoom);
-				boost::hash_combine(idx, i.key);
+				boost::hash_combine(idx, i.keyIndex);
 				boost::hash_combine(idx, type_index(i.value));
 
 				if(i.value.has_string_value())

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -23,6 +23,7 @@ struct string_ptr_less_than {
 
 class AttributeKeyStore {
 public:
+	AttributeKeyStore(): keys2indexSize(0) {}
 	uint16_t key2index(const std::string& key);
 	const std::string& getKey(uint16_t index) const;
 	std::atomic<uint32_t> keys2indexSize;
@@ -151,7 +152,9 @@ public:
 	AttributePairStore():
 		pairs(ATTRIBUTE_SHARDS),
 		pairsMaps(ATTRIBUTE_SHARDS),
-		pairsMutex(ATTRIBUTE_SHARDS) {
+		pairsMutex(ATTRIBUTE_SHARDS),
+		hotShardSize(0)
+	{
 		// NB: the hot shard is stored in its own, pre-allocated vector.
 		// pairs[0] is _not_ the hot shard
 		hotShard.reserve(1 << 16);

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <atomic>
 #include <boost/functional/hash.hpp>
+#include <boost/container/flat_map.hpp>
 #include <vector>
 #include <unordered_map>
 #include <tsl/ordered_set.h>
@@ -263,11 +264,11 @@ private:
 	// we suspect will be popular. It only ever has 64KB items,
 	// so that we can reference it with a short.
 	static std::vector<std::mutex> pairsMutex;
-	static std::vector<std::map<const AttributePair*, uint32_t, AttributePairStore::key_value_less_ptr>> pairsMaps;
+	static std::vector<boost::container::flat_map<const AttributePair*, uint32_t, AttributePairStore::key_value_less_ptr>> pairsMaps;
 
 	// The hot pool requires the ability to look up index by
 	// pair value.
-	static std::shared_ptr<std::map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>> hotMap;
+	static std::shared_ptr<boost::container::flat_map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>> hotMap;
 };
 
 // AttributeSet is a set of AttributePairs

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -14,8 +14,6 @@ typedef uint32_t AttributeIndex; // check this is enough
 
 class AttributeKeyStore {
 public:
-	// We jump through some hoops to have no locks for most readers,
-	// locking only if we need to add the value.
 	uint16_t key2index(const std::string& key) {
 		std::lock_guard<std::mutex> lock(keys2indexMutex);
 		const auto& rv = keys2index.find(key);

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -107,7 +107,7 @@ struct AttributeStore {
 	int lookups=0;
 
 	AttributeIndex add(AttributeSet const &attributes);
-	std::set<AttributePair, AttributeSet::key_value_less> get(AttributeIndex index) const;
+	const std::set<AttributePair, AttributeSet::key_value_less>& get(AttributeIndex index) const;
 	void reportSize() const;
 	void doneReading();
 	

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -92,7 +92,7 @@ struct AttributePair {
 	float floatValue() const { return floatValue_; }
 	bool boolValue() const { return valueType == AttributePairType::True; }
 
-	static bool isHot(const AttributePair& pair, const AttributeKeyStore& keyStore) {
+	static bool isHot(const AttributePair& pair, const std::string& keyName) {
 		// Is this pair a candidate for the hot pool?
 
 		// Hot pairs are pairs that we think are likely to be re-used, like
@@ -125,7 +125,6 @@ struct AttributePair {
 		}
 
 		// Keys that sound like name, name:en, etc, aren't eligible.
-		const auto& keyName = keyStore.getKey(pair.keyIndex);
 		if (keyName.size() >= 4 && keyName[0] == 'n' && keyName[1] == 'a' && keyName[2] == 'm' && keyName[3])
 			return false;
 

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -244,6 +244,14 @@ public:
 		}
 	}; 
 
+	struct key_value_less_ptr {
+		bool operator()(AttributePair const* lhs, AttributePair const* rhs) const {            
+			return (lhs->minzoom != rhs->minzoom) ? (lhs->minzoom < rhs->minzoom)
+			 : (lhs->keyIndex != rhs->keyIndex) ? (lhs->keyIndex < rhs->keyIndex)
+			 : compare(lhs->value, rhs->value);
+		}
+	}; 
+
 	static std::vector<std::deque<AttributePair>> pairs;
 
 private:
@@ -255,11 +263,11 @@ private:
 	// we suspect will be popular. It only ever has 64KB items,
 	// so that we can reference it with a short.
 	static std::vector<std::mutex> pairsMutex;
-	static std::vector<std::map<const AttributePair, uint32_t, AttributePairStore::key_value_less>> pairsMaps;
+	static std::vector<std::map<const AttributePair*, uint32_t, AttributePairStore::key_value_less_ptr>> pairsMaps;
 
 	// The hot pool requires the ability to look up index by
 	// pair value.
-	static std::shared_ptr<std::map<const AttributePair, uint16_t, AttributePairStore::key_value_less>> hotMap;
+	static std::shared_ptr<std::map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>> hotMap;
 };
 
 // AttributeSet is a set of AttributePairs

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -2,7 +2,6 @@
 #ifndef _ATTRIBUTE_STORE_H
 #define _ATTRIBUTE_STORE_H
 
-#include "vector_tile.pb.h"
 #include <mutex>
 #include <atomic>
 #include <boost/functional/hash.hpp>
@@ -10,8 +9,6 @@
 #include <vector>
 #include <unordered_map>
 #include <tsl/ordered_set.h>
-#include <random>
-#include <iostream>
 
 // TODO: the PairStore and KeyStore have static scope. Should probably
 // do the work to move them into AttributeStore, and change how
@@ -203,7 +200,7 @@ struct AttributePair {
 		else if(has_bool_value())
 			boost::hash_combine(rv, bool_value());
 		else {
-			std::cout << "cannot hash pair, unknown value, keyIndex=" << keyIndex << std::endl;
+			throw new std::out_of_range("cannot hash pair, unknown value");
 		}
 
 		return rv;

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -9,10 +9,92 @@
 #include <vector>
 #include <unordered_map>
 #include <tsl/ordered_set.h>
+#include <random>
+#include <iostream>
+
+inline std::ostream& operator<<(std::ostream& os, const vector_tile::Tile_Value& value) {
+	if (value.has_string_value()) os << "[str]" << value.string_value();
+	if (value.has_bool_value()) os << "[bool]" << value.bool_value();
+	if (value.has_float_value()) os << "[float]" << value.float_value();
+	return os;
+}
+
 
 /* AttributeStore - global dictionary for attributes */
 
 typedef uint32_t AttributeIndex; // check this is enough
+
+// All members of this class are thread-safe.
+//
+// AttributeKeyStore maintains a pointer to the live version.
+// Lookup misses will result in a new version being published.
+class AttributeKeyStoreImmutable {
+public:
+	AttributeKeyStoreImmutable(std::map<const std::string, uint16_t> keys2index): keys2index(keys2index) {
+	}
+
+	uint16_t key2index(const std::string& key) {
+		auto rv = keys2index.find(key);
+
+		if (rv == keys2index.end())
+			// 0 acts as a sentinel to say that it's missing.
+			return 0;
+
+		return rv->second;
+	}
+
+	const std::map<const std::string, uint16_t> getKeys2IndexMap() { return keys2index; }
+
+private:
+	std::map<const std::string, uint16_t> keys2index;
+};
+
+class AttributeKeyStore {
+public:
+	// We jump through some hoops to have no locks for most readers,
+	// locking only if we need to add the value.
+	static uint16_t key2index(const std::string& key) {
+		auto index = immutable->key2index(key);
+
+		if (index != 0)
+			return index;
+
+		std::lock_guard<std::mutex> lock(keys2index_mutex);
+
+		// 0 is used as a sentinel, so ensure that the 0th element is just a dummy element.
+		if (keys.size() == 0)
+			keys.push_back("");
+
+		// Double-check that it's not there - maybe we were in a race
+		auto reallyMissing = immutable->key2index(key);
+		if (reallyMissing != 0)
+			return reallyMissing;
+
+		uint16_t newIndex = keys.size();
+
+		// This is very unlikely. We expect more like 50-100 keys.
+		if (newIndex >= 65535)
+			throw std::out_of_range("more than 65,536 unique keys");
+
+		std::map<const std::string, uint16_t> newMap(immutable->getKeys2IndexMap());
+		newMap[key] = newIndex;
+		keys.push_back(key);
+
+		immutable = std::make_unique<AttributeKeyStoreImmutable>(newMap);
+		return newIndex;
+	}
+
+	static const std::string& getKey(uint16_t index) {
+		return keys[index];
+	}
+
+private:
+	static std::mutex keys2index_mutex;
+	static std::unique_ptr<AttributeKeyStoreImmutable> immutable;
+	// NB: we use a deque, not a vector, because a deque never invalidates
+	// pointers to its members as long as you only push_back
+	static std::deque<std::string> keys;
+};
 
 // AttributePair is a key/value pair (with minzoom)
 struct AttributePair {
@@ -21,7 +103,7 @@ struct AttributePair {
 	char minzoom;
 
 	AttributePair(std::string const &key, vector_tile::Tile_Value const &value, char minzoom)
-		: keyIndex(key2index(key)), value(value), minzoom(minzoom)
+		: keyIndex(AttributeKeyStore::key2index(key)), value(value), minzoom(minzoom)
 	{ }
 
 	bool operator==(const AttributePair &other) const {
@@ -33,59 +115,74 @@ struct AttributePair {
 	}
 
 	const std::string& key() const {
-		// To be thread-safe, you must only read the actual string value after all
-		// attribute sets have been constructed, e.g. when writing output values.
-		//
-		// In general, prefer to use keyIndex for equality checking when building
-		// up the sets of AttributePairs.
-		return keys[keyIndex];
+		return AttributeKeyStore::getKey(keyIndex);
 	}
+
+	enum class Index { BOOL, FLOAT, STRING };
+	static Index type_index(vector_tile::Tile_Value const &v) {
+		if     (v.has_string_value()) return Index::STRING;
+		else if(v.has_float_value())  return Index::FLOAT;
+		else                          return Index::BOOL;
+	}
+
+	size_t hash() const {
+		std::size_t rv = minzoom;
+		boost::hash_combine(rv, keyIndex);
+		boost::hash_combine(rv, type_index(value));
+
+		if(value.has_string_value())
+			boost::hash_combine(rv, value.string_value());
+		else if(value.has_float_value())
+			boost::hash_combine(rv, value.float_value());
+		else
+			boost::hash_combine(rv, value.bool_value());
+
+		return rv;
+	}
+};
+
+
+// Pick SHARD_BITS such that PAIR_SHARDS is at least 2x your number of cores.
+// This reduces the odds of lock contention on inserting/retrieving the "cold" pairs.
+// For now, it's hardcoded, perhaps it should be a function of the numThreads argument.
+#define SHARD_BITS 7
+#define PAIR_SHARDS (1 << SHARD_BITS)
+
+class AttributePairStore {
+public:
+	static const AttributePair& getPair(uint32_t i) {
+		uint32_t shard = i >> (32 - SHARD_BITS);
+		uint32_t offset = i & (~(~0u << (32 - SHARD_BITS)));
+
+		std::lock_guard<std::mutex> lock(pairRefs_mutex[shard]);
+		return pairRefs[shard][offset];
+	};
+
+	static uint32_t addPair(const AttributePair& pair);
 
 private:
-	static std::map<std::string, uint16_t> keys2index;
-	static std::vector<std::string> keys;
-	static std::mutex rw_mutex;
+	// We refer to all attribute pairs by index. To avoid contention,
+	// we shard the deques containing the pairs. If there are two shards,
+	// shard 1 starts from 0, shard 2 starts from 2^31, and so on.
+	// TODO: optimize for "hot" pairs, which will be stored in the first 64K entries,
+	//       so that we can refer to them by a short.
+	static std::vector<std::deque<AttributePair>> pairRefs;
+	static std::vector<std::mutex> pairRefs_mutex;
 
-	// TODO: the set of unique keys is relatively stable, like ~50 or so.
-	//
-	// Forcing all readers to take a lock might be expensive. Currently,
-	// other locks dominate processing. Once PR #578 lands, revisit to see
-	// if this is a bottleneck.
-	//
-	// If it is, re-write to have lock-free reads: publish a pointer to
-	// an immutable map/vector for lookups.
-	//
-	// If a reader fails to find the key it wants, it could then grab a lock,
-	// clone the map/vector, check again for its entry, insert if missing,
-	// and swap the pointer to the immutable map/vector.
-	static uint16_t key2index(const std::string& key) {
-		std::lock_guard<std::mutex> lock(rw_mutex);
-
-		try {
-			return keys2index.at(key);
-		} catch (std::out_of_range &err) {
-			uint32_t newIndex = keys.size();
-			if (newIndex > 65535)
-				throw std::out_of_range("more than 65,536 unique keys");
-			keys2index[key] = newIndex;
-			keys.push_back(key);
-			return newIndex;
-		}
-	}
 };
 
 // AttributeSet is a set of AttributePairs
 // = the complete attributes for one object
 struct AttributeSet {
 	static bool compare(vector_tile::Tile_Value const &lhs, vector_tile::Tile_Value const &rhs) {
-		auto lhs_id = type_index(lhs);
-		auto rhs_id = type_index(lhs);
+		auto lhs_id = AttributePair::type_index(lhs);
+		auto rhs_id = AttributePair::type_index(lhs);
 		if(lhs_id < rhs_id) return true;
 		if(lhs_id > rhs_id) return false;
 		switch(lhs_id) {
-			case Index::BOOL:    return lhs.bool_value() < rhs.bool_value();
-			case Index::FLOAT:   return lhs.float_value() < rhs.float_value();
-			case Index::STRING:  return lhs.string_value() < rhs.string_value();
+			case AttributePair::Index::BOOL:    return lhs.bool_value() < rhs.bool_value();
+			case AttributePair::Index::FLOAT:   return lhs.float_value() < rhs.float_value();
+			case AttributePair::Index::STRING:  return lhs.string_value() < rhs.string_value();
 		}
 		throw std::runtime_error("Invalid type in attribute store");
 	}
@@ -98,47 +195,78 @@ struct AttributeSet {
         }
     }; 
 
-	enum class Index { BOOL, FLOAT, STRING };
-	static Index type_index(vector_tile::Tile_Value const &v) {
-		if     (v.has_string_value()) return Index::STRING;
-		else if(v.has_float_value())  return Index::FLOAT;
-		else                          return Index::BOOL;
-	}
-
 	struct hash_function {
+		// Calculating the hash value requires indirection and locks, so
+		// we use a memoized version calculated once the AttributeSet is finalized.
 		size_t operator()(const AttributeSet &attributes) const {
-			auto idx = attributes.values.size();
-			for(auto const &i: attributes.values) {
-				boost::hash_combine(idx, i.minzoom);
-				boost::hash_combine(idx, i.keyIndex);
-				boost::hash_combine(idx, type_index(i.value));
-
-				if(i.value.has_string_value())
-					boost::hash_combine(idx, i.value.string_value());
-				else if(i.value.has_float_value())
-					boost::hash_combine(idx, i.value.float_value());
-				else
-					boost::hash_combine(idx, i.value.bool_value());
-			}
-			return idx;
+			return attributes.hash_value;
 		}
 	};
 	bool operator==(const AttributeSet &other) const {
-		return values==other.values;
+		if (hash_value == 0 && values.size() != 0)
+			std::cout << "unexpected hash value of 0 for this, values.size()=" << values.size() << std::endl;
+		if (other.hash_value == 0 && other.values.size() != 0) {
+			std::cout << "unexpected hash value of 0 for other, other.values.size()=" << other.values.size() << std::endl;
+		}
+
+		if (hash_value != other.hash_value)
+			return false;
+
+		if (values.size() != other.values.size())
+			return false;
+
+		// Equivalent if, for every value in values, there is a value in other.values
+		// whose pair is the same.
+		// TODO: finalize_set ought to ensure that everyone's values are sorted such
+		//  that we can just do a pairwise comparison.
+
+		for (const auto& myValue: values) {
+			bool ok = false;
+			const auto& myPair = AttributePairStore::getPair(myValue);
+			for (const auto& theirValue: other.values) {
+				const auto& theirPair = AttributePairStore::getPair(theirValue);
+
+				if (myPair == theirPair) {
+					ok = true;
+					break;
+				}
+			}
+
+			if (!ok)
+				return false;
+		}
+
+		return true;
 	}
 
-	std::set<AttributePair, key_value_less> values;
+	void finalize_set();
+
+	std::vector<uint32_t> values;
 
 	void add(AttributePair const &kv);
 	void add(std::string const &key, vector_tile::Tile_Value const &v, char minzoom);
 
 	AttributeSet() { }
-	AttributeSet(const AttributeSet &a) { values = a.values; } // copy constructor, don't copy lock
+	AttributeSet(const AttributeSet &a) {
+		// TODO: can we just use the default copy constructor?
+		// This was needed to avoid copying the atomic<bool> which I am currently
+		// discarding.
+		hash_value = a.hash_value;
+		values = a.values;
+	}
 
 private:
-	std::atomic<bool> lock_ = { false };
-	void lock() { while(lock_.exchange(true, std::memory_order_acquire)); }
-	void unlock() { lock_.store(false, std::memory_order_release); }
+	// hash_value is memoized when AttributeStore tries to add it.
+	// Storing this costs us 4 bytes, but we make that back via shenanigans
+	// that require a fast hash_value computation.
+	size_t hash_value;
+
+// TODO: Chesterton's (memory?) fence... is this being used to impose
+//   memory read barriers?
+// Maybe it ought not be quietly discarded?
+//	std::atomic<bool> lock_ = { false };
+//	void lock() { while(lock_.exchange(true, std::memory_order_acquire)); }
+//	void unlock() { lock_.store(false, std::memory_order_release); }
 };
 
 // AttributeStore is the store for all AttributeSets
@@ -147,8 +275,8 @@ struct AttributeStore {
 	mutable std::mutex mutex;
 	int lookups=0;
 
-	AttributeIndex add(AttributeSet const &attributes);
-	const std::set<AttributePair, AttributeSet::key_value_less>& get(AttributeIndex index) const;
+	AttributeIndex add(AttributeSet &attributes);
+	std::set<AttributePair, AttributeSet::key_value_less> get(AttributeIndex index) const;
 	void reportSize() const;
 	void doneReading();
 	

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -248,7 +248,7 @@ struct AttributeSet {
 				return false;
 			}
 
-			for (int i = 0; i < 12; i++) {
+			for (int i = 0; i < sizeof(lhs->shortValues)/sizeof(lhs->shortValues[0]); i++) {
 				if (lhs->shortValues[i] != rhs->shortValues[i]) {
 					return lhs->shortValues[i] < rhs->shortValues[i];
 				}
@@ -271,7 +271,7 @@ struct AttributeSet {
 		}
 
 		size_t idx = 0;
-		for (int i = 0; i < 12; i++)
+		for (int i = 0; i < sizeof(shortValues)/sizeof(shortValues[0]); i++)
 			boost::hash_combine(idx, shortValues[i]);
 
 		return idx;
@@ -347,7 +347,10 @@ struct AttributeSet {
 		return getValueAtIndex(actualIndex);
 	}
 
-	AttributeSet(): useVector(false), shortValues({}) {}
+	AttributeSet(): useVector(false) {
+		for (int i = 0; i < sizeof(shortValues)/sizeof(shortValues[0]); i++)
+			shortValues[i] = 0;
+	}
 	AttributeSet(const AttributeSet &&a) = delete;
 
 	AttributeSet(const AttributeSet &a) {
@@ -356,10 +359,10 @@ struct AttributeSet {
 		if (useVector) {
 			new (&intValues) std::vector<uint32_t>;
 			intValues = a.intValues;
-			for (int i = 0; i < 12; i++)
+			for (int i = 0; i < sizeof(shortValues)/sizeof(shortValues[0]); i++)
 				shortValues[i] = 0;
 		} else {
-			for (int i = 0; i < 12; i++)
+			for (int i = 0; i < sizeof(shortValues)/sizeof(shortValues[0]); i++)
 				shortValues[i] = a.shortValues[i];
 		}
 	}

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -4,6 +4,7 @@
 
 #include <mutex>
 #include <deque>
+#include <map>
 #include <iostream>
 #include <boost/functional/hash.hpp>
 #include <boost/container/flat_map.hpp>

--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -6,6 +6,7 @@
 #include "geom.h"
 #include <utility>
 #include <unordered_set>
+#include <boost/functional/hash.hpp>
 
 #ifdef FAT_TILE_INDEX
 typedef uint32_t TileCoordinate;
@@ -42,7 +43,9 @@ typedef class TileCoordinates_ TileCoordinates;
 namespace std {
 	template<> struct hash<TileCoordinates> {
 		size_t operator()(const TileCoordinates & obj) const {
-			return hash<TileCoordinate>()(obj.x) ^ hash<TileCoordinate>()(obj.y);
+			size_t rv = obj.x;
+			boost::hash_combine(rv, obj.y);
+			return rv;
 		}
 	};
 }

--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -6,7 +6,6 @@
 #include "geom.h"
 #include <utility>
 #include <unordered_set>
-#include <boost/functional/hash.hpp>
 
 #ifdef FAT_TILE_INDEX
 typedef uint32_t TileCoordinate;
@@ -43,9 +42,7 @@ typedef class TileCoordinates_ TileCoordinates;
 namespace std {
 	template<> struct hash<TileCoordinates> {
 		size_t operator()(const TileCoordinates & obj) const {
-			size_t rv = obj.x;
-			boost::hash_combine(rv, obj.y);
-			return rv;
+			return hash<TileCoordinate>()(obj.x) ^ hash<TileCoordinate>()(obj.y);
 		}
 	};
 }

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -206,6 +206,7 @@ private:
 		multiPolygonInited = false;
 		relationAccepted = false;
 		relationSubscript = -1;
+		lastStoredGeometryId = 0;
 	}
 
 	const inline Point getPoint() {
@@ -242,6 +243,9 @@ private:
 	bool multiLinestringInited;
 	MultiPolygon multiPolygonCache;
 	bool multiPolygonInited;
+
+	NodeID lastStoredGeometryId;
+	OutputGeometryType lastStoredGeometryType;
 
 	const class Config &config;
 	class LayerDefinition &layers;

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -79,7 +79,7 @@ public:
 	 * (we can't easily use find() because of the different value-type encoding - 
 	 *	should be possible to improve this though)
 	 */
-	int findValue(const std::vector<vector_tile::Tile_Value>* valueList, const vector_tile::Tile_Value &value) const;
+	int findValue(const std::vector<vector_tile::Tile_Value>* valueList, const AttributePair& value) const;
 };
 #pragma pack(pop)
 

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -29,14 +29,13 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
 #pragma pack(push, 4)
 class OutputObject {
 
-protected:	
+public:
 	OutputObject(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeIndex attributes, uint mz) 
 		: objectID(id), geomType(type), layer(l), z_order(0),
 		  minZoom(mz), attributes(attributes)
 	{ }
 
 
-public:
 	NodeID objectID 			: 36;					// id of point/linestring/polygon
 	unsigned minZoom 			: 4;					// minimum zoom level in which object is written
 	AttributeIndex attributes   : 30;					// index in attribute storage
@@ -82,50 +81,6 @@ public:
 	int findValue(const std::vector<vector_tile::Tile_Value>* valueList, const AttributePair& value) const;
 };
 #pragma pack(pop)
-
-/**
- * \brief An OutputObject derived class that contains data originally from OsmMemTiles
-*/
-class OutputObjectPoint : public OutputObject
-{
-public:
-	OutputObjectPoint(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeIndex attributes, uint minzoom)
-		: OutputObject(type, l, id, attributes, minzoom)
-	{ 
-		assert(type == POINT_);
-	}
-}; 
-
-class OutputObjectLinestring : public OutputObject
-{
-public:
-	OutputObjectLinestring(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeIndex attributes, uint minzoom)
-		: OutputObject(type, l, id, attributes, minzoom)
-	{ 
-		assert(type == LINESTRING_);
-	}
-};
-
-class OutputObjectMultiLinestring : public OutputObject
-{
-public:
-	OutputObjectMultiLinestring(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeIndex attributes, uint minzoom)
-		: OutputObject(type, l, id, attributes, minzoom)
-	{ 
-		assert(type == MULTILINESTRING_);
-	}
-};
-
-
-class OutputObjectMultiPolygon : public OutputObject
-{
-public:
-	OutputObjectMultiPolygon(OutputGeometryType type, uint_least8_t l, NodeID id, AttributeIndex attributes, uint minzoom)
-		: OutputObject(type, l, id, attributes, minzoom)
-	{ 
-		assert(type == POLYGON_);
-	}
-};
 
 class OutputObjectRef
 {

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -79,7 +79,7 @@ public:
 	 * (we can't easily use find() because of the different value-type encoding - 
 	 *	should be possible to improve this though)
 	 */
-	int findValue(std::vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Value const &value) const;
+	int findValue(const std::vector<vector_tile::Tile_Value>* valueList, const vector_tile::Tile_Value &value) const;
 };
 #pragma pack(pop)
 

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -98,6 +98,13 @@ public:
 		linestring_store = std::make_unique<linestring_store_t>();
 		multi_polygon_store = std::make_unique<multi_polygon_store_t>();
 		multi_linestring_store = std::make_unique<multi_linestring_store_t>();
+
+		// Put something at index 0 of all stores so that 0 can be used
+		// as a sentinel.
+		point_store->push_back(Point(0,0));
+		linestring_store->push_back(linestring_t());
+		multi_polygon_store->push_back(multi_polygon_t());
+		multi_linestring_store->push_back(multi_linestring_t());
 	}
 	void reportSize() const;
 	

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -20,8 +20,7 @@ class TileDataSource {
 protected:	
 	std::mutex mutex;
 	TileIndex tileIndex;
-	std::vector<std::deque<OutputObject>> objects;
-	std::vector<std::mutex> objectsMutex;
+	std::deque<std::deque<OutputObject>> objects;
 	
 	// rtree index of large objects
 	using oo_rtree_param_type = boost::geometry::index::quadratic<128>;
@@ -56,7 +55,7 @@ protected:
 
 public:
 	TileDataSource(unsigned int baseZoom) 
-		: baseZoom(baseZoom), objects(16), objectsMutex(16)
+		: baseZoom(baseZoom)
 	{ }
 
 	///This must be thread safe!
@@ -71,14 +70,7 @@ public:
 		MergeSingleTileDataAtZoom(dstIndex, zoom, baseZoom, tileIndex, dstTile);
 	}
 
-	OutputObjectRef CreateObject(OutputObject const &oo) {
-		size_t hash = (uint64_t)&oo ^ 0x9e3779b97f4a7c16;
-		size_t shard = hash % objectsMutex.size();
-		std::lock_guard<std::mutex> lock(objectsMutex[shard]);
-		objects[shard].push_back(oo);
-		return &objects[shard].back();
-	}
-
+	OutputObjectRef CreateObject(OutputObject const &oo);
 	void AddGeometryToIndex(Linestring const &geom, std::vector<OutputObjectRef> const &outputs);
 	void AddGeometryToIndex(MultiLinestring const &geom, std::vector<OutputObjectRef> const &outputs);
 	void AddGeometryToIndex(MultiPolygon const &geom, std::vector<OutputObjectRef> const &outputs);

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -1,5 +1,7 @@
 #include "attribute_store.h"
 
+#include <iostream>
+
 // AttributeKeyStore
 std::deque<std::string> AttributeKeyStore::keys;
 std::mutex AttributeKeyStore::keys2index_mutex;
@@ -10,10 +12,6 @@ std::unique_ptr<AttributeKeyStoreImmutable> AttributeKeyStore::immutable(
 );
 
 // AttributePairStore
-thread_local std::random_device dev;
-thread_local std::mt19937 rng(dev());
-thread_local std::uniform_int_distribution<std::mt19937::result_type> nextShard(0, PAIR_SHARDS-1);
-
 std::vector<std::deque<AttributePair>> AttributePairStore::pairs(PAIR_SHARDS);
 std::vector<std::mutex> AttributePairStore::pairsMutex(PAIR_SHARDS);
 std::vector<boost::container::flat_map<const AttributePair*, uint32_t, AttributePairStore::key_value_less_ptr>> AttributePairStore::pairsMaps(PAIR_SHARDS);

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -1,28 +1,115 @@
 #include "attribute_store.h"
 
-// AttributePair
-std::map<std::string, uint16_t> AttributePair::keys2index;
-std::vector<std::string> AttributePair::keys;
-std::mutex AttributePair::rw_mutex;
+// AttributeKeyStore
+std::deque<std::string> AttributeKeyStore::keys;
+std::mutex AttributeKeyStore::keys2index_mutex;
+std::unique_ptr<AttributeKeyStoreImmutable> AttributeKeyStore::immutable(
+	new AttributeKeyStoreImmutable(
+		std::map<const std::string, uint16_t>()
+	)
+);
+
+// AttributePairStore
+// TODO: can we use a hash instead of an RNG for assigning? For now, we have hot spots
+// until we handle "hot" attribute pairs (eg tunnel=0).
+thread_local std::random_device dev;
+thread_local std::mt19937 rng(dev());
+thread_local std::uniform_int_distribution<std::mt19937::result_type> nextShard(0, PAIR_SHARDS-1);
+
+std::vector<std::deque<AttributePair>> AttributePairStore::pairRefs(PAIR_SHARDS);
+std::vector<std::mutex> AttributePairStore::pairRefs_mutex(PAIR_SHARDS);
+
+uint32_t AttributePairStore::addPair(const AttributePair& pair) {
+	// TODO: is it worth using a hash? We could also randomly assign pairs
+	// to shards.
+	// The pair has a `keyIndex`, so subsequent runs of the program will
+	// likely have a different hash value for the pair anyway, so there's
+	// no reproduceability benefit.
+	//
+	// Oh, yeah, until we do hot/cold, random assignment is probably needed...
+//		uint32_t hashValue = pair.hash();
+//		size_t shard = hashValue >> (32 - SHARD_BITS);
+//	timespec start, end;
+//	clock_gettime(CLOCK_MONOTONIC, &start);
+
+	size_t shard = nextShard(rng);
+//	uint64_t shardy = 1e9 * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
+//	size_t shard = shardy % PAIR_SHARDS;
+//	std::cout << "nextShard=" << shard << std::endl << std::flush;
+	std::lock_guard<std::mutex> lock(pairRefs_mutex[shard]);
+//		std::cout << "pairRefs_mutex[" << shard << "]=" << pairRefs_mutex[shard].native_handle() << std::endl;
+	uint32_t offset = pairRefs[shard].size();
+	pairRefs[shard].push_back(pair);
+	uint32_t rv = (shard << (32 - SHARD_BITS)) + offset;
+//		std::cout << "adding pair to shard=" << shard << ", offset=" << offset << ", index=" << rv;
+	return rv;
+};
 
 
 // AttributeSet
 
 void AttributeSet::add(AttributePair const &kv) {
-	lock();
-	values.insert(kv);
-	unlock();
+	// TODO: implement hot/cold strategy to re-use popular pairs
+	uint32_t index = AttributePairStore::addPair(kv);
+	values.push_back(index);
 }
 void AttributeSet::add(std::string const &key, vector_tile::Tile_Value const &v, char minzoom) {
 	AttributePair kv(key,v,minzoom);
-	lock();
-	values.insert(kv);
-	unlock();
+	add(kv);
+}
+
+bool sortFn(const AttributePair* a, const AttributePair* b) {
+	if (a->minzoom != b->minzoom)
+		return a->minzoom < b->minzoom;
+
+	if (a->keyIndex != b->keyIndex)
+		return a->keyIndex < b->keyIndex;
+
+	if (a->value.has_string_value()) return b->value.has_string_value() && a->value.string_value() < b->value.string_value();
+	if (a->value.has_bool_value()) return b->value.has_bool_value() && a->value.bool_value() < b->value.bool_value();
+	if (a->value.has_float_value()) return b->value.has_float_value() && a->value.float_value() < b->value.float_value();
+	throw std::runtime_error("Invalid type in AttributeSet");
+}
+
+void AttributeSet::finalize_set() {
+	// Memoize the hash value of this set so we don't repeatedly calculate it
+	// when inserting/querying sets.
+	//
+	// TODO: sort its attribute pairs so == tests can do a simple pairwise comparisons
+	auto idx = values.size();
+
+	std::vector<const AttributePair*> pairs;
+	for(auto const &j: values) {
+		// NB: getPair takes a lock
+		const auto& i = AttributePairStore::getPair(j);
+		pairs.push_back(&i);
+	}
+	
+	// Sort pairs in a stable way, so that we produce the same hash
+	std::sort (pairs.begin(), pairs.end(), sortFn);
+
+	for (auto const &i: pairs) {
+		boost::hash_combine(idx, i->minzoom);
+		boost::hash_combine(idx, i->keyIndex);
+		boost::hash_combine(idx, AttributePair::type_index(i->value));
+
+		if(i->value.has_string_value())
+			boost::hash_combine(idx, i->value.string_value());
+		else if(i->value.has_float_value())
+			boost::hash_combine(idx, i->value.float_value());
+		else
+			boost::hash_combine(idx, i->value.bool_value());
+	}
+	hash_value = idx;
 }
 
 // AttributeStore
 
-AttributeIndex AttributeStore::add(AttributeSet const &attributes) {
+AttributeIndex AttributeStore::add(AttributeSet &attributes) {
+	// TODO: there's probably a way to use C++ types to distinguish a finalized
+	// and non-finalized AttributeSet, which would make this safer.
+	attributes.finalize_set();
+
 	std::lock_guard<std::mutex> lock(mutex);
 	lookups++;
 
@@ -36,9 +123,18 @@ AttributeIndex AttributeStore::add(AttributeSet const &attributes) {
 	return idx;
 }
 
-const std::set<AttributePair, AttributeSet::key_value_less>& AttributeStore::get(AttributeIndex index) const {
+// TODO: consider implementing this as an iterator, or returning a cheaper
+//       container than a set (vector?)
+std::set<AttributePair, AttributeSet::key_value_less> AttributeStore::get(AttributeIndex index) const {
 	try {
-		return attribute_sets.nth(index).key().values;
+		const auto pairIds = attribute_sets.nth(index).key().values;
+
+		std::set<AttributePair, AttributeSet::key_value_less> rv;
+		for (const auto& id: pairIds) {
+			rv.insert(AttributePairStore::getPair(id));
+		}
+
+		return rv;
 	} catch (std::out_of_range &err) {
 		throw std::runtime_error("Failed to fetch attributes at index "+std::to_string(index)+" - size is "+std::to_string(attribute_sets.size()));
 	}
@@ -46,6 +142,40 @@ const std::set<AttributePair, AttributeSet::key_value_less>& AttributeStore::get
 
 void AttributeStore::reportSize() const {
 	std::cout << "Attributes: " << attribute_sets.size() << " sets from " << lookups << " objects" << std::endl;
+
+	// Print detailed histogram of frequencies of attributes.
+	if (false) {
+		std::map<uint32_t, uint32_t> tagCountDist;
+
+		size_t pairs = 0;
+		std::map<AttributePair, size_t, AttributeSet::key_value_less> uniques;
+		for (const auto attr_set: attribute_sets) {
+			pairs += attr_set.values.size();
+
+			try {
+				tagCountDist[attr_set.values.size()]++;
+			} catch (std::out_of_range &err) {
+				tagCountDist[attr_set.values.size()] = 1;
+			}
+
+			for (const auto attr: attr_set.values) {
+				try {
+					uniques[AttributePairStore::getPair(attr)]++;
+				} catch (std::out_of_range &err) {
+					uniques[AttributePairStore::getPair(attr)] = 1;
+				}
+			}
+		}
+		std::cout << "AttributePairs: " << pairs << ", unique: " << uniques.size() << std::endl;
+
+		for (const auto entry: tagCountDist) {
+			std::cout << "tagCountDist " << entry.first << " tags occurs " << entry.second << " times" << std::endl;
+		}
+
+		for (const auto entry: uniques) {
+			std::cout << "attrpair freq= " << entry.second << " key=" << entry.first.key() <<" value=" << entry.first.value << std::endl;
+		}
+	}
 }
 
 void AttributeStore::doneReading() {

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -207,9 +207,7 @@ AttributeIndex AttributeStore::add(AttributeSet &attributes) {
 	return rv;
 }
 
-// TODO: consider implementing this as an iterator, or returning a cheaper
-//       container than a set (vector?)
-std::set<AttributePair, AttributePairStore::key_value_less> AttributeStore::get(AttributeIndex index) const {
+std::vector<AttributePair> AttributeStore::get(AttributeIndex index) const {
 	try {
 		uint32_t shard = index >> (32 - SHARD_BITS);
 		uint32_t offset = index & (~(~0u << (32 - SHARD_BITS)));
@@ -220,9 +218,9 @@ std::set<AttributePair, AttributePairStore::key_value_less> AttributeStore::get(
 
 		const size_t n = attrSet.numPairs();
 
-		std::set<AttributePair, AttributePairStore::key_value_less> rv;
+		std::vector<AttributePair> rv;
 		for (size_t i = 0; i < n; i++) {
-			rv.insert(pairStore.getPair(attrSet.getPair(i)));
+			rv.push_back(pairStore.getPair(attrSet.getPair(i)));
 		}
 
 		return rv;

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -1,5 +1,11 @@
 #include "attribute_store.h"
 
+// AttributePair
+std::map<std::string, uint16_t> AttributePair::keys2index;
+std::vector<std::string> AttributePair::keys;
+std::mutex AttributePair::rw_mutex;
+
+
 // AttributeSet
 
 void AttributeSet::add(AttributePair const &kv) {

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -111,38 +111,9 @@ bool sortFn(const AttributePair* a, const AttributePair* b) {
 }
 
 void AttributeSet::finalize_set() {
-	// Memoize the hash value of this set so we don't repeatedly calculate it
-	// when inserting/querying sets.
-	//
-	// TODO: sort its attribute pairs so == tests can do a simple pairwise comparisons
-	auto idx = values.size();
-
-	std::vector<const AttributePair*> pairs;
-	for(auto const &j: values) {
-		// NB: getPair takes a lock
-		const auto& i = AttributePairStore::getPair(j);
-		pairs.push_back(&i);
-	}
-	
-	// Sort pairs in a stable way, so that we produce the same hash
-	std::sort (pairs.begin(), pairs.end(), sortFn);
-
-	for (auto const &i: pairs) {
-		boost::hash_combine(idx, i->minzoom);
-		boost::hash_combine(idx, i->keyIndex);
-		boost::hash_combine(idx, AttributePair::type_index(i->value));
-
-		if(i->value.has_string_value())
-			boost::hash_combine(idx, i->value.string_value());
-		else if(i->value.has_float_value())
-			boost::hash_combine(idx, i->value.float_value());
-		else if(i->value.has_bool_value())
-			boost::hash_combine(idx, i->value.bool_value());
-		else {
-			std::cout << "unknown Tile_Value in finalize_set, keyIndex was " << i->keyIndex << std::endl;
-		}
-	}
-	hash_value = idx;
+	// Ensure that values are sorted, so we have a canonical representation of
+	// an attribute set.
+	sort(values.begin(), values.end());
 }
 
 // AttributeStore

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -39,6 +39,11 @@ uint32_t AttributePairStore::addPair(const AttributePair& pair) {
 
 		// OK, it's definitely not there. Is there room to add it?
 		if (pairs[0].size() < 1 << 16) {
+
+			// We use 0 as a sentinel, so ensure there's at least one entry in the shard.
+			if (pairs[0].size() == 0)
+				pairs[0].push_back(AttributePair("", vector_tile::Tile_Value(), 0));
+
 			uint16_t newIndex = pairs[0].size();
 			std::map<const AttributePair, uint16_t, AttributePairStore::key_value_less> newMap(hotMap->begin(), hotMap->end());
 			newMap[pair] = newIndex;

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -5,11 +5,7 @@
 // AttributeKeyStore
 std::deque<std::string> AttributeKeyStore::keys;
 std::mutex AttributeKeyStore::keys2index_mutex;
-std::unique_ptr<AttributeKeyStoreImmutable> AttributeKeyStore::immutable(
-	new AttributeKeyStoreImmutable(
-		std::map<const std::string, uint16_t>()
-	)
-);
+std::map<const std::string, uint16_t> AttributeKeyStore::keys2index;
 
 // AttributePairStore
 std::vector<std::deque<AttributePair>> AttributePairStore::pairs(PAIR_SHARDS);
@@ -59,6 +55,10 @@ uint32_t AttributePairStore::addPair(const AttributePair& pair) {
 		return it->second;
 
 	uint32_t offset = pairs[shard].size();
+
+	if (offset >= 1 << (32 - PAIR_SHARDS))
+		throw std::out_of_range("pair shard overflow");
+
 	pairs[shard].push_back(pair);
 	const AttributePair* ptr = &pairs[shard][offset];
 	uint32_t rv = (shard << (32 - SHARD_BITS)) + offset;

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -16,8 +16,8 @@ thread_local std::uniform_int_distribution<std::mt19937::result_type> nextShard(
 
 std::vector<std::deque<AttributePair>> AttributePairStore::pairs(PAIR_SHARDS);
 std::vector<std::mutex> AttributePairStore::pairsMutex(PAIR_SHARDS);
-std::vector<std::map<const AttributePair*, uint32_t, AttributePairStore::key_value_less_ptr>> AttributePairStore::pairsMaps(PAIR_SHARDS);
-std::shared_ptr<std::map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>> AttributePairStore::hotMap(new std::map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>());
+std::vector<boost::container::flat_map<const AttributePair*, uint32_t, AttributePairStore::key_value_less_ptr>> AttributePairStore::pairsMaps(PAIR_SHARDS);
+std::shared_ptr<boost::container::flat_map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>> AttributePairStore::hotMap(new boost::container::flat_map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>());
 
 uint32_t AttributePairStore::addPair(const AttributePair& pair) {
 	const bool hot = pair.hot();
@@ -47,11 +47,11 @@ uint32_t AttributePairStore::addPair(const AttributePair& pair) {
 				pairs[0].push_back(AttributePair("", vector_tile::Tile_Value(), 0));
 
 			uint16_t newIndex = pairs[0].size();
-			std::map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr> newMap(hotMap->begin(), hotMap->end());
+			boost::container::flat_map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr> newMap(hotMap->begin(), hotMap->end());
 			pairs[0].push_back(pair);
 			const AttributePair* ptr = &pairs[0][newIndex];
 			newMap[ptr] = newIndex;
-			hotMap = std::make_shared<std::map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>>(newMap);
+			hotMap = std::make_shared<boost::container::flat_map<const AttributePair*, uint16_t, AttributePairStore::key_value_less_ptr>>(newMap);
 			return newIndex;
 		}
 	}
@@ -186,7 +186,7 @@ void AttributeStore::reportSize() const {
 	std::cout << "Attributes: " << attribute_sets.size() << " sets from " << lookups << " objects" << std::endl;
 
 	// Print detailed histogram of frequencies of attributes.
-	if (true) {
+	if (false) {
 		std::map<uint32_t, uint32_t> tagCountDist;
 
 		for (size_t i = 0; i < AttributePairStore::pairs.size(); i++) {

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -82,19 +82,48 @@ void AttributeSet::addPair(uint32_t pairIndex) {
 		intValues = tmp;
 	}
 }
+void AttributeSet::removePairWithKey(const AttributePairStore& pairStore, uint32_t keyIndex) {
+	// When adding a new key/value, we need to remove any existing pair that has that key.
+	if (useVector) {
+		for (int i = 0; i < intValues.size(); i++) {
+			const AttributePair& p = pairStore.getPair(intValues[i]);
+			if (p.keyIndex == keyIndex) {
+				intValues.erase(intValues.begin() + i);
+				return;
+			}
+		}
+
+		return;
+	}
+
+	for (int i = 0; i < 8; i++) {
+		const uint32_t pairIndex = getValueAtIndex(i);
+		if (pairIndex != 0) {
+			const AttributePair& p = pairStore.getPair(pairIndex);
+			if (p.keyIndex == keyIndex) {
+				setValueAtIndex(i, 0);
+				return;
+			}
+		}
+	}
+}
+
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, const std::string& v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
 	bool isHot = AttributePair::isHot(kv, key);
+	attributeSet.removePairWithKey(pairStore, kv.keyIndex);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, bool v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
 	bool isHot = AttributePair::isHot(kv, key);
+	attributeSet.removePairWithKey(pairStore, kv.keyIndex);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, float v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
 	bool isHot = AttributePair::isHot(kv, key);
+	attributeSet.removePairWithKey(pairStore, kv.keyIndex);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -127,19 +127,6 @@ void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const 
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 
-bool sortFn(const AttributePair* a, const AttributePair* b) {
-	if (a->minzoom != b->minzoom)
-		return a->minzoom < b->minzoom;
-
-	if (a->keyIndex != b->keyIndex)
-		return a->keyIndex < b->keyIndex;
-
-	if (a->hasStringValue()) return b->hasStringValue() && a->stringValue() < b->stringValue();
-	if (a->hasBoolValue()) return b->hasBoolValue() && a->boolValue() < b->boolValue();
-	if (a->hasFloatValue()) return b->hasFloatValue() && a->floatValue() < b->floatValue();
-	throw std::runtime_error("Invalid type in AttributeSet");
-}
-
 void AttributeSet::finalizeSet() {
 	// Ensure that values are sorted, giving us a canonical representation,
 	// so that we can have fast hash/equality functions.

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -194,7 +194,7 @@ AttributeIndex AttributeStore::add(AttributeSet &attributes) {
 	return rv;
 }
 
-std::vector<AttributePair> AttributeStore::get(AttributeIndex index) const {
+std::vector<const AttributePair*> AttributeStore::get(AttributeIndex index) const {
 	try {
 		uint32_t shard = index >> (32 - SHARD_BITS);
 		uint32_t offset = index & (~(~0u << (32 - SHARD_BITS)));
@@ -205,9 +205,9 @@ std::vector<AttributePair> AttributeStore::get(AttributeIndex index) const {
 
 		const size_t n = attrSet.numPairs();
 
-		std::vector<AttributePair> rv;
+		std::vector<const AttributePair*> rv;
 		for (size_t i = 0; i < n; i++) {
-			rv.push_back(pairStore.getPair(attrSet.getPair(i)));
+			rv.push_back(&pairStore.getPair(attrSet.getPair(i)));
 		}
 
 		return rv;

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -84,17 +84,17 @@ void AttributeSet::addPair(uint32_t pairIndex) {
 }
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, const std::string& v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
-	bool isHot = AttributePair::isHot(kv, keyStore);
+	bool isHot = AttributePair::isHot(kv, key);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, bool v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
-	bool isHot = AttributePair::isHot(kv, keyStore);
+	bool isHot = AttributePair::isHot(kv, key);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, float v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
-	bool isHot = AttributePair::isHot(kv, keyStore);
+	bool isHot = AttributePair::isHot(kv, key);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -30,7 +30,7 @@ AttributeIndex AttributeStore::add(AttributeSet const &attributes) {
 	return idx;
 }
 
-std::set<AttributePair, AttributeSet::key_value_less> AttributeStore::get(AttributeIndex index) const {
+const std::set<AttributePair, AttributeSet::key_value_less>& AttributeStore::get(AttributeIndex index) const {
 	try {
 		return attribute_sets.nth(index).key().values;
 	} catch (std::out_of_range &err) {

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -461,21 +461,21 @@ void OsmLuaProcessing::Attribute(const string &key, const string &val) { Attribu
 void OsmLuaProcessing::AttributeWithMinZoom(const string &key, const string &val, const char minzoom) {
 	if (val.size()==0) { return; }		// don't set empty strings
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
-	outputs.back().second.add(key, val, minzoom);
+	attributeStore.addAttribute(outputs.back().second, key, val, minzoom);
 	setVectorLayerMetadata(outputs.back().first.layer, key, 0);
 }
 
 void OsmLuaProcessing::AttributeNumeric(const string &key, const float val) { AttributeNumericWithMinZoom(key,val,0); }
 void OsmLuaProcessing::AttributeNumericWithMinZoom(const string &key, const float val, const char minzoom) {
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
-	outputs.back().second.add(key, val, minzoom);
+	attributeStore.addAttribute(outputs.back().second, key, val, minzoom);
 	setVectorLayerMetadata(outputs.back().first.layer, key, 1);
 }
 
 void OsmLuaProcessing::AttributeBoolean(const string &key, const bool val) { AttributeBooleanWithMinZoom(key,val,0); }
 void OsmLuaProcessing::AttributeBooleanWithMinZoom(const string &key, const bool val, const char minzoom) {
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
-	outputs.back().second.add(key, val, minzoom);
+	attributeStore.addAttribute(outputs.back().second, key, val, minzoom);
 	setVectorLayerMetadata(outputs.back().first.layer, key, 2);
 }
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -461,27 +461,21 @@ void OsmLuaProcessing::Attribute(const string &key, const string &val) { Attribu
 void OsmLuaProcessing::AttributeWithMinZoom(const string &key, const string &val, const char minzoom) {
 	if (val.size()==0) { return; }		// don't set empty strings
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
-	vector_tile::Tile_Value v;
-	v.set_string_value(val);
-	outputs.back().second.add(key, v, minzoom);
+	outputs.back().second.add(key, val, minzoom);
 	setVectorLayerMetadata(outputs.back().first.layer, key, 0);
 }
 
 void OsmLuaProcessing::AttributeNumeric(const string &key, const float val) { AttributeNumericWithMinZoom(key,val,0); }
 void OsmLuaProcessing::AttributeNumericWithMinZoom(const string &key, const float val, const char minzoom) {
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
-	vector_tile::Tile_Value v;
-	v.set_float_value(val);
-	outputs.back().second.add(key, v, minzoom);
+	outputs.back().second.add(key, val, minzoom);
 	setVectorLayerMetadata(outputs.back().first.layer, key, 1);
 }
 
 void OsmLuaProcessing::AttributeBoolean(const string &key, const bool val) { AttributeBooleanWithMinZoom(key,val,0); }
 void OsmLuaProcessing::AttributeBooleanWithMinZoom(const string &key, const bool val, const char minzoom) {
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
-	vector_tile::Tile_Value v;
-	v.set_bool_value(val);
-	outputs.back().second.add(key, v, minzoom);
+	outputs.back().second.add(key, val, minzoom);
 	setVectorLayerMetadata(outputs.back().first.layer, key, 2);
 }
 

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -57,12 +57,20 @@ void OutputObject::writeAttributes(
 		}
 		
 		// Look for value
-		const vector_tile::Tile_Value& value = it.value;
-		int subscript = findValue(valueList, value);
+		int subscript = findValue(valueList, it);
 		if (subscript>-1) {
 			featurePtr->add_tags(subscript);
 		} else {
 			uint32_t subscript = valueList->size();
+			vector_tile::Tile_Value value;
+			if (it.has_string_value()) {
+				value.set_string_value(it.string_value());
+			} else if (it.has_bool_value()) {
+				value.set_bool_value(it.bool_value());
+			} else if (it.has_float_value()) {
+				value.set_float_value(it.float_value());
+			}
+			
 			valueList->push_back(value);
 			featurePtr->add_tags(subscript);
 		}
@@ -75,7 +83,7 @@ void OutputObject::writeAttributes(
 // Find a value in the value dictionary
 // (we can't easily use find() because of the different value-type encoding - 
 //	should be possible to improve this though)
-int OutputObject::findValue(const vector<vector_tile::Tile_Value>* valueList, const vector_tile::Tile_Value &value) const {
+int OutputObject::findValue(const vector<vector_tile::Tile_Value>* valueList, const AttributePair& value) const {
 	for (size_t i=0; i<valueList->size(); i++) {
 		const vector_tile::Tile_Value& v = valueList->at(i);
 		if (v.has_string_value() && value.has_string_value() && v.string_value()==value.string_value()) { return i; }

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -57,7 +57,7 @@ void OutputObject::writeAttributes(
 		}
 		
 		// Look for value
-		vector_tile::Tile_Value const &value = it.value;
+		const vector_tile::Tile_Value& value = it.value;
 		int subscript = findValue(valueList, value);
 		if (subscript>-1) {
 			featurePtr->add_tags(subscript);
@@ -75,9 +75,9 @@ void OutputObject::writeAttributes(
 // Find a value in the value dictionary
 // (we can't easily use find() because of the different value-type encoding - 
 //	should be possible to improve this though)
-int OutputObject::findValue(vector<vector_tile::Tile_Value> *valueList, vector_tile::Tile_Value const &value) const {
+int OutputObject::findValue(const vector<vector_tile::Tile_Value>* valueList, const vector_tile::Tile_Value &value) const {
 	for (size_t i=0; i<valueList->size(); i++) {
-		vector_tile::Tile_Value v = valueList->at(i);
+		const vector_tile::Tile_Value& v = valueList->at(i);
 		if (v.has_string_value() && value.has_string_value() && v.string_value()==value.string_value()) { return i; }
 		if (v.has_float_value()  && value.has_float_value()  && v.float_value() ==value.float_value() ) { return i; }
 		if (v.has_bool_value()	 && value.has_bool_value()   && v.bool_value()  ==value.bool_value()	) { return i; }

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -45,7 +45,7 @@ void OutputObject::writeAttributes(
 		if (it.minzoom > zoom) continue;
 
 		// Look for key
-		std::string const &key = it.key();
+		std::string const &key = attributeStore.keyStore.getKey(it.keyIndex);
 		auto kt = find(keyList->begin(), keyList->end(), key);
 		if (kt != keyList->end()) {
 			uint32_t subscript = kt - keyList->begin();

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -45,7 +45,7 @@ void OutputObject::writeAttributes(
 		if (it.minzoom > zoom) continue;
 
 		// Look for key
-		std::string const &key = it.key;
+		std::string const &key = it.key();
 		auto kt = find(keyList->begin(), keyList->end(), key);
 		if (kt != keyList->end()) {
 			uint32_t subscript = kt - keyList->begin();

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -42,10 +42,10 @@ void OutputObject::writeAttributes(
 	auto attr = attributeStore.get(attributes);
 
 	for(auto const &it: attr) {
-		if (it.minzoom > zoom) continue;
+		if (it->minzoom > zoom) continue;
 
 		// Look for key
-		std::string const &key = attributeStore.keyStore.getKey(it.keyIndex);
+		std::string const &key = attributeStore.keyStore.getKey(it->keyIndex);
 		auto kt = find(keyList->begin(), keyList->end(), key);
 		if (kt != keyList->end()) {
 			uint32_t subscript = kt - keyList->begin();
@@ -57,18 +57,18 @@ void OutputObject::writeAttributes(
 		}
 		
 		// Look for value
-		int subscript = findValue(valueList, it);
+		int subscript = findValue(valueList, *it);
 		if (subscript>-1) {
 			featurePtr->add_tags(subscript);
 		} else {
 			uint32_t subscript = valueList->size();
 			vector_tile::Tile_Value value;
-			if (it.hasStringValue()) {
-				value.set_string_value(it.stringValue());
-			} else if (it.hasBoolValue()) {
-				value.set_bool_value(it.boolValue());
-			} else if (it.hasFloatValue()) {
-				value.set_float_value(it.floatValue());
+			if (it->hasStringValue()) {
+				value.set_string_value(it->stringValue());
+			} else if (it->hasBoolValue()) {
+				value.set_bool_value(it->boolValue());
+			} else if (it->hasFloatValue()) {
+				value.set_float_value(it->floatValue());
 			}
 			
 			valueList->push_back(value);

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -63,19 +63,19 @@ void OutputObject::writeAttributes(
 		} else {
 			uint32_t subscript = valueList->size();
 			vector_tile::Tile_Value value;
-			if (it.has_string_value()) {
-				value.set_string_value(it.string_value());
-			} else if (it.has_bool_value()) {
-				value.set_bool_value(it.bool_value());
-			} else if (it.has_float_value()) {
-				value.set_float_value(it.float_value());
+			if (it.hasStringValue()) {
+				value.set_string_value(it.stringValue());
+			} else if (it.hasBoolValue()) {
+				value.set_bool_value(it.boolValue());
+			} else if (it.hasFloatValue()) {
+				value.set_float_value(it.floatValue());
 			}
 			
 			valueList->push_back(value);
 			featurePtr->add_tags(subscript);
 		}
 
-		//if(value.has_string_value())
+		//if(value.hasStringValue())
 		//	std::cout << "Write attr: " << key << " " << value.string_value() << std::endl;	
 	}
 }
@@ -86,9 +86,9 @@ void OutputObject::writeAttributes(
 int OutputObject::findValue(const vector<vector_tile::Tile_Value>* valueList, const AttributePair& value) const {
 	for (size_t i=0; i<valueList->size(); i++) {
 		const vector_tile::Tile_Value& v = valueList->at(i);
-		if (v.has_string_value() && value.has_string_value() && v.string_value()==value.string_value()) { return i; }
-		if (v.has_float_value()  && value.has_float_value()  && v.float_value() ==value.float_value() ) { return i; }
-		if (v.has_bool_value()	 && value.has_bool_value()   && v.bool_value()  ==value.bool_value()	) { return i; }
+		if (v.has_string_value() && value.hasStringValue() && v.string_value()==value.stringValue()) { return i; }
+		if (v.has_float_value()  && value.hasFloatValue()  && v.float_value() ==value.floatValue() ) { return i; }
+		if (v.has_bool_value()	 && value.hasBoolValue()   && v.bool_value()  ==value.boolValue()	) { return i; }
 	}
 	return -1;
 }

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -56,25 +56,23 @@ AttributeIndex readShapefileAttributes(
 		// Write values to vector tiles
 		for (auto key : out_table.keys()) {
 			kaguya::LuaRef val = out_table[key];
-			vector_tile::Tile_Value v;
 			if (val.isType<std::string>()) {
-				v.set_string_value(static_cast<std::string const&>(val));
+				attributes.add(key, static_cast<const std::string&>(val), 0);
 				layer.attributeMap[key] = 0;
 			} else if (val.isType<int>()) {
 				if (key=="_minzoom") { minzoom=val; continue; }
-				v.set_float_value(val);
+				attributes.add(key, (float)val, 0);
 				layer.attributeMap[key] = 1;
 			} else if (val.isType<double>()) {
-				v.set_float_value(val);
+				attributes.add(key, (float)val, 0);
 				layer.attributeMap[key] = 1;
 			} else if (val.isType<bool>()) {
-				v.set_bool_value(val);
+				attributes.add(key, (bool)val, 0);
 				layer.attributeMap[key] = 2;
 			} else {
 				// don't even think about trying to write nested tables, thank you
 				std::cout << "Didn't recognise Lua output type: " << val << std::endl;
 			}
-			attributes.add(key, v, 0);
 		}
 	} else {
 		for (auto it : columnMap) {
@@ -82,17 +80,16 @@ AttributeIndex readShapefileAttributes(
 			string key = it.second;
 			vector_tile::Tile_Value v;
 			switch (columnTypeMap[pos]) {
-				case 1:  v.set_int_value(DBFReadIntegerAttribute(dbf, recordNum, pos));
+				case 1:  attributes.add(key, (float)DBFReadIntegerAttribute(dbf, recordNum, pos), 0);
 				         layer.attributeMap[key] = 1;
 				         break;
-				case 2:  v.set_float_value(static_cast<float>(DBFReadDoubleAttribute(dbf, recordNum, pos)));
+				case 2:  attributes.add(key, static_cast<float>(DBFReadDoubleAttribute(dbf, recordNum, pos)), 0);
 				         layer.attributeMap[key] = 1;
 				         break;
-				default: v.set_string_value(DBFReadStringAttribute(dbf, recordNum, pos));
+				default: attributes.add(key, DBFReadStringAttribute(dbf, recordNum, pos), 0);
 				         layer.attributeMap[key] = 0;
 				         break;
 			}
-			attributes.add(key, v, 0);
 		}
 	}
 	return osmLuaProcessing.getAttributeStore().add(attributes);

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -36,6 +36,8 @@ AttributeIndex readShapefileAttributes(
 		LayerDef &layer,
 		OsmLuaProcessing &osmLuaProcessing, int &minzoom) {
 
+	AttributeStore& attributeStore = osmLuaProcessing.getAttributeStore();
+
 	AttributeSet attributes;
 	if (osmLuaProcessing.canRemapShapefiles()) {
 		// Create table object
@@ -57,17 +59,17 @@ AttributeIndex readShapefileAttributes(
 		for (auto key : out_table.keys()) {
 			kaguya::LuaRef val = out_table[key];
 			if (val.isType<std::string>()) {
-				attributes.add(key, static_cast<const std::string&>(val), 0);
+				attributeStore.addAttribute(attributes, key, static_cast<const std::string&>(val), 0);
 				layer.attributeMap[key] = 0;
 			} else if (val.isType<int>()) {
 				if (key=="_minzoom") { minzoom=val; continue; }
-				attributes.add(key, (float)val, 0);
+				attributeStore.addAttribute(attributes, key, (float)val, 0);
 				layer.attributeMap[key] = 1;
 			} else if (val.isType<double>()) {
-				attributes.add(key, (float)val, 0);
+				attributeStore.addAttribute(attributes, key, (float)val, 0);
 				layer.attributeMap[key] = 1;
 			} else if (val.isType<bool>()) {
-				attributes.add(key, (bool)val, 0);
+				attributeStore.addAttribute(attributes, key, (bool)val, 0);
 				layer.attributeMap[key] = 2;
 			} else {
 				// don't even think about trying to write nested tables, thank you
@@ -80,19 +82,19 @@ AttributeIndex readShapefileAttributes(
 			string key = it.second;
 			vector_tile::Tile_Value v;
 			switch (columnTypeMap[pos]) {
-				case 1:  attributes.add(key, (float)DBFReadIntegerAttribute(dbf, recordNum, pos), 0);
+				case 1:  attributeStore.addAttribute(attributes, key, (float)DBFReadIntegerAttribute(dbf, recordNum, pos), 0);
 				         layer.attributeMap[key] = 1;
 				         break;
-				case 2:  attributes.add(key, static_cast<float>(DBFReadDoubleAttribute(dbf, recordNum, pos)), 0);
+				case 2:  attributeStore.addAttribute(attributes, key, static_cast<float>(DBFReadDoubleAttribute(dbf, recordNum, pos)), 0);
 				         layer.attributeMap[key] = 1;
 				         break;
-				default: attributes.add(key, DBFReadStringAttribute(dbf, recordNum, pos), 0);
+				default: attributeStore.addAttribute(attributes, key, DBFReadStringAttribute(dbf, recordNum, pos), 0);
 				         layer.attributeMap[key] = 0;
 				         break;
 			}
 		}
 	}
-	return osmLuaProcessing.getAttributeStore().add(attributes);
+	return attributeStore.add(attributes);
 }
 
 // Read shapefile, and create OutputObjects for all objects within the specified bounding box

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -76,7 +76,7 @@ OutputObjectRef ShpMemTiles::StoreShapefileGeometry(uint_least8_t layerNum,
 	
 				Point sp(p->x()*10000000.0, p->y()*10000000.0);
 				NodeID oid = store_point(sp);
-				oo = CreateObject(OutputObjectPoint(geomType, layerNum, oid, attrIdx, minzoom));
+				oo = CreateObject(OutputObject(geomType, layerNum, oid, attrIdx, minzoom));
 				if (isIndexed) indexedGeometries.push_back(oo);
 
 				tilex =  lon2tilex(p->x(), baseZoom);
@@ -88,7 +88,7 @@ OutputObjectRef ShpMemTiles::StoreShapefileGeometry(uint_least8_t layerNum,
 		case LINESTRING_:
 		{
 			NodeID oid = store_linestring(boost::get<Linestring>(geometry));
-			oo = CreateObject(OutputObjectLinestring(geomType, layerNum, oid, attrIdx, minzoom));
+			oo = CreateObject(OutputObject(geomType, layerNum, oid, attrIdx, minzoom));
 			if (isIndexed) indexedGeometries.push_back(oo);
 
 			std::vector<OutputObjectRef> oolist { oo };
@@ -99,7 +99,7 @@ OutputObjectRef ShpMemTiles::StoreShapefileGeometry(uint_least8_t layerNum,
 		case POLYGON_:
 		{
 			NodeID oid = store_multi_polygon(boost::get<MultiPolygon>(geometry));
-			oo = CreateObject(OutputObjectMultiPolygon(geomType, layerNum, oid, attrIdx, minzoom));
+			oo = CreateObject(OutputObject(geomType, layerNum, oid, attrIdx, minzoom));
 			if (isIndexed) indexedGeometries.push_back(oo);
 
 			std::vector<OutputObjectRef> oolist { oo };

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -9,6 +9,19 @@ using namespace std;
 
 typedef std::pair<OutputObjectsConstIt,OutputObjectsConstIt> OutputObjectsConstItPair;
 
+thread_local std::deque<OutputObject>* tlsObjects = NULL;
+
+OutputObjectRef TileDataSource::CreateObject(OutputObject const &oo) {
+	if (tlsObjects == NULL) {
+		std::lock_guard<std::mutex> lock(mutex);
+		objects.push_back(std::deque<OutputObject>());
+		tlsObjects = &objects.back();
+	}
+
+	tlsObjects->push_back(oo);
+	return &tlsObjects->back();
+}
+
 void TileDataSource::MergeTileCoordsAtZoom(uint zoom, uint baseZoom, const TileIndex &srcTiles, TileCoordinatesSet &dstCoords) {
 	if (zoom==baseZoom) {
 		// at z14, we can just use tileIndex


### PR DESCRIPTION
This fixes a bug where:

```lua
obj:Attribute('name', 'some value')
obj:Attribute('name', 'some other value')
```

sometimes resulted in the first value being saved, sometimes the second. Now the last value always wins.

There are also some memory reductions: about 2,300MB less memory is needed for GB. This comes from two locations:

- AttributeStore - 1,300MB
- OsmMemTiles - 1,000MB

The PR does a few things.

1. Rather than store a whole `std::string` in `AttributePair` to identify the key (`name:latin`, `kind`, `iata`, etc), it identifies the key by a `uint16_t`. This limits Tilemaker to only 64K keys -- probably fine? Shortbread uses about 50, for reference.
2. Rather than store a whole `AttributePair` in an `AttributeSet`, it references them by a vector of `uint32_t`. This limits Tilemaker to 4B `AttributePair`s. This might be an issue -- but it's easily extended to more if needed. I see elsewhere that [Tilemaker is limited to 1B `AttributeSet`s](https://github.com/systemed/tilemaker/blob/d9bb72b929226937c9b06bd5279b0ec09a162a53/include/output_object.h#L42) -- probably if one has an issue, the other will, too.
3. I lied, `AttributeSet` only sometimes uses an actual vector of `uint32_t`s -- most of the time, a vector is overkill, as items only have a handful of attributes. Instead, `AttributeSet` typically uses the 24 bytes that a vector would occupy to store an array of 4 shorts and 4 ints†. Only if this array gets exhausted does it change to using a vector.
4. `vector_tile::Tile_Value` turns out to be quite big -- it's 96 bytes. I replaced it with a union of `std::string`, `float` and `bool`. I didn't notice any negative impact to PBF generation at the end from newing it up on a per-layer basis.
5. Recognize when a user calls `Layer` with the same geometry, and avoid processing/storing the geometry a second time. For example, when a profile writes a geometry for a river as well as for its name.

† The system tries to assign IDs that would fit in a short to those `AttributePair`s that it thinks will be very popular, like `rank=1`, `amenity=toilets`, `indoor=false` and so on. This lets most `AttributeSet`s store their pairs without having to allocate a vector.