### PR TITLE
subdivide blocks if needed in Phase::Relations

### DIFF
--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -15,7 +15,7 @@
 class OsmLuaProcessing;
 
 struct BlockData {
-	uint64_t offset;
+	long int offset;
 	google::protobuf::int32 length;
 	// For Phase::Relations -- only process the entries in the block if
 	// index % denominator == modulo. This allows us to use multiple cores

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -329,7 +329,7 @@ int PbfReader::ReadPbfFile(unordered_set<string> const &nodeKeys, unsigned int t
 			break;
 		}
 
-		blocks[blocks.size()] = { infile->tellg(), bh.datasize(), 0, 1 };
+		blocks[blocks.size()] = { (long int)infile->tellg(), bh.datasize(), 0, 1 };
 		infile->seekg(bh.datasize(), std::ios_base::cur);
 		
 	}

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -351,7 +351,7 @@ int PbfReader::ReadPbfFile(unordered_set<string> const &nodeKeys, unsigned int t
 				blocks.clear();
 
 				for (const auto& actualBlock: copied) {
-					for (int i = 0; i < threadNum; i++) {
+					for (size_t i = 0; i < threadNum; i++) {
 						blocks[blocks.size()] = { actualBlock.second.offset, actualBlock.second.length, i, threadNum };
 					}
 				}


### PR DESCRIPTION
This is a small quality-of-life tweak for people iterating on a theme on a small extract.

I often test on a Nova Scotia extract. It's big enough to test many things, but small enough to be fast to process, about 25 seconds. 6 seconds are spent in Phase::Relations processing.

The extract has 1,647 blocks, split roughly:
- 1,500-ish with nodes
- 140-ish with ways
- only 3 with relations

Thus, most of my CPU cores are idle during Phase::Relations, as there are not enough blocks to go around.

This is doubly bad, as a block of relations takes much longer than a block of nodes or ways, due to the more complex geometries involved.

This PR changes Tilemaker such that if it sees the relations phase has too few blocks, it artificially subdivides them in order to keep the CPUs busy.

This reduces my time for Nova Scotia to about 20 seconds.