### PR TITLE
Retry with boost::geometry::intersection if fast_clip fails

### DIFF
--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -171,7 +171,20 @@ Geometry buildWayGeometry(OSMStore &osmStore, OutputObject const &oo, const Tile
 			geom::assign(mp, input);
 			fast_clip(mp, box);
 			geom::correct(mp);
-			if (!geom::is_valid(mp)) make_valid(mp);
+			geom::validity_failure_type failure = geom::validity_failure_type::no_failure;
+			if (!geom::is_valid(mp,failure)) { 
+				if (failure==geom::failure_spikes) {
+					geom::remove_spikes(mp);
+				} else if (failure==geom::failure_self_intersections || failure==geom::failure_intersecting_interiors) {
+					// retry with Boost intersection if fast_clip has caused self-intersections
+					MultiPolygon output;
+					geom::intersection(input, box, output);
+					geom::correct(output);
+					return output;
+				} else {
+					// occasionally also wrong_topological_dimension, disconnected_interior
+				}
+			}
 			return mp;
 		}
 


### PR DESCRIPTION
As per #594 and #574/#580, Maplibre GL Native objects to the 0-width borders around tile margins that `fast_clip` can create.

This PR falls back to `boost::geometry::intersection` when we're in a situation where self-intersections persist. We don't use `make_valid` (i.e. the custom correct code) at all in this case, just plain vanilla `boost::geometry::correct`. I've tested it with the original problem regions of Venice and Copenhagen, and with the additional problem areas of Athens and Shetland, and it appears to work reliably.

Performance is downgraded but less than I expected:

- Antarctica was 7hr29 in 2.0, was 2hr59 with fast_clip, now 3hr04
- Maine (canonical example for horrid multipolygons) was 34m37 in 2.0, was 4m23 with fast_clip, now 5m32
- Great Britain was 7m03 recently, 7m26 with make_valid, now 7m39

Given that this retains most of the performance gain while reliably producing correct geometries, I'm inclined to merge this. We can look at options for other clipping algorithms in the future.

There is one remaining issue where South Uist can disappear at z5, but I think this is a simplify problem rather than a clipping problem - simplify is creating a 0-width connection between the two islands. 