### PR TITLE
Clipping monster polygons

### DIFF
--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -308,7 +308,10 @@ protected:
 	// to track the tiles that would be entirely filled.
 	//
 	// To minimize lock contention, we shard by NodeID.
-	std::vector<std::map<std::pair<uint16_t, NodeID>, uint64_t>> largePolygons;
+	std::vector<std::map<std::pair<uint16_t, NodeID>, uint64_t>> largeCoveringPolygons;
+	// Like above, but for the case where we're in the hole of the polygon,
+	// and so render nothing.
+	std::vector<std::map<std::pair<uint16_t, NodeID>, uint64_t>> largeExcludedPolygons;
 
 
 public:
@@ -447,7 +450,7 @@ public:
 
 
 private:	
-	void checkForLargePolygon(NodeID objectID, const TileBbox& bbox, const MultiPolygon& mp);
+	void updateLargePolygonMaps(NodeID objectID, const TileBbox& bbox, const MultiPolygon& mp);
 };
 
 TileCoordinatesSet getTilesAtZoom(

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -96,7 +96,7 @@ void MergeIntersecting(MultiPolygon &input, MultiPolygon &to_merge) {
 
 template <typename T>
 void CheckNextObjectAndMerge(
-	const TileDataSource* source,
+	TileDataSource* source,
 	OutputObjectsConstIt& jt,
 	OutputObjectsConstIt ooSameLayerEnd, 
 	const TileBbox& bbox,
@@ -147,7 +147,7 @@ void RemoveInnersBelowSize(MultiPolygon &g, double filterArea) {
 }
 
 void ProcessObjects(
-	const TileDataSource* source,
+	TileDataSource* source,
 	const AttributeStore& attributeStore,
 	OutputObjectsConstIt ooSameLayerBegin,
 	OutputObjectsConstIt ooSameLayerEnd, 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -543,16 +543,6 @@ int main(int argc, char* argv[]) {
 					unsigned int zoom = tileCoordinates[i].first;
 					TileCoordinates coords = tileCoordinates[i].second;
 
-					/*
-					// Only do tiles at z6/16/18 and underneath -- this is the
-					// middle of the Hudson Bay.
-					if (zoom < 6)
-						continue;
-					size_t newx = coords.x / (1 << (zoom - 6));
-					size_t newy = coords.y / (1 << (zoom - 6));
-					if (newx != 16 || newy != 18)
-						continue;
-						*/
 					std::vector<std::vector<OutputObjectID>> data;
 					for (auto source : sources) {
 						data.emplace_back(source->getObjectsForTile(sortOrders, zoom, coords));

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -542,6 +542,17 @@ int main(int argc, char* argv[]) {
 				for(std::size_t i = startIndex; i < endIndex; ++i) {
 					unsigned int zoom = tileCoordinates[i].first;
 					TileCoordinates coords = tileCoordinates[i].second;
+
+					/*
+					// Only do tiles at z6/16/18 and underneath -- this is the
+					// middle of the Hudson Bay.
+					if (zoom < 6)
+						continue;
+					size_t newx = coords.x / (1 << (zoom - 6));
+					size_t newy = coords.y / (1 << (zoom - 6));
+					if (newx != 16 || newy != 18)
+						continue;
+						*/
 					std::vector<std::vector<OutputObjectID>> data;
 					for (auto source : sources) {
 						data.emplace_back(source->getObjectsForTile(sortOrders, zoom, coords));


### PR DESCRIPTION
This implements some ideas to mitigate the impact of clipping monster multipolygons.

In particular, for any multipolygon that is fully clipped out (i.e. we're in its hole) or clips to the full extent of a tile at z6..z8, we'll track the z9 tiles that it would fully cover or be excluded from.

Later, when processing a tile at z7 or higher, we'll check this tracking information to short-circuit doing an expensive clip operation.

Processing the Hudson Bay extract [1]:

master:
```
real	22m27.753s
user	336m50.481s
sys	0m25.314s
```

this branch:
```
real	3m46.838s
user	45m33.959s
sys	0m12.161s
```

I think the general idea here is sound...but I also think I don't know much about geometry or how it interacts with vector tiles, so a critical eye & mind would be extra appreciated.

Eyeballing the resulting tiles, it seems to look OK. This is not very rigorous, though. :) I wonder if there is tooling that will diff an mbtiles or pmtiles file? In theory, the files ought to be equivalent.

[1]: https://extract.bbbike.org/?lang=en;sw_lng=-99.269;sw_lat=53.617;ne_lng=-65.244;ne_lat=64.616;format=osm.pbf;city=a%20big%20bay;email=cldellow%40gmail.com;as=76.54103151056417;pg=0.8698404751901266;coords=;oi=1;layers=B000T;submit=;expire=
