### PR TITLE
tile index: don't block on shared lock

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -193,6 +193,10 @@ public:
 
 	struct luaProcessingException :std::exception {};
 
+	void FlushTileIndex() {
+		osmMemTiles.FlushTileIndex();
+	}
+
 private:
 	/// Internal: clear current cached state
 	inline void reset() {

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -563,12 +563,15 @@ void OsmLuaProcessing::setNode(NodeID id, LatpLon node, const tag_map_t &tags) {
 	}
 
 	if (!this->empty()) {
+		std::vector<TileIndexEntry> entries;
 		TileCoordinates index = latpLon2index(node, this->config.baseZoom);
 
 		for (auto &output : OutputsAsOORefs()) {
-			osmMemTiles.AddObjectToTileIndex(index, output);
+			entries.push_back(std::make_pair(index, output));
 		}
-	} 
+
+		osmMemTiles.AddObjectsToTileIndex(entries);
+	}
 }
 
 // We are now processing a way

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -357,6 +357,8 @@ int PbfReader::ReadPbfFile(unordered_set<string> const &nodeKeys, unsigned int t
 			osmStore.ways_sort(threadNum);
 		}
 	}
+	const auto& osmLuaProcessing = generate_output();
+	osmLuaProcessing->FlushTileIndex();
 	return 0;
 }
 

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -272,4 +272,5 @@ void readShapefile(const Box &clippingBox,
 
 	SHPClose(shp);
 	DBFClose(dbf);
+	shpMemTiles.FlushTileIndex();
 }

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -81,7 +81,10 @@ OutputObjectRef ShpMemTiles::StoreShapefileGeometry(uint_least8_t layerNum,
 
 				tilex =  lon2tilex(p->x(), baseZoom);
 				tiley = latp2tiley(p->y(), baseZoom);
-				AddObjectToTileIndex(TileCoordinates(tilex, tiley), oo);
+
+				std::vector<TileIndexEntry> entries;
+				entries.push_back(std::make_pair(TileCoordinates(tilex, tiley), oo));
+				AddObjectsToTileIndex(entries);
 			}
 		} break;
 


### PR DESCRIPTION
I promise I'm running out of PRs. :)

Previously, each worker thread tried to eagerly insert their object into the index, blocking if another thread had the lock.

The index update operation can be expensive -- it potentially has to rebalance the `map`, and potentially has to grow + copy the value's `vector`.

But I think no one reads the index until the output stage, so the workers could just add their updates to a queue and move on with their other work.

That's what they now do. If, after adding the object, the queue is looking large, one worker will self-nominate to flush the queue into the map. Two queues are maintained, so that other workers aren't blocked while this flush is happening.

`refactor_geometries` branch for reading GB:

```
real 1m28.080s
user 19m26.234s
sys 0m28.319s
```

This branch:

```
real 1m20.228s
user 18m59.398s
sys 0m16.494s
```