### PR TITLE
Make shapefile processing multi-threaded

### DIFF
--- a/include/read_shp.h
+++ b/include/read_shp.h
@@ -14,6 +14,8 @@
 // Shapelib
 #include "shapefil.h"
 
+std::mutex attributeMutex;
+
 void fillPointArrayFromShapefile(std::vector<Point> *points, SHPObject *shape, uint part);
 
 /// Read requested attributes from a shapefile, and encode into an OutputObject

--- a/include/read_shp.h
+++ b/include/read_shp.h
@@ -14,8 +14,6 @@
 // Shapelib
 #include "shapefil.h"
 
-std::mutex attributeMutex;
-
 void fillPointArrayFromShapefile(std::vector<Point> *points, SHPObject *shape, uint part);
 
 /// Read requested attributes from a shapefile, and encode into an OutputObject

--- a/include/read_shp.h
+++ b/include/read_shp.h
@@ -21,14 +21,19 @@ AttributeIndex readShapefileAttributes(DBFHandle &dbf, int recordNum,
                                        std::unordered_map<int,std::string> &columnMap,
                                        std::unordered_map<int,int> &columnTypeMap,
                                        LayerDef &layer,
-                                       OsmLuaProcessing &osmLuaProcessing, int &minzoom);
+                                       OsmLuaProcessing &osmLuaProcessing, uint &minzoom);
 
 /// Read shapefile, and create OutputObjects for all objects within the specified bounding box
 void readShapefile(const Box &clippingBox,
                    class LayerDefinition &layers,
                    uint baseZoom, uint layerNum,
-				   class ShpMemTiles &shpMemTiles,
-				   OsmLuaProcessing &osmLuaProcessing);
+                   uint threadNum,
+                   class ShpMemTiles &shpMemTiles,
+                   OsmLuaProcessing &osmLuaProcessing);
+
+// Process an individual shapefile record
+void processShapeGeometry(SHPObject* shape, AttributeIndex attrIdx, ShpMemTiles &shpMemTiles,
+                          const Box &clippingBox, const LayerDef &layer, uint layerNum, bool hasName, const std::string &name);
 
 #endif //_READ_SHP_H
 

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -12,6 +12,8 @@ namespace geom = boost::geometry;
 	Read shapefiles into Boost geometries
 */
 
+std::mutex attributeMutex;
+
 void fillPointArrayFromShapefile(vector<Point> *points, SHPObject *shape, uint part) {
 	uint start = shape->panPartStart[part];
 	uint end   = (int(part)==shape->nParts-1) ? shape->nVertices : shape->panPartStart[part+1];

--- a/src/read_shp.cpp
+++ b/src/read_shp.cpp
@@ -41,6 +41,7 @@ AttributeIndex readShapefileAttributes(
 		LayerDef &layer,
 		OsmLuaProcessing &osmLuaProcessing, uint &minzoom) {
 
+	std::lock_guard<std::mutex> lock(attributeMutex);
 	AttributeStore& attributeStore = osmLuaProcessing.getAttributeStore();
 
 	AttributeSet attributes;

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -346,7 +346,8 @@ int main(int argc, char* argv[]) {
 			readShapefile(clippingBox,
 			              layers,
 			              config.baseZoom, layerNum,
-						  shpMemTiles, osmLuaProcessing);
+			              threadNum,
+			              shpMemTiles, osmLuaProcessing);
 		}
 	}
 	shpMemTiles.reportSize();


### PR DESCRIPTION
Currently shapefile reading is entirely single-threaded. This PR shunts the geometry processing into separate threads.

The Lua `attribute_function` doesn't do much, only basic tag remapping. The expensive bit is the geometry assembly, which includes our old friends `geom::intersection` and `make_valid`. So we can get away with putting a single mutex around the Lua access rather than creating a Lua state for each thread.

Total processing time is reduced by 6m30 for North America. (The North America .pbf crosses the 180° meridian so it ends up pulling in shapefiles for -180° to 180°.)

This also moves some geometry error output to verbose mode.

The shapefile reader code is very old and needs tidying up and moving into a `ShpReader` class, but this will do for now. Ideally we should refactor the `StoreShapefileGeometry` calls out of processShapeGeometry and put them in the calling lambda, which would make more sense conceptually and mean we didn't have to pass so many parameters around. But that will require a little bit of refactoring work on multilinestrings.