### PR TITLE
Avoid creating small artefacts when scaling

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -124,6 +124,7 @@ public:
 	TileBbox(TileCoordinates i, uint z, bool h, bool e);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
+	std::vector<Point> scaleRing(Ring const &src) const;
 	MultiPolygon scaleGeometry(MultiPolygon const &src) const;
 	std::pair<double, double> floorLatpLon(double latp, double lon) const;
 

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -105,7 +105,7 @@ std::vector<Point> TileBbox::scaleRing(Ring const &src) const {
 		auto scaled = scaleLatpLon(i.y(), i.x()); // -> .first is x, .second is y
 		bool found = false;
 		for (size_t j=1; j<5; j++) {
-			if ((points.size()-j) < 1) break;
+			if (points.size() < 1+j) break;
 			Point check = points[points.size()-j];
 			if (check.x()==scaled.first && check.y()==scaled.second) {
 				points.resize(points.size()-j+1); found=true; break;

--- a/src/write_geometry.cpp
+++ b/src/write_geometry.cpp
@@ -53,7 +53,7 @@ void WriteGeometryVisitor::operator()(const MultiPolygon &mp) const {
 		XYString points;
 		Ring ring = geom::exterior_ring(*it);
 		for (auto jt = ring.begin(); jt != ring.end(); ++jt) {
-			pair<int,int> xy(jt->get<1>(), jt->get<0>());
+			pair<int,int> xy(jt->get<0>(), jt->get<1>());
 			points.push_back(xy);
 		}
 		bool success = writeDeltaString(&points, featurePtr, &lastPos, true);
@@ -63,7 +63,7 @@ void WriteGeometryVisitor::operator()(const MultiPolygon &mp) const {
 		for (auto ii = interiors.begin(); ii != interiors.end(); ++ii) {
 			points.clear();
 			for (auto jt = ii->begin(); jt != ii->end(); ++jt) {
-				pair<int,int> xy(jt->get<1>(), jt->get<0>());
+				pair<int,int> xy(jt->get<0>(), jt->get<1>());
 				points.push_back(xy);
 			}
 			writeDeltaString(&points, featurePtr, &lastPos, true);


### PR DESCRIPTION
When we scale geometries from projected lat / lon to vector tile coordinates, we often create small spikes and self-intersecting triangles/squares, particularly on intricate geometries like coastlines at lower zoom levels. Although the simplify operation does a good job of removing these, we stand a better chance of producing valid geometries if we don't create these artefacts in the first place.

This PR uses a naive algorithm to minimise the chance of small artefacts. When scaling, for each point, it checks the last five points to see if it duplicates any of them. If so, we backtrack to that point and discard the intervening points.

This appears to fix geometry issues in Andros and the Hebrides. Output tilesize is very slightly reduced and there's no discernible impact on runtimes. 