### PR TITLE
Clipping monster polygons 2

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -33,6 +33,15 @@ public:
 			return false;
 		return y == obj.y;
 	}
+
+	bool operator <(const TileCoordinates_ & obj) const
+	{
+		if (x != obj.x)
+			return x < obj.x;
+
+		return y < obj.y;
+	}
+
 };
 struct TileCoordinatesCompare {
     bool operator()(const class TileCoordinates_& a, const class TileCoordinates_& b) const {

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -335,7 +335,7 @@ public:
 		TileCoordinates coordinates
 	);
 
-	Geometry buildWayGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox) const;
+	Geometry buildWayGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox);
 	LatpLon buildNodeGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox) const;
 
 	void open() {
@@ -427,6 +427,10 @@ public:
 
 
 private:	
+	std::vector<std::map<std::tuple<uint16_t, TileCoordinates, NodeID>, std::shared_ptr<MultiPolygon>>> clipCache;
+	std::vector<std::mutex> clipCacheMutex;
+	std::vector<size_t> clipCacheSize;
+	void cacheClippedGeometry(const TileBbox& box, const NodeID objectID, const MultiPolygon& mp);
 };
 
 TileCoordinatesSet getTilesAtZoom(

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -100,6 +100,10 @@ void TileDataSource::collectObjectsForTile(
 		TileCoordinate z6x = dstIndex.x / (1 << (zoom - CLUSTER_ZOOM));
 		TileCoordinate z6y = dstIndex.y / (1 << (zoom - CLUSTER_ZOOM));
 
+		if (z6x >= 64 || z6y >= 64) {
+			if (verbose) std::cerr << "collectObjectsForTile: invalid tile z" << zoom << "/" << dstIndex.x << "/" << dstIndex.y << std::endl;
+			return;
+		}
 		iStart = z6x * CLUSTER_ZOOM_WIDTH + z6y;
 		iEnd = iStart + 1;
 	}

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -96,7 +96,7 @@ void MergeIntersecting(MultiPolygon &input, MultiPolygon &to_merge) {
 
 template <typename T>
 void CheckNextObjectAndMerge(
-	const TileDataSource* source,
+	TileDataSource* source,
 	OutputObjectsConstIt& jt,
 	OutputObjectsConstIt ooSameLayerEnd, 
 	const TileBbox& bbox,
@@ -147,7 +147,7 @@ void RemoveInnersBelowSize(MultiPolygon &g, double filterArea) {
 }
 
 void ProcessObjects(
-	const TileDataSource* source,
+	TileDataSource* source,
 	const AttributeStore& attributeStore,
 	OutputObjectsConstIt ooSameLayerBegin,
 	OutputObjectsConstIt ooSameLayerEnd, 


### PR DESCRIPTION
This replaces https://github.com/systemed/tilemaker/pull/606

When writing, we keep a cache of previously clipped geometries. Higher zooms will prefer to clip a cached, clipped geometry over an uncached, unclipped geometry.

With this PR:

- Hudson Bay: 1m28s
- Antarctica: 9m5s

Antarctica doesn't max out the CPU due to https://github.com/systemed/tilemaker/issues/596 - I think a next step there could be to have a buffer so workers can just enqueue a tile (up to some limit) and move on with their work.

I also noticed that the Antarctica mbtiles couldn't be converted by the `pmtiles convert` command. I suspect this is a pre-existing issue, but I've never generated Antarctica before. My guess is it's related to https://github.com/systemed/tilemaker/blob/06b68df2a969fc6ddc1e579ee6747458661d8683/src/tile_worker.cpp#L187, and we need to not write a tile at all if it has no features, not just remove the empty feature.