### PR TITLE
AttributeStore: skip locks when outputting

### DIFF
--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -39,13 +39,13 @@ void OutputObject::writeAttributes(
 	vector_tile::Tile_Feature *featurePtr,
 	char zoom) const {
 
-	auto attr = attributeStore.get(attributes);
+	auto attr = attributeStore.getUnsafe(attributes);
 
 	for(auto const &it: attr) {
 		if (it->minzoom > zoom) continue;
 
 		// Look for key
-		std::string const &key = attributeStore.keyStore.getKey(it->keyIndex);
+		std::string const &key = attributeStore.keyStore.getKeyUnsafe(it->keyIndex);
 		auto kt = find(keyList->begin(), keyList->end(), key);
 		if (kt != keyList->end()) {
 			uint32_t subscript = kt - keyList->begin();

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -346,7 +346,7 @@ int main(int argc, char* argv[]) {
 				});	
 			if (ret != 0) return ret;
 		} 
-		attributeStore.doneReading();
+		attributeStore.finalize();
 		osmMemTiles.reportSize();
 		attributeStore.reportSize();
 		void_mmap_allocator::shutdown(); // this clears the mmap'ed nodes/ways/relations (quickly!)


### PR DESCRIPTION
The locks in AttributeStore are necessary only during PBF reading, to avoid concurrent mutations corrupting things.

Once we're writing the mbtiles, it's safe to read without acquiring the lock. This eliminates ~9% of system time, and ~2-3% of wall clock time.

The PR also adds a `finalize()` to AttributeStore, AttributeKeyStore and AttributePairStore. Nothing actually uses this yet - I initially checked the `finalized` variable and threw if an unsafe method was called, but that gave up the speed benefits, so I removed it again.

Perhaps in the future, a debug build could leave such checks in to detect programming errors.