### PR TITLE
be able to render the planet with 32gb of RAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ file(GLOB tilemaker_src_files
 	src/mbtiles.cpp
 	src/mmap_allocator.cpp
 	src/node_stores.cpp
+	src/options_parser.cpp
 	src/osm_lua_processing.cpp
 	src/osm_mem_tiles.cpp
 	src/osm_store.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ file(GLOB tilemaker_src_files
 	src/pooled_string.cpp
 	src/read_pbf.cpp
 	src/read_shp.cpp
+	src/sharded_node_store.cpp
 	src/shared_data.cpp
 	src/shp_mem_tiles.cpp
 	src/sorted_node_store.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ file(GLOB tilemaker_src_files
 	src/read_pbf.cpp
 	src/read_shp.cpp
 	src/sharded_node_store.cpp
+	src/sharded_way_store.cpp
 	src/shared_data.cpp
 	src/shp_mem_tiles.cpp
 	src/sorted_node_store.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ file(GLOB tilemaker_src_files
 	src/osm_store.cpp
 	src/output_object.cpp
 	src/pbf_blocks.cpp
+	src/pooled_string.cpp
 	src/read_pbf.cpp
 	src/read_shp.cpp
 	src/shared_data.cpp

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ tilemaker: \
 	src/mbtiles.o \
 	src/mmap_allocator.o \
 	src/node_stores.o \
+	src/options_parser.o \
 	src/osm_lua_processing.o \
 	src/osm_mem_tiles.o \
 	src/osm_store.o \
@@ -152,6 +153,10 @@ test_deque_map: \
 	test/deque_map.test.o
 	$(CXX) $(CXXFLAGS) -o test.deque_map $^ $(INC) $(LIB) $(LDFLAGS) && ./test.deque_map
 
+test_options_parser: \
+	src/options_parser.o \
+	test/options_parser.test.o
+	$(CXX) $(CXXFLAGS) -o test.options_parser $^ $(INC) $(LIB) $(LDFLAGS) && ./test.options_parser
 
 test_pooled_string: \
 	src/mmap_allocator.o \
@@ -167,7 +172,6 @@ test_sorted_node_store: \
 	src/sorted_node_store.o \
 	test/sorted_node_store.test.o
 	$(CXX) $(CXXFLAGS) -o test.sorted_node_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.sorted_node_store
-
 
 test_sorted_way_store: \
 	src/external/streamvbyte_decode.o \

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ tilemaker: \
 	src/osm_store.o \
 	src/output_object.o \
 	src/pbf_blocks.o \
+	src/pooled_string.o \
 	src/read_pbf.o \
 	src/read_shp.o \
 	src/shared_data.o \
@@ -124,7 +125,13 @@ tilemaker: \
 	src/write_geometry.o
 	$(CXX) $(CXXFLAGS) -o tilemaker $^ $(INC) $(LIB) $(LDFLAGS)
 
-test: test_sorted_way_store
+test: test_pooled_string test_sorted_way_store
+
+test_pooled_string: \
+	src/mmap_allocator.o \
+	src/pooled_string.o \
+	test/pooled_string.test.o
+	$(CXX) $(CXXFLAGS) -o test.pooled_string $^ $(INC) $(LIB) $(LDFLAGS) && ./test.pooled_string
 
 test_sorted_way_store: \
 	src/external/streamvbyte_decode.o \
@@ -132,7 +139,7 @@ test_sorted_way_store: \
 	src/external/streamvbyte_zigzag.o \
 	src/mmap_allocator.o \
 	src/sorted_way_store.o \
-	src/sorted_way_store.test.o
+	test/sorted_way_store.test.o
 	$(CXX) $(CXXFLAGS) -o test.sorted_way_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.sorted_way_store
 
 
@@ -152,6 +159,6 @@ install:
 	install docs/man/tilemaker.1 ${DESTDIR}${MANPREFIX}/man1/
 
 clean:
-	rm -f tilemaker src/*.o src/external/*.o include/*.o include/*.pb.h
+	rm -f tilemaker src/*.o src/external/*.o include/*.o include/*.pb.h test/*.o
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ tilemaker: \
 	src/read_pbf.o \
 	src/read_shp.o \
 	src/sharded_node_store.o \
+	src/sharded_way_store.o \
 	src/shared_data.o \
 	src/shp_mem_tiles.o \
 	src/sorted_node_store.o \

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,12 @@ tilemaker: \
 	src/write_geometry.o
 	$(CXX) $(CXXFLAGS) -o tilemaker $^ $(INC) $(LIB) $(LDFLAGS)
 
-test: test_attribute_store test_pooled_string test_sorted_way_store
+test: test_append_vector test_attribute_store test_pooled_string test_sorted_way_store
+
+test_append_vector: \
+	src/mmap_allocator.o \
+	test/append_vector.test.o
+	$(CXX) $(CXXFLAGS) -o test.append_vector $^ $(INC) $(LIB) $(LDFLAGS) && ./test.append_vector
 
 test_attribute_store: \
 	src/mmap_allocator.o \

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ test: test_attribute_store test_pooled_string test_sorted_way_store
 test_attribute_store: \
 	src/mmap_allocator.o \
 	src/attribute_store.o \
+	src/pooled_string.o \
 	test/attribute_store.test.o
 	$(CXX) $(CXXFLAGS) -o test.attribute_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.attribute_store
 

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,13 @@ tilemaker: \
 	src/write_geometry.o
 	$(CXX) $(CXXFLAGS) -o tilemaker $^ $(INC) $(LIB) $(LDFLAGS)
 
-test: test_pooled_string test_sorted_way_store
+test: test_attribute_store test_pooled_string test_sorted_way_store
+
+test_attribute_store: \
+	src/mmap_allocator.o \
+	src/attribute_store.o \
+	test/attribute_store.test.o
+	$(CXX) $(CXXFLAGS) -o test.attribute_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.attribute_store
 
 test_pooled_string: \
 	src/mmap_allocator.o \

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,12 @@ tilemaker: \
 	src/write_geometry.o
 	$(CXX) $(CXXFLAGS) -o tilemaker $^ $(INC) $(LIB) $(LDFLAGS)
 
-test: test_append_vector test_attribute_store test_pooled_string test_sorted_way_store
+test: \
+	test_append_vector \
+	test_attribute_store \
+	test_pooled_string \
+	test_sorted_node_store \
+	test_sorted_way_store
 
 test_append_vector: \
 	src/mmap_allocator.o \
@@ -144,6 +149,16 @@ test_pooled_string: \
 	src/pooled_string.o \
 	test/pooled_string.test.o
 	$(CXX) $(CXXFLAGS) -o test.pooled_string $^ $(INC) $(LIB) $(LDFLAGS) && ./test.pooled_string
+
+test_sorted_node_store: \
+	src/external/streamvbyte_decode.o \
+	src/external/streamvbyte_encode.o \
+	src/external/streamvbyte_zigzag.o \
+	src/mmap_allocator.o \
+	src/sorted_node_store.o \
+	test/sorted_node_store.test.o
+	$(CXX) $(CXXFLAGS) -o test.sorted_node_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.sorted_node_store
+
 
 test_sorted_way_store: \
 	src/external/streamvbyte_decode.o \

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ tilemaker: \
 	src/pooled_string.o \
 	src/read_pbf.o \
 	src/read_shp.o \
+	src/sharded_node_store.o \
 	src/shared_data.o \
 	src/shp_mem_tiles.o \
 	src/sorted_node_store.o \

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ tilemaker: \
 test: \
 	test_append_vector \
 	test_attribute_store \
+	test_deque_map \
 	test_pooled_string \
 	test_sorted_node_store \
 	test_sorted_way_store
@@ -145,6 +146,11 @@ test_attribute_store: \
 	src/pooled_string.o \
 	test/attribute_store.test.o
 	$(CXX) $(CXXFLAGS) -o test.attribute_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.attribute_store
+
+test_deque_map: \
+	test/deque_map.test.o
+	$(CXX) $(CXXFLAGS) -o test.deque_map $^ $(INC) $(LIB) $(LDFLAGS) && ./test.deque_map
+
 
 test_pooled_string: \
 	src/mmap_allocator.o \

--- a/include/append_vector.h
+++ b/include/append_vector.h
@@ -1,0 +1,193 @@
+#ifndef _APPEND_VECTOR_H
+#define _APPEND_VECTOR_H
+
+#include "mmap_allocator.h"
+#include <vector>
+#include <queue>
+
+// Tilemaker collects OutputObjects in a list that
+// - spills to disk
+// - only gets appended to
+//
+// Vector is great for linear access, but resizes cause expensive disk I/O to
+// copy elements.
+//
+// Deque is great for growing without disk I/O, but it allocates in blocks of 512,
+// which is inefficient for linear access.
+//
+// Instead, we author a limited vector-of-vectors class that allocates in bigger chunks,
+// to get the best of both worlds.
+
+#define APPEND_VECTOR_SIZE 8192
+namespace AppendVectorNS {
+	template <class T>
+	class AppendVector {
+	public:
+		struct Iterator {
+			using iterator_category = std::random_access_iterator_tag;
+			using difference_type   = std::ptrdiff_t;
+			using value_type        = T;
+			using pointer           = T*;
+			using reference         = T&;
+
+			Iterator(AppendVector<T>& appendVector, uint16_t vec, uint16_t offset):
+				appendVector(&appendVector), vec(vec), offset(offset) {}
+
+			Iterator():
+				appendVector(nullptr), vec(0), offset(0) {}
+
+
+			bool operator<(const Iterator& other) const {
+				if (vec < other.vec)
+					return true;
+
+				if (vec > other.vec)
+					return false;
+
+				return offset < other.offset;
+			}
+
+			bool operator>=(const Iterator& other) const {
+				return !(*this < other);
+			}
+
+			Iterator operator-(int delta) const {
+				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
+				absolute -= delta;
+				return Iterator(*appendVector, absolute / APPEND_VECTOR_SIZE, absolute % APPEND_VECTOR_SIZE);
+			}
+
+			Iterator operator+(int delta) const {
+				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
+				absolute += delta;
+				return Iterator(*appendVector, absolute / APPEND_VECTOR_SIZE, absolute % APPEND_VECTOR_SIZE);
+			}
+
+			bool operator==(const Iterator& other) const {
+				return appendVector == other.appendVector && vec == other.vec && offset == other.offset;
+			}
+
+			bool operator!=(const Iterator& other) const {
+				return !(*this == other);
+			}
+
+			std::ptrdiff_t operator-(const Iterator& other) const {
+				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
+				int64_t otherAbsolute = other.vec * APPEND_VECTOR_SIZE + other.offset;
+
+				return absolute - otherAbsolute;
+			}
+
+			reference operator*() const {
+				auto& vector = appendVector->vecs[vec];
+				auto& el = vector[offset];
+				return el;
+			}
+
+			pointer operator->() const {
+				auto& vector = appendVector->vecs[vec];
+				auto& el = vector[offset];
+				return &el;
+			}
+
+			Iterator& operator+= (int delta) {
+				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
+				absolute += delta;
+
+				vec = absolute / APPEND_VECTOR_SIZE;
+				offset = absolute % APPEND_VECTOR_SIZE;
+				return *this;
+			}
+
+			Iterator& operator-= (int delta) {
+				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
+				absolute -= delta;
+
+				vec = absolute / APPEND_VECTOR_SIZE;
+				offset = absolute % APPEND_VECTOR_SIZE;
+				return *this;
+			}
+
+			// Prefix increment
+			Iterator& operator++() {
+				offset++;
+				if (offset == APPEND_VECTOR_SIZE) {
+					offset = 0;
+					vec++;
+				}
+				return *this;
+			}  
+
+			// Postfix increment
+			Iterator operator++(int) { Iterator tmp = *this; ++(*this); return tmp; }
+
+			// Prefix decrement
+			Iterator& operator--() {
+				if (offset > 0) {
+					offset--;
+				} else {
+					vec--;
+					offset = APPEND_VECTOR_SIZE - 1;
+				}
+
+				return *this;
+			}
+
+			// Postfix decrement
+			Iterator operator--(int) { Iterator tmp = *this; --(*this); return tmp; }
+
+		private:
+			mutable AppendVector<T>* appendVector;
+			int32_t vec, offset;
+		};
+
+		AppendVector():
+			count(0),
+			vecs(1) {
+		}
+
+		void clear() {
+			count = 0;
+			vecs.clear();
+			vecs.push_back(std::vector<T, mmap_allocator<T>>());
+			vecs.back().reserve(APPEND_VECTOR_SIZE);
+		}
+
+		size_t size() const {
+			return count;
+		}
+
+		T& operator [](int idx) {
+			return vecs[idx / APPEND_VECTOR_SIZE][idx % APPEND_VECTOR_SIZE];
+		}
+
+		Iterator begin() {
+			return Iterator(*this, 0, 0);
+		}
+
+		Iterator end() {
+			return Iterator(*this, vecs.size() - 1, count % APPEND_VECTOR_SIZE);
+		}
+
+		void push_back(const T& el) {
+			if (vecs.back().capacity() == 0)
+				vecs.back().reserve(APPEND_VECTOR_SIZE);
+
+			vecs.back().push_back(el);
+
+			if (vecs.back().size() == vecs.back().capacity()) {
+				vecs.push_back(std::vector<T, mmap_allocator<T>>());
+				vecs.back().reserve(APPEND_VECTOR_SIZE);
+			}
+
+			count++;
+		}
+
+		size_t count;
+		std::deque<std::vector<T, mmap_allocator<T>>> vecs;
+	};
+}
+
+#undef APPEND_VECTOR_SIZE
+
+#endif

--- a/include/append_vector.h
+++ b/include/append_vector.h
@@ -158,7 +158,9 @@ namespace AppendVectorNS {
 		}
 
 		T& operator [](int idx) {
-			return vecs[idx / APPEND_VECTOR_SIZE][idx % APPEND_VECTOR_SIZE];
+			auto& vec = vecs[idx / APPEND_VECTOR_SIZE];
+			auto& el = vec[idx % APPEND_VECTOR_SIZE];
+			return el;
 		}
 
 		Iterator begin() {

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -10,6 +10,7 @@
 #include <boost/functional/hash.hpp>
 #include <boost/container/flat_map.hpp>
 #include <vector>
+#include "pooled_string.h"
 
 /* AttributeStore - global dictionary for attributes */
 
@@ -423,6 +424,7 @@ private:
 struct AttributeStore {
 	AttributeIndex add(AttributeSet &attributes);
 	std::vector<const AttributePair*> getUnsafe(AttributeIndex index) const;
+	size_t size() const;
 	void reportSize() const;
 	void finalize();
 

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -123,7 +123,7 @@ struct AttributePair {
 	float floatValue() const { return floatValue_; }
 	bool boolValue() const { return floatValue_; }
 
-	static bool isHot(const AttributePair& pair, const std::string& keyName) {
+	static bool isHot(const std::string& keyName, const std::string& value) {
 		// Is this pair a candidate for the hot pool?
 
 		// Hot pairs are pairs that we think are likely to be re-used, like
@@ -132,25 +132,11 @@ struct AttributePair {
 		// The trick is that we commit to putting them in the hot pool
 		// before we know if we were right.
 
-		// All boolean pairs are eligible.
-		if (pair.hasBoolValue())
-			return true;
-
-		// Small integers are eligible.
-		if (pair.hasFloatValue()) {
-			float v = pair.floatValue();
-
-			if (ceil(v) == v && v >= 0 && v <= 25)
-				return true;
-		}
-
-		// The remaining things should be strings, but just in case...
-		if (!pair.hasStringValue())
-			return false;
+		// The rules for floats/booleans are managed in their addAttribute call.
 
 		// Only strings that are IDish are eligible: only lowercase letters.
 		bool ok = true;
-		for (const auto& c: pair.stringValue()) {
+		for (const auto& c: value) {
 			if (c != '-' && c != '_' && (c < 'a' || c > 'z'))
 				return false;
 		}

--- a/include/deque_map.h
+++ b/include/deque_map.h
@@ -103,7 +103,7 @@ public:
 
 	struct iterator {
 		const DequeMap<T>& dm;
-		int offset;
+		size_t offset;
 		iterator(const DequeMap<T>& dm, int offset): dm(dm), offset(offset) {}
 		void operator++() { offset++; }
 		bool operator!=(iterator& other) { return offset != other.offset; }

--- a/include/deque_map.h
+++ b/include/deque_map.h
@@ -104,7 +104,7 @@ public:
 	struct iterator {
 		const DequeMap<T>& dm;
 		size_t offset;
-		iterator(const DequeMap<T>& dm, int offset): dm(dm), offset(offset) {}
+		iterator(const DequeMap<T>& dm, size_t offset): dm(dm), offset(offset) {}
 		void operator++() { offset++; }
 		bool operator!=(iterator& other) { return offset != other.offset; }
 		const T& operator*() const { return dm.objects[dm.keys[offset]]; }

--- a/include/deque_map.h
+++ b/include/deque_map.h
@@ -1,0 +1,128 @@
+#ifndef DEQUE_MAP_H
+#define DEQUE_MAP_H
+
+#include <algorithm>
+#include <boost/range/irange.hpp>
+#include <cstring>
+#include <deque>
+#include <vector>
+
+// A class which looks deep within the soul of some instance of
+// a class T and assigns it a number based on the order in which
+// it joined (or reminds it of its number).
+//
+// Used to translate an 8-byte pointer into a 4-byte ID that can be
+// used repeatedly.
+template <class T>
+class DequeMap {
+public:
+	DequeMap(): maxSize(0) {}
+	DequeMap(uint32_t maxSize): maxSize(maxSize) {}
+
+	bool full() const {
+		return maxSize != 0 && size() == maxSize;
+	}
+
+	// If `entry` is already in the map, return its index.
+	// Otherwise, if maxSize is `0`, or greater than the number of entries in the map,
+	// add the item and return its index.
+	// Otherwise, return -1.
+	int32_t add(const T& entry) {
+		// Search to see if we've already got this entry.
+		const auto offsets = boost::irange<uint32_t>(0, keys.size());
+		const auto it = std::lower_bound(
+			offsets.begin(),
+			offsets.end(),
+			entry,
+			[&](const auto &e, auto id) {
+				return objects.at(keys[e]) < id;
+			}
+		);
+
+		// We do, return its index.
+		if (it != offsets.end() && objects[keys[*it]] == entry)
+			return keys[*it];
+
+		if (maxSize > 0 && objects.size() >= maxSize)
+			return -1;
+
+		// We don't, so store it...
+		const uint32_t newIndex = objects.size();
+		objects.push_back(entry);
+
+		// ...and add its index to our keys vector.
+		const uint32_t keysOffset = it == offsets.end() ? offsets.size() : *it;
+
+		const uint32_t desiredSize = keys.size() + 1;
+
+		// Amortize growth
+		if (keys.capacity() < desiredSize)
+			keys.reserve(keys.capacity() * 1.5);
+
+		keys.resize(desiredSize);
+
+		// Unless we're adding to the end, we need to shuffle existing keys down
+		// to make room for our new index.
+		if (keysOffset != newIndex) {
+			std::memmove(&keys[keysOffset + 1], &keys[keysOffset], sizeof(uint32_t) * (keys.size() - 1 - keysOffset));
+		}
+
+		keys[keysOffset] = newIndex;
+		return newIndex;
+	}
+
+	void clear() {
+		objects.clear();
+		keys.clear();
+	}
+
+	// Returns the index of `entry` if present, -1 otherwise.
+	int32_t find(const T& entry) const {
+		const auto offsets = boost::irange<uint32_t>(0, keys.size());
+		const auto it = std::lower_bound(
+			offsets.begin(),
+			offsets.end(),
+			entry,
+			[&](const auto &e, auto id) {
+				return objects.at(keys[e]) < id;
+			}
+		);
+
+		// We do, return its index.
+		if (it != offsets.end() && objects[keys[*it]] == entry)
+			return keys[*it];
+
+		return -1;
+	}
+
+	const T& at(uint32_t index) const {
+		return objects.at(index);
+	}
+
+	size_t size() const { return objects.size(); }
+
+	struct iterator {
+		const DequeMap<T>& dm;
+		int offset;
+		iterator(const DequeMap<T>& dm, int offset): dm(dm), offset(offset) {}
+		void operator++() { offset++; }
+		bool operator!=(iterator& other) { return offset != other.offset; }
+		const T& operator*() const { return dm.objects[dm.keys[offset]]; }
+	};
+
+	iterator begin() const { return iterator{*this, 0}; }
+	iterator end() const { return iterator{*this, keys.size()}; }
+
+private:
+	uint32_t maxSize;
+
+	// Using a deque is necessary, as it provides pointer-stability for previously
+	// added objects when it grows the storage (as opposed to, e.g., vector).
+	std::deque<T> objects;
+
+	// Whereas `objects` is ordered by insertion-time, `keys` is sorted such that
+	// objects[key[0]] < objects[key[1]] < ... < objects[key[$]]
+	// operator< of T.
+	std::vector<uint32_t> keys;
+};
+#endif

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -3,7 +3,8 @@
 #define _HELPERS_H
 
 #include <zlib.h>
-#include "geom.h"
+#include <sstream>
+#include <vector>
 
 // General helper routines
 

--- a/include/node_store.h
+++ b/include/node_store.h
@@ -25,6 +25,8 @@ public:
 	virtual LatpLon at(NodeID i) const = 0;
 
 	virtual bool contains(size_t shard, NodeID id) const = 0;
+	virtual NodeStore& shard(size_t shard) = 0;
+	virtual const NodeStore& shard(size_t shard) const = 0;
 	virtual size_t shards() const = 0;
 };
 

--- a/include/node_store.h
+++ b/include/node_store.h
@@ -23,6 +23,10 @@ public:
 	// Accessors
 	virtual size_t size() const = 0;
 	virtual LatpLon at(NodeID i) const = 0;
+
+	virtual bool contains(size_t shard, NodeID id) const = 0;
+	virtual size_t shard() const = 0;
+	virtual size_t shards() const = 0;
 };
 
 #endif

--- a/include/node_store.h
+++ b/include/node_store.h
@@ -25,7 +25,6 @@ public:
 	virtual LatpLon at(NodeID i) const = 0;
 
 	virtual bool contains(size_t shard, NodeID id) const = 0;
-	virtual size_t shard() const = 0;
 	virtual size_t shards() const = 0;
 };
 

--- a/include/node_stores.h
+++ b/include/node_stores.h
@@ -24,6 +24,11 @@ public:
 	}
 	void batchStart() {}
 
+	bool contains(size_t shard, NodeID id) const override;
+	size_t shard() const override { return 0; }
+	size_t shards() const override { return 1; }
+	
+
 private: 
 	mutable std::mutex mutex;
 	std::vector<std::shared_ptr<map_t>> mLatpLons;
@@ -50,6 +55,12 @@ public:
 	void clear() override;
 	void finalize(size_t numThreads) override {}
 	void batchStart() {}
+
+	// CompactNodeStore has no metadata to know whether or not it contains
+	// a node, so it's not suitable for used in sharded scenarios.
+	bool contains(size_t shard, NodeID id) const override { return true; }
+	size_t shard() const override { return 0; }
+	size_t shards() const override { return 1; }
 
 private: 
 	// @brief Insert a latp/lon pair.

--- a/include/node_stores.h
+++ b/include/node_stores.h
@@ -20,10 +20,10 @@ public:
 	LatpLon at(NodeID i) const override;
 	size_t size() const override;
 	void insert(const std::vector<element_t>& elements) override;
-	void clear() { 
+	void clear() override {
 		reopen();
 	}
-	void batchStart() {}
+	void batchStart() override {}
 
 	bool contains(size_t shard, NodeID id) const override;
 	NodeStore& shard(size_t shard) override { return *this; }
@@ -56,7 +56,7 @@ public:
 	void insert(const std::vector<element_t>& elements) override;
 	void clear() override;
 	void finalize(size_t numThreads) override {}
-	void batchStart() {}
+	void batchStart() override {}
 
 	// CompactNodeStore has no metadata to know whether or not it contains
 	// a node, so it's not suitable for used in sharded scenarios.

--- a/include/node_stores.h
+++ b/include/node_stores.h
@@ -26,6 +26,8 @@ public:
 	void batchStart() {}
 
 	bool contains(size_t shard, NodeID id) const override;
+	NodeStore& shard(size_t shard) override { return *this; }
+	const NodeStore& shard(size_t shard) const override { return *this; }
 	size_t shards() const override { return 1; }
 	
 
@@ -59,6 +61,8 @@ public:
 	// CompactNodeStore has no metadata to know whether or not it contains
 	// a node, so it's not suitable for used in sharded scenarios.
 	bool contains(size_t shard, NodeID id) const override { return true; }
+	NodeStore& shard(size_t shard) override { return *this; }
+	const NodeStore& shard(size_t shard) const override { return *this; }
 	size_t shards() const override { return 1; }
 
 private: 

--- a/include/node_stores.h
+++ b/include/node_stores.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include "node_store.h"
 #include "sorted_node_store.h"
+#include "sharded_node_store.h"
 #include "mmap_allocator.h"
 
 class BinarySearchNodeStore : public NodeStore
@@ -25,7 +26,6 @@ public:
 	void batchStart() {}
 
 	bool contains(size_t shard, NodeID id) const override;
-	size_t shard() const override { return 0; }
 	size_t shards() const override { return 1; }
 	
 
@@ -59,7 +59,6 @@ public:
 	// CompactNodeStore has no metadata to know whether or not it contains
 	// a node, so it's not suitable for used in sharded scenarios.
 	bool contains(size_t shard, NodeID id) const override { return true; }
-	size_t shard() const override { return 0; }
 	size_t shards() const override { return 1; }
 
 private: 

--- a/include/options_parser.h
+++ b/include/options_parser.h
@@ -28,6 +28,9 @@ namespace OptionsParser {
 		bool uncompressedNodes = false;
 		bool uncompressedWays = false;
 		bool materializeGeometries = false;
+		// lazyGeometries is the inverse of materializeGeometries. It can be passed
+		// to override an implicit materializeGeometries, as in the non-store case.
+		bool lazyGeometries = false;
 		bool shardStores = false;
 	};
 

--- a/include/options_parser.h
+++ b/include/options_parser.h
@@ -1,0 +1,54 @@
+#ifndef OPTIONS_PARSER_H
+#define OPTIONS_PARSER_H
+
+#include <exception>
+#include <string>
+#include <vector>
+
+namespace OptionsParser {
+	struct OptionException : std::exception {
+		OptionException(std::string message): message(message) {}
+
+		/// Returns the explanatory string.
+		const char* what() const noexcept override {
+				return message.data();
+		}
+
+		private:
+			std::string message;
+	};
+
+	enum class OutputMode: char { File = 0, MBTiles = 1, PMTiles = 2 };
+
+	struct OsmOptions {
+		std::string storeFile;
+		bool compact = false;
+		bool skipIntegrity = false;
+		bool uncompressedNodes = false;
+		bool uncompressedWays = false;
+		bool materializeGeometries = false;
+		bool shardStores = false;
+	};
+
+	struct Options {
+		std::vector<std::string> inputFiles;
+		std::string luaFile;
+		std::string jsonFile;
+		uint threadNum = 0;
+		std::string outputFile;
+		std::string bbox;
+
+		OsmOptions osm;
+		bool showHelp = false;
+		bool verbose = false;
+		bool mergeSqlite = false;
+		bool mapsplit = false;
+		OutputMode outputMode = OutputMode::File;
+		bool logTileTimings = false;
+	};
+
+	Options parse(const int argc, const char* argv[]);
+	void showHelp();
+};
+
+#endif

--- a/include/options_parser.h
+++ b/include/options_parser.h
@@ -35,7 +35,7 @@ namespace OptionsParser {
 		std::vector<std::string> inputFiles;
 		std::string luaFile;
 		std::string jsonFile;
-		uint threadNum = 0;
+		uint32_t threadNum = 0;
 		std::string outputFile;
 		std::string bbox;
 

--- a/include/options_parser.h
+++ b/include/options_parser.h
@@ -22,6 +22,7 @@ namespace OptionsParser {
 
 	struct OsmOptions {
 		std::string storeFile;
+		bool fast = false;
 		bool compact = false;
 		bool skipIntegrity = false;
 		bool uncompressedNodes = false;

--- a/include/osm_mem_tiles.h
+++ b/include/osm_mem_tiles.h
@@ -6,10 +6,15 @@
 #include "osm_store.h"
 #include "geometry_cache.h"
 
+// NB: Currently, USE_NODE_STORE and USE_WAY_STORE are equivalent.
+// If we permit LayerAsCentroid to be generated from the OSM stores,
+// this will have to change.
 #define OSM_THRESHOLD (1ull << 35)
+#define USE_NODE_STORE (1ull << 35)
+#define IS_NODE(x) (((x) >> 35) == (USE_NODE_STORE >> 35))
 #define USE_WAY_STORE (1ull << 35)
 #define IS_WAY(x) (((x) >> 35) == (USE_WAY_STORE >> 35))
-#define OSM_ID(x) ((x) & 0b111111111111111111111111111111111)
+#define OSM_ID(x) ((x) & 0b11111111111111111111111111111111111)
 
 class NodeStore;
 class WayStore;
@@ -37,6 +42,7 @@ public:
 		const NodeID objectID,
 		const TileBbox &bbox
 	) override;
+	LatpLon buildNodeGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox) const override;
 
 
 	void Clear();

--- a/include/osm_mem_tiles.h
+++ b/include/osm_mem_tiles.h
@@ -37,6 +37,8 @@ public:
 		const WayStore& wayStore
 	);
 
+	std::string name() const override { return "osm"; }
+
 	Geometry buildWayGeometry(
 		const OutputGeometryType geomType, 
 		const NodeID objectID,

--- a/include/osm_mem_tiles.h
+++ b/include/osm_mem_tiles.h
@@ -9,12 +9,12 @@
 // NB: Currently, USE_NODE_STORE and USE_WAY_STORE are equivalent.
 // If we permit LayerAsCentroid to be generated from the OSM stores,
 // this will have to change.
-#define OSM_THRESHOLD (1ull << 35)
-#define USE_NODE_STORE (1ull << 35)
-#define IS_NODE(x) (((x) >> 35) == (USE_NODE_STORE >> 35))
-#define USE_WAY_STORE (1ull << 35)
-#define IS_WAY(x) (((x) >> 35) == (USE_WAY_STORE >> 35))
-#define OSM_ID(x) ((x) & 0b11111111111111111111111111111111111)
+#define OSM_THRESHOLD (1ull << TILE_DATA_ID_SIZE)
+#define USE_NODE_STORE (2ull << TILE_DATA_ID_SIZE)
+#define IS_NODE(x) (((x) >> TILE_DATA_ID_SIZE) == (USE_NODE_STORE >> TILE_DATA_ID_SIZE))
+#define USE_WAY_STORE (1ull << TILE_DATA_ID_SIZE)
+#define IS_WAY(x) (((x) >> TILE_DATA_ID_SIZE) == (USE_WAY_STORE >> TILE_DATA_ID_SIZE))
+#define OSM_ID(x) ((x) & 0b1111111111111111111111111111111111)
 
 class NodeStore;
 class WayStore;
@@ -44,14 +44,14 @@ public:
 		const NodeID objectID,
 		const TileBbox &bbox
 	) override;
-	LatpLon buildNodeGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox) const override;
+	LatpLon buildNodeGeometry(NodeID const objectID, const TileBbox &bbox) const override;
 
 
 	void Clear();
 
 private:
-	void populateLinestring(Linestring& ls, NodeID objectID);
-	Linestring& getOrBuildLinestring(NodeID objectID);
+	void populateLinestring(Linestring& ls, NodeID objectID) const;
+	Linestring& getOrBuildLinestring(NodeID objectID) const;
 	void populateMultiPolygon(MultiPolygon& dst, NodeID objectID) override;
 
 	const NodeStore& nodeStore;

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -22,9 +22,6 @@ std::ostream& operator<<(std::ostream& os, OutputGeometryType geomType);
 
 /**
  * \brief OutputObject - any object (node, linestring, polygon) to be outputted to tiles
-
- * Possible future improvements to save memory:
- * - use a global dictionary for attribute key/values
 */
 #pragma pack(push, 4)
 class OutputObject {

--- a/include/pooled_string.h
+++ b/include/pooled_string.h
@@ -1,20 +1,19 @@
 #ifndef _POOLED_STRING_H
 #define _POOLED_STRING_H
 
-// std::string allows the allocated size to differ from the used size,
-// which means it needs an extra pointer. It also supports large strings.
+// std::string is quite general:
+// - mutable
+// - unlimited length
+// - capacity can differ from size
+// - can deallocate its dynamic memory
 //
-// Our use case does not require this: we have immutable strings and always
-// know their exact size, which fit in 64K.
+// Our use case, by contrast is immutable, bounded strings that live for the
+// duration of the process.
 //
-// Further, g++'s implementation of std::string is inefficient - it takes 32
-// bytes (vs clang's 24 bytes), while only allowing a small-string optimization
-// for strings of length 15 or less.
+// This gives us some room to have less memory overhead, especially on
+// g++, whose implementation of std::string requires 32 bytes.
 //
-// std::string also needs to be able to free its allocated memory -- in our case,
-// we're fine with the memory living until the process dies.
-//
-// Instead, we implemented `PooledString`. It has a size of 16 bytes, and a small
+// Thus, we implement `PooledString`. It has a size of 16 bytes, and a small
 // string optimization for strings <= 15 bytes. (We will separately teach
 // AttributePair to encode Latin-character strings more efficiently, so that many
 // strings of size 24 or less fit in 15 bytes.)
@@ -22,17 +21,32 @@
 // If it needs to allocate memory, it does so from a shared pool. It is unable
 // to free the memory once allocated.
 
+// PooledString has one of three modes:
+// - [126:127] = 00: small-string, length is in [120:125], lower 15 bytes are string
+// - [126:127] = 10: pooled string, table is in bytes 1..3, offset in bytes 4..5, length in bytes 6..7
+// - [126:127] = 11: pointer to std::string, pointer is in bytes 8..15
+//
+// Note that the pointer mode is not safe to be stored. It exists just to allow
+// lookups in the AttributePair map before deciding to allocate a string.
+
 #include <vector>
 #include <string>
 
 namespace PooledStringNS {
   class PooledString {
     public:
+      // Create a short string or heap string, long-lived.
       PooledString(const std::string& str);
+
+
+      // Create a std string - only valid so long as the string that is
+      // pointed to is valid.
+      PooledString(const std::string* str);
       size_t size() const;
       bool operator==(const PooledString& other) const;
       bool operator!=(const PooledString& other) const;
       std::string toString() const;
+      const char* data() const;
 
     private:
       // 0..3 is index into table, 4..5 is offset, 6..7 is length

--- a/include/pooled_string.h
+++ b/include/pooled_string.h
@@ -43,10 +43,12 @@ namespace PooledStringNS {
       // pointed to is valid.
       PooledString(const std::string* str);
       size_t size() const;
+      bool operator<(const PooledString& other) const;
       bool operator==(const PooledString& other) const;
       bool operator!=(const PooledString& other) const;
       std::string toString() const;
       const char* data() const;
+      void ensureStringIsOwned();
 
     private:
       // 0..3 is index into table, 4..5 is offset, 6..7 is length

--- a/include/pooled_string.h
+++ b/include/pooled_string.h
@@ -1,0 +1,45 @@
+#ifndef _POOLED_STRING_H
+#define _POOLED_STRING_H
+
+// std::string allows the allocated size to differ from the used size,
+// which means it needs an extra pointer. It also supports large strings.
+//
+// Our use case does not require this: we have immutable strings and always
+// know their exact size, which fit in 64K.
+//
+// Further, g++'s implementation of std::string is inefficient - it takes 32
+// bytes (vs clang's 24 bytes), while only allowing a small-string optimization
+// for strings of length 15 or less.
+//
+// std::string also needs to be able to free its allocated memory -- in our case,
+// we're fine with the memory living until the process dies.
+//
+// Instead, we implemented `PooledString`. It has a size of 16 bytes, and a small
+// string optimization for strings <= 15 bytes. (We will separately teach
+// AttributePair to encode Latin-character strings more efficiently, so that many
+// strings of size 24 or less fit in 15 bytes.)
+//
+// If it needs to allocate memory, it does so from a shared pool. It is unable
+// to free the memory once allocated.
+
+#include <vector>
+#include <string>
+
+namespace PooledStringNS {
+  class PooledString {
+    public:
+      PooledString(const std::string& str);
+      size_t size() const;
+      bool operator==(const PooledString& other) const;
+      bool operator!=(const PooledString& other) const;
+      std::string toString() const;
+
+    private:
+      // 0..3 is index into table, 4..5 is offset, 6..7 is length
+      uint8_t storage[16];
+  };
+}
+
+using PooledString = PooledStringNS::PooledString;
+
+#endif

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -58,7 +58,9 @@ public:
 		const std::unordered_set<std::string>& nodeKeys,
 		unsigned int threadNum,
 		const pbfreader_generate_stream& generate_stream,
-		const pbfreader_generate_output& generate_output
+		const pbfreader_generate_output& generate_output,
+		const NodeStore& nodeStore,
+		const WayStore& wayStore
 	);
 
 	// Read tags into a map from a way/node/relation

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -53,6 +53,7 @@ public:
 	using pbfreader_generate_stream = std::function< std::shared_ptr<std::istream> () >;
 
 	int ReadPbfFile(
+		uint shards,
 		bool hasSortTypeThenID,
 		const std::unordered_set<std::string>& nodeKeys,
 		unsigned int threadNum,
@@ -79,11 +80,20 @@ private:
 		const BlockMetadata& blockMetadata,
 		const std::unordered_set<std::string>& nodeKeys,
 		bool locationsOnWays,
-		ReadPhase phase
+		ReadPhase phase,
+		uint shard,
+		uint effectiveShard
 	);
 	bool ReadNodes(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb, const std::unordered_set<int> &nodeKeyPositions);
 
-	bool ReadWays(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb, bool locationsOnWays);
+	bool ReadWays(
+		OsmLuaProcessing &output,
+		PrimitiveGroup &pg,
+		PrimitiveBlock const &pb,
+		bool locationsOnWays,
+		uint shard,
+		uint effectiveShards
+	);
 	bool ScanRelations(OsmLuaProcessing &output, PrimitiveGroup &pg, PrimitiveBlock const &pb);
 	bool ReadRelations(
 		OsmLuaProcessing& output,

--- a/include/read_pbf.h
+++ b/include/read_pbf.h
@@ -101,7 +101,9 @@ private:
 		OsmLuaProcessing& output,
 		PrimitiveGroup& pg,
 		const PrimitiveBlock& pb,
-		const BlockMetadata& blockMetadata
+		const BlockMetadata& blockMetadata,
+		uint shard,
+		uint effectiveShards
 	);
 
 	inline bool RelationIsType(Relation const &rel, int typeKey, int val) {

--- a/include/sharded_node_store.h
+++ b/include/sharded_node_store.h
@@ -20,6 +20,8 @@ public:
 	}
 
 	bool contains(size_t shard, NodeID id) const override;
+	NodeStore& shard(size_t shard) override { return *stores[shard]; }
+	const NodeStore& shard(size_t shard) const override { return *stores[shard]; }
 	size_t shards() const override;
 
 private:

--- a/include/sharded_node_store.h
+++ b/include/sharded_node_store.h
@@ -15,7 +15,7 @@ public:
 	size_t size() const override;
 	void batchStart() override;
 	void insert(const std::vector<element_t>& elements) override;
-	void clear() { 
+	void clear() override {
 		reopen();
 	}
 

--- a/include/sharded_node_store.h
+++ b/include/sharded_node_store.h
@@ -1,0 +1,30 @@
+#ifndef _SHARDED_NODE_STORE
+#define _SHARDED_NODE_STORE
+
+#include <functional>
+#include <memory>
+#include "node_store.h"
+
+class ShardedNodeStore : public NodeStore {
+public:
+	ShardedNodeStore(std::function<std::shared_ptr<NodeStore>()> createNodeStore);
+	~ShardedNodeStore();
+	void reopen() override;
+	void finalize(size_t threadNum) override;
+	LatpLon at(NodeID i) const override;
+	size_t size() const override;
+	void batchStart() override;
+	void insert(const std::vector<element_t>& elements) override;
+	void clear() { 
+		reopen();
+	}
+
+	bool contains(size_t shard, NodeID id) const override;
+	size_t shards() const override;
+
+private:
+	std::function<std::shared_ptr<NodeStore>()> createNodeStore;
+	std::vector<std::shared_ptr<NodeStore>> stores;
+};
+
+#endif

--- a/include/sharded_way_store.h
+++ b/include/sharded_way_store.h
@@ -1,0 +1,34 @@
+#ifndef _SHARDED_WAY_STORE
+#define _SHARDED_WAY_STORE
+
+#include <functional>
+#include <memory>
+#include "way_store.h"
+
+class NodeStore;
+
+class ShardedWayStore : public WayStore {
+public:
+	ShardedWayStore(std::function<std::shared_ptr<WayStore>()> createWayStore, const NodeStore& nodeStore);
+	~ShardedWayStore();
+	void reopen() override;
+	void batchStart() override;
+	std::vector<LatpLon> at(WayID wayid) const override;
+	bool requiresNodes() const override;
+	void insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) override;
+	void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;
+	void clear() override;
+	std::size_t size() const override;
+	void finalize(unsigned int threadNum) override;
+
+	bool contains(size_t shard, WayID id) const override;
+	WayStore& shard(size_t shard) override;
+	size_t shards() const override;
+	
+private:
+	std::function<std::shared_ptr<WayStore>()> createWayStore;
+	const NodeStore& nodeStore;
+	std::vector<std::shared_ptr<WayStore>> stores;
+};
+
+#endif

--- a/include/sharded_way_store.h
+++ b/include/sharded_way_store.h
@@ -23,6 +23,7 @@ public:
 
 	bool contains(size_t shard, WayID id) const override;
 	WayStore& shard(size_t shard) override;
+	const WayStore& shard(size_t shard) const override;
 	size_t shards() const override;
 	
 private:

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -7,6 +7,7 @@
 
 #include "rapidjson/document.h"
 
+#include "options_parser.h"
 #include "osm_store.h"
 #include "output_object.h"
 #include "mbtiles.h"
@@ -61,10 +62,6 @@ public:
 	std::string serialiseToJSON() const;
 };
 
-const int OUTPUT_FILE = 0;
-const int OUTPUT_MBTILES = 1;
-const int OUTPUT_PMTILES = 2;
-
 ///\brief Config read from JSON to control behavior of program
 class Config {
 	
@@ -91,7 +88,7 @@ class SharedData {
 
 public:
 	const class LayerDefinition &layers;
-	int outputMode;
+	OptionsParser::OutputMode outputMode;
 	bool mergeSqlite;
 	MBTiles mbtiles;
 	PMTiles pmtiles;

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -11,6 +11,8 @@ class ShpMemTiles : public TileDataSource
 public:
 	ShpMemTiles(size_t threadNum, uint baseZoom);
 
+	std::string name() const override { return "shp"; }
+
 	void CreateNamedLayerIndex(const std::string& layerName);
 
 	// Used in shape file loading

--- a/include/sorted_node_store.h
+++ b/include/sorted_node_store.h
@@ -71,6 +71,8 @@ public:
 	}
 
 	bool contains(size_t shard, NodeID id) const override;
+	NodeStore& shard(size_t shard) override { return *this; }
+	const NodeStore& shard(size_t shard) const override { return *this; }
 	size_t shards() const override { return 1; }
 
 private: 

--- a/include/sorted_node_store.h
+++ b/include/sorted_node_store.h
@@ -66,7 +66,7 @@ public:
 	size_t size() const override;
 	void batchStart() override;
 	void insert(const std::vector<element_t>& elements) override;
-	void clear() { 
+	void clear() override {
 		reopen();
 	}
 

--- a/include/sorted_node_store.h
+++ b/include/sorted_node_store.h
@@ -69,6 +69,10 @@ public:
 		reopen();
 	}
 
+	bool contains(size_t shard, NodeID ID) const override { throw std::runtime_error("SortedNodeStore::contains not implemented"); }
+	size_t shard() const override { return 0; }
+	size_t shards() const override { return 1; }
+
 private: 
 	// When true, store chunks compressed. Only store compressed if the
 	// chunk is sufficiently large.

--- a/include/sorted_node_store.h
+++ b/include/sorted_node_store.h
@@ -3,6 +3,7 @@
 
 #include "node_store.h"
 #include "mmap_allocator.h"
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -86,6 +87,15 @@ private:
 	// multiple threads. They'll get folded into the index during finalize()
 	std::map<NodeID, std::vector<element_t>> orphanage;
 	std::vector<std::vector<element_t>> workerBuffers;
+
+	std::atomic<uint64_t> totalGroups;
+	std::atomic<uint64_t> totalNodes;
+	std::atomic<uint64_t> totalGroupSpace;
+	std::atomic<uint64_t> totalAllocatedSpace;
+	std::atomic<uint64_t> totalChunks;
+	std::atomic<uint64_t> chunkSizeFreqs[257];
+	std::atomic<uint64_t> groupSizeFreqs[257];
+
 	void collectOrphans(const std::vector<element_t>& orphans);
 	void publishGroup(const std::vector<element_t>& nodes);
 };

--- a/include/sorted_node_store.h
+++ b/include/sorted_node_store.h
@@ -70,7 +70,7 @@ public:
 		reopen();
 	}
 
-	bool contains(size_t shard, NodeID ID) const override { throw std::runtime_error("SortedNodeStore::contains not implemented"); }
+	bool contains(size_t shard, NodeID id) const override;
 	size_t shard() const override { return 0; }
 	size_t shards() const override { return 1; }
 

--- a/include/sorted_node_store.h
+++ b/include/sorted_node_store.h
@@ -71,7 +71,6 @@ public:
 	}
 
 	bool contains(size_t shard, NodeID id) const override;
-	size_t shard() const override { return 0; }
 	size_t shards() const override { return 1; }
 
 private: 

--- a/include/sorted_way_store.h
+++ b/include/sorted_way_store.h
@@ -93,6 +93,10 @@ public:
 	void clear() override;
 	std::size_t size() const override;
 	void finalize(unsigned int threadNum) override;
+
+	bool contains(size_t shard, WayID id) const override { throw std::runtime_error("SortedWayStore::contains not implemented"); }
+	size_t shard() const override { return 0; }
+	size_t shards() const override { return 1; }
 	
 	static uint16_t encodeWay(
 		const std::vector<NodeID>& way,

--- a/include/sorted_way_store.h
+++ b/include/sorted_way_store.h
@@ -97,6 +97,7 @@ public:
 
 	bool contains(size_t shard, WayID id) const override;
 	WayStore& shard(size_t shard) override { return *this; }
+	const WayStore& shard(size_t shard) const override { return *this; }
 	size_t shards() const override { return 1; }
 	
 	static uint16_t encodeWay(

--- a/include/sorted_way_store.h
+++ b/include/sorted_way_store.h
@@ -95,7 +95,7 @@ public:
 	std::size_t size() const override;
 	void finalize(unsigned int threadNum) override;
 
-	bool contains(size_t shard, WayID id) const override { throw std::runtime_error("SortedWayStore::contains not implemented"); }
+	bool contains(size_t shard, WayID id) const override;
 	size_t shard() const override { return 0; }
 	size_t shards() const override { return 1; }
 	

--- a/include/sorted_way_store.h
+++ b/include/sorted_way_store.h
@@ -90,13 +90,13 @@ public:
 	std::vector<LatpLon> at(WayID wayid) const override;
 	bool requiresNodes() const override { return true; }
 	void insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) override;
-	const void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;
+	void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;
 	void clear() override;
 	std::size_t size() const override;
 	void finalize(unsigned int threadNum) override;
 
 	bool contains(size_t shard, WayID id) const override;
-	size_t shard() const override { return 0; }
+	WayStore& shard(size_t shard) override { return *this; }
 	size_t shards() const override { return 1; }
 	
 	static uint16_t encodeWay(

--- a/include/sorted_way_store.h
+++ b/include/sorted_way_store.h
@@ -1,6 +1,7 @@
 #ifndef _SORTED_WAY_STORE_H
 #define _SORTED_WAY_STORE_H
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -117,6 +118,13 @@ private:
 	// multiple threads. They'll get folded into the index during finalize()
 	std::map<WayID, std::vector<std::pair<WayID, std::vector<NodeID>>>> orphanage;
 	std::vector<std::vector<std::pair<WayID, std::vector<NodeID>>>> workerBuffers;
+
+	std::atomic<uint64_t> totalWays;
+	std::atomic<uint64_t> totalNodes;
+	std::atomic<uint64_t> totalGroups;
+	std::atomic<uint64_t> totalGroupSpace;
+	std::atomic<uint64_t> totalChunks;
+
 	void collectOrphans(const std::vector<std::pair<WayID, std::vector<NodeID>>>& orphans);
 	void publishGroup(const std::vector<std::pair<WayID, std::vector<NodeID>>>& ways);
 };

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -9,6 +9,7 @@
 #include <boost/sort/sort.hpp>
 #include "output_object.h"
 #include "clip_cache.h"
+#include "mmap_allocator.h"
 
 typedef std::vector<class TileDataSource *> SourceList;
 
@@ -47,10 +48,10 @@ struct OutputObjectXYID {
 template<typename OO> void finalizeObjects(
 	const size_t& threadNum,
 	const unsigned int& baseZoom,
-	typename std::vector<std::vector<OO>>::iterator begin,
-	typename std::vector<std::vector<OO>>::iterator end
+	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator begin,
+	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator end
 	) {
-	for (typename std::vector<std::vector<OO>>::iterator it = begin; it != end; it++) {
+	for (auto it = begin; it != end; it++) {
 		if (it->size() == 0)
 			continue;
 
@@ -108,7 +109,7 @@ template<typename OO> void finalizeObjects(
 
 template<typename OO> void collectTilesWithObjectsAtZoomTemplate(
 	const unsigned int& baseZoom,
-	const typename std::vector<std::vector<OO>>::iterator objects,
+	const typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator objects,
 	const size_t size,
 	const unsigned int zoom,
 	TileCoordinatesSet& output
@@ -150,7 +151,7 @@ inline OutputObjectID outputObjectWithId<OutputObjectXYID>(const OutputObjectXYI
 
 template<typename OO> void collectObjectsForTileTemplate(
 	const unsigned int& baseZoom,
-	typename std::vector<std::vector<OO>>::iterator objects,
+	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator objects,
 	size_t iStart,
 	size_t iEnd,
 	unsigned int zoom,
@@ -292,8 +293,8 @@ protected:
 	//
 	// If config.include_ids is true, objectsWithIds will be populated.
 	// Otherwise, objects.
-	std::vector<std::vector<OutputObjectXY>> objects;
-	std::vector<std::vector<OutputObjectXYID>> objectsWithIds;
+	std::vector<std::deque<OutputObjectXY, mmap_allocator<OutputObjectXY>>> objects;
+	std::vector<std::deque<OutputObjectXYID, mmap_allocator<OutputObjectXYID>>> objectsWithIds;
 	
 	// rtree index of large objects
 	using oo_rtree_param_type = boost::geometry::index::quadratic<128>;

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <boost/sort/sort.hpp>
 #include "output_object.h"
+#include "append_vector.h"
 #include "clip_cache.h"
 #include "mmap_allocator.h"
 
@@ -49,9 +50,9 @@ template<typename OO> void finalizeObjects(
 	const std::string& name,
 	const size_t& threadNum,
 	const unsigned int& baseZoom,
-	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator begin,
-	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator end,
-	typename std::vector<std::deque<OO, mmap_allocator<OO>>>& lowZoom
+	typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator begin,
+	typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator end,
+	typename std::vector<AppendVectorNS::AppendVector<OO>>& lowZoom
 	) {
 #ifdef CLOCK_MONOTONIC
 	timespec startTs, endTs;
@@ -73,8 +74,6 @@ template<typename OO> void finalizeObjects(
 		}
 		if (it->size() == 0)
 			continue;
-
-		it->shrink_to_fit();
 
 		for (auto objectIt = it->begin(); objectIt != it->end(); objectIt++)
 			if (objectIt->oo.minZoom < CLUSTER_ZOOM)
@@ -133,7 +132,7 @@ template<typename OO> void finalizeObjects(
 
 template<typename OO> void collectTilesWithObjectsAtZoomTemplate(
 	const unsigned int& baseZoom,
-	const typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator objects,
+	const typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator objects,
 	const size_t size,
 	const unsigned int zoom,
 	TileCoordinatesSet& output
@@ -175,7 +174,7 @@ inline OutputObjectID outputObjectWithId<OutputObjectXYID>(const OutputObjectXYI
 
 template<typename OO> void collectObjectsForTileTemplate(
 	const unsigned int& baseZoom,
-	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator objects,
+	typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator objects,
 	size_t iStart,
 	size_t iEnd,
 	unsigned int zoom,
@@ -318,10 +317,10 @@ protected:
 	//
 	// If config.include_ids is true, objectsWithIds will be populated.
 	// Otherwise, objects.
-	std::vector<std::deque<OutputObjectXY, mmap_allocator<OutputObjectXY>>> objects;
-	std::vector<std::deque<OutputObjectXY, mmap_allocator<OutputObjectXY>>> lowZoomObjects;
-	std::vector<std::deque<OutputObjectXYID, mmap_allocator<OutputObjectXYID>>> objectsWithIds;
-	std::vector<std::deque<OutputObjectXYID, mmap_allocator<OutputObjectXYID>>> lowZoomObjectsWithIds;
+	std::vector<AppendVectorNS::AppendVector<OutputObjectXY>> objects;
+	std::vector<AppendVectorNS::AppendVector<OutputObjectXY>> lowZoomObjects;
+	std::vector<AppendVectorNS::AppendVector<OutputObjectXYID>> objectsWithIds;
+	std::vector<AppendVectorNS::AppendVector<OutputObjectXYID>> lowZoomObjectsWithIds;
 	
 	// rtree index of large objects
 	using oo_rtree_param_type = boost::geometry::index::quadratic<128>;

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -362,7 +362,7 @@ public:
 	);
 
 	virtual Geometry buildWayGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox);
-	LatpLon buildNodeGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox) const;
+	virtual LatpLon buildNodeGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox) const;
 
 	void open() {
 		// Put something at index 0 of all stores so that 0 can be used

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -49,13 +49,18 @@ template<typename OO> void finalizeObjects(
 	const size_t& threadNum,
 	const unsigned int& baseZoom,
 	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator begin,
-	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator end
+	typename std::vector<std::deque<OO, mmap_allocator<OO>>>::iterator end,
+	typename std::vector<std::deque<OO, mmap_allocator<OO>>>& lowZoom
 	) {
 	for (auto it = begin; it != end; it++) {
 		if (it->size() == 0)
 			continue;
 
 		it->shrink_to_fit();
+
+		for (auto objectIt = it->begin(); objectIt != it->end(); objectIt++)
+			if (objectIt->oo.minZoom < CLUSTER_ZOOM)
+				lowZoom[0].push_back(*objectIt);
 
 		// If the user is doing a a small extract, there are few populated
 		// entries in `object`.
@@ -103,7 +108,6 @@ template<typename OO> void finalizeObjects(
 			},
 			threadNum
 		);
-
 	}
 }
 
@@ -294,7 +298,9 @@ protected:
 	// If config.include_ids is true, objectsWithIds will be populated.
 	// Otherwise, objects.
 	std::vector<std::deque<OutputObjectXY, mmap_allocator<OutputObjectXY>>> objects;
+	std::vector<std::deque<OutputObjectXY, mmap_allocator<OutputObjectXY>>> lowZoomObjects;
 	std::vector<std::deque<OutputObjectXYID, mmap_allocator<OutputObjectXYID>>> objectsWithIds;
+	std::vector<std::deque<OutputObjectXYID, mmap_allocator<OutputObjectXYID>>> lowZoomObjectsWithIds;
 	
 	// rtree index of large objects
 	using oo_rtree_param_type = boost::geometry::index::quadratic<128>;

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -12,6 +12,8 @@
 #include "clip_cache.h"
 #include "mmap_allocator.h"
 
+#define TILE_DATA_ID_SIZE 34
+
 typedef std::vector<class TileDataSource *> SourceList;
 
 class TileBbox;
@@ -407,7 +409,7 @@ public:
 	);
 
 	virtual Geometry buildWayGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox);
-	virtual LatpLon buildNodeGeometry(OutputGeometryType const geomType, NodeID const objectID, const TileBbox &bbox) const;
+	virtual LatpLon buildNodeGeometry(NodeID const objectID, const TileBbox &bbox) const;
 
 	void open() {
 		// Put something at index 0 of all stores so that 0 can be used
@@ -425,18 +427,18 @@ public:
 	NodeID storePoint(Point const &input);
 
 	inline size_t getShard(NodeID id) const {
-		// Note: we only allocate 35 bits for the IDs. This allows us to
-		// use bit 36 for TileDataSource-specific handling (e.g.,
+		// Note: we only allocate 34 bits for the IDs. This allows us to
+		// use bits 35 and 36 for TileDataSource-specific handling (e.g.,
 		// OsmMemTiles may want to generate points/ways on the fly by
 		// referring to the WayStore).
 
-		return id >> (35 - shardBits);
+		return id >> (TILE_DATA_ID_SIZE - shardBits);
 	}
 
 	virtual void populateMultiPolygon(MultiPolygon& dst, NodeID objectID);
 
 	inline size_t getId(NodeID id) const {
-		return id & (~(~0ull << (35 - shardBits)));
+		return id & (~(~0ull << (TILE_DATA_ID_SIZE - shardBits)));
 	}
 
 	const Point& retrievePoint(NodeID id) const {

--- a/include/way_store.h
+++ b/include/way_store.h
@@ -24,6 +24,7 @@ public:
 
 	virtual bool contains(size_t shard, WayID id) const = 0;
 	virtual WayStore& shard(size_t shard) = 0;
+	virtual const WayStore& shard(size_t shard) const = 0;
 	virtual size_t shards() const = 0;
 };
 

--- a/include/way_store.h
+++ b/include/way_store.h
@@ -17,13 +17,13 @@ public:
 	virtual std::vector<LatpLon> at(WayID wayid) const = 0;
 	virtual bool requiresNodes() const = 0;
 	virtual void insertLatpLons(std::vector<ll_element_t>& newWays) = 0;
-	virtual const void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) = 0;
+	virtual void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) = 0;
 	virtual void clear() = 0;
 	virtual std::size_t size() const = 0;
 	virtual void finalize(unsigned int threadNum) = 0;
 
 	virtual bool contains(size_t shard, WayID id) const = 0;
-	virtual size_t shard() const = 0;
+	virtual WayStore& shard(size_t shard) = 0;
 	virtual size_t shards() const = 0;
 };
 

--- a/include/way_store.h
+++ b/include/way_store.h
@@ -21,6 +21,10 @@ public:
 	virtual void clear() = 0;
 	virtual std::size_t size() const = 0;
 	virtual void finalize(unsigned int threadNum) = 0;
+
+	virtual bool contains(size_t shard, WayID id) const = 0;
+	virtual size_t shard() const = 0;
+	virtual size_t shards() const = 0;
 };
 
 #endif

--- a/include/way_stores.h
+++ b/include/way_stores.h
@@ -21,6 +21,10 @@ public:
 	std::size_t size() const override;
 	void finalize(unsigned int threadNum) override;
 
+	bool contains(size_t shard, WayID id) const override;
+	size_t shard() const override { return 0; }
+	size_t shards() const override { return 1; }
+
 private:
 	mutable std::mutex mutex;
 	std::unique_ptr<map_t> mLatpLonLists;

--- a/include/way_stores.h
+++ b/include/way_stores.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include "way_store.h"
 #include "sorted_way_store.h"
+#include "sharded_way_store.h"
 
 class BinarySearchWayStore: public WayStore {
 
@@ -16,13 +17,13 @@ public:
 	std::vector<LatpLon> at(WayID wayid) const override;
 	bool requiresNodes() const override { return false; }
 	void insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) override;
-	const void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;
+	void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;
 	void clear() override;
 	std::size_t size() const override;
 	void finalize(unsigned int threadNum) override;
 
 	bool contains(size_t shard, WayID id) const override;
-	size_t shard() const override { return 0; }
+	WayStore& shard(size_t shard) override { return *this; }
 	size_t shards() const override { return 1; }
 
 private:

--- a/include/way_stores.h
+++ b/include/way_stores.h
@@ -24,6 +24,7 @@ public:
 
 	bool contains(size_t shard, WayID id) const override;
 	WayStore& shard(size_t shard) override { return *this; }
+	const WayStore& shard(size_t shard) const override { return *this; }
 	size_t shards() const override { return 1; }
 
 private:

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -307,11 +307,16 @@ std::vector<const AttributePair*> AttributeStore::getUnsafe(AttributeIndex index
 	}
 }
 
-void AttributeStore::reportSize() const {
+size_t AttributeStore::size() const {
 	size_t numAttributeSets = 0;
 	for (int i = 0; i < ATTRIBUTE_SHARDS; i++)
 		numAttributeSets += sets[i].size();
-	std::cout << "Attributes: " << numAttributeSets << " sets from " << lookups.load() << " objects" << std::endl;
+
+	return numAttributeSets;
+}
+
+void AttributeStore::reportSize() const {
+	std::cout << "Attributes: " << size() << " sets from " << lookups.load() << " objects" << std::endl;
 
 	// Print detailed histogram of frequencies of attributes.
 	if (false) {

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -200,19 +200,19 @@ void AttributeSet::removePairWithKey(const AttributePairStore& pairStore, uint32
 
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, const std::string& v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
-	bool isHot = AttributePair::isHot(kv, key);
+	bool isHot = AttributePair::isHot(key, v);
 	attributeSet.removePairWithKey(pairStore, kv.keyIndex);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, bool v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
-	bool isHot = AttributePair::isHot(kv, key);
+	bool isHot = true; // All bools are eligible to be hot pairs
 	attributeSet.removePairWithKey(pairStore, kv.keyIndex);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }
 void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, float v, char minzoom) {
 	AttributePair kv(keyStore.key2index(key),v,minzoom);
-	bool isHot = AttributePair::isHot(kv, key);
+	bool isHot = v >= 0 && v <= 25 && ceil(v) == v; // Whole numbers in 0..25 are eligible to be hot pairs
 	attributeSet.removePairWithKey(pairStore, kv.keyIndex);
 	attributeSet.addPair(pairStore.addPair(kv, isHot));
 }

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -92,7 +92,7 @@ uint32_t AttributePairStore::addPair(const AttributePair& pair, bool isHot) {
 		// Not found, ensure our local map is up-to-date for future calls,
 		// and fall through to the main map.
 		//
-		// Note that we can read `hotShard` without a lock
+		// Note that we can read `hotShard` without a lock, its size is fixed
 		while (tlsHotShardSize < hotShardSize.load()) {
 			tlsHotShardSize++;
 			tlsHotShardMap[&hotShard[tlsHotShardSize]] = tlsHotShardSize;

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -4,6 +4,8 @@
 #include <iomanip>
 #include <sstream>
 #include <cstring>
+#include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include "helpers.h"
 
@@ -11,7 +13,6 @@
 #define MOD_GZIP_ZLIB_CFACTOR 9
 #define MOD_GZIP_ZLIB_BSIZE 8096
 
-namespace geom = boost::geometry;
 using namespace std;
 
 // Bounding box string parsing

--- a/src/mmap_allocator.cpp
+++ b/src/mmap_allocator.cpp
@@ -79,10 +79,10 @@ thread_local mmap_shm_ptr mmap_shm_thread_region_ptr;
 std::mutex mmap_allocator_mutex;
 
 mmap_file::mmap_file(std::string const &filename, std::size_t offset)
-	: mapping(filename.c_str(), boost::interprocess::read_write)
+	: filename(filename)
+	, mapping(filename.c_str(), boost::interprocess::read_write)
 	, region(mapping, boost::interprocess::read_write)
 	, buffer(boost::interprocess::create_only, reinterpret_cast<uint8_t *>(region.get_address()) + offset, region.get_size() - offset)
-	, filename(filename)
 { }
 
 mmap_file::~mmap_file()

--- a/src/node_stores.cpp
+++ b/src/node_stores.cpp
@@ -14,6 +14,17 @@ void BinarySearchNodeStore::reopen()
 	}
 }
 
+bool BinarySearchNodeStore::contains(size_t shard, NodeID i) const {
+	auto internalShard = mLatpLons[shardPart(i)];
+	auto id = idPart(i);
+
+	auto iter = std::lower_bound(internalShard->begin(), internalShard->end(), id, [](auto const &e, auto i) { 
+		return e.first < i; 
+	});
+
+	return !(iter == internalShard->end() || iter->first != id);
+}
+
 LatpLon BinarySearchNodeStore::at(NodeID i) const {
 	auto shard = mLatpLons[shardPart(i)];
 	auto id = idPart(i);

--- a/src/options_parser.cpp
+++ b/src/options_parser.cpp
@@ -37,7 +37,7 @@ po::options_description getParser(OptionsParser::Options& options) {
 		("no-compress-ways", po::bool_switch(&options.osm.uncompressedWays),  "store ways uncompressed")
 		("materialize-geometries", po::bool_switch(&options.osm.materializeGeometries),  "materialize geometries")
 		("shard-stores", po::bool_switch(&options.osm.shardStores),  "use an alternate reading/writing strategy for low-memory machines")
-		("threads",po::value< uint >(&options.threadNum)->default_value(0),              "number of threads (automatically detected if 0)")
+		("threads",po::value<uint32_t>(&options.threadNum)->default_value(0),              "number of threads (automatically detected if 0)")
 			;
 
 	desc.add(performance);

--- a/src/options_parser.cpp
+++ b/src/options_parser.cpp
@@ -1,0 +1,100 @@
+#include "options_parser.h"
+
+#include <thread>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <iostream>
+#include "helpers.h"
+
+#ifndef TM_VERSION
+#define TM_VERSION (version not set)
+#endif
+#define STR1(x)  #x
+#define STR(x)  STR1(x)
+
+using namespace std;
+namespace po = boost::program_options;
+
+po::options_description getParser(OptionsParser::Options& options) {
+	po::options_description desc("tilemaker " STR(TM_VERSION) "\nConvert OpenStreetMap .pbf files into vector tiles\n\nAvailable options");
+	desc.add_options()
+		("help",                                                                 "show help message")
+		("input",  po::value< vector<string> >(&options.inputFiles),                     "source .osm.pbf file")
+		("output", po::value< string >(&options.outputFile),                             "target directory or .mbtiles/.pmtiles file")
+		("bbox",   po::value< string >(&options.bbox),                                   "bounding box to use if input file does not have a bbox header set, example: minlon,minlat,maxlon,maxlat")
+		("merge"  ,po::bool_switch(&options.mergeSqlite),                                "merge with existing .mbtiles (overwrites otherwise)")
+		("config", po::value< string >(&options.jsonFile)->default_value("config.json"), "config JSON file")
+		("process",po::value< string >(&options.luaFile)->default_value("process.lua"),  "tag-processing Lua file")
+		("store",  po::value< string >(&options.osm.storeFile),  "temporary storage for node/ways/relations data")
+		("compact",po::bool_switch(&options.osm.compact),  "Reduce overall memory usage (compact mode).\nNOTE: This requires the input to be renumbered (osmium renumber)")
+		("no-compress-nodes", po::bool_switch(&options.osm.uncompressedNodes),  "Store nodes uncompressed")
+		("no-compress-ways", po::bool_switch(&options.osm.uncompressedWays),  "Store ways uncompressed")
+		("materialize-geometries", po::bool_switch(&options.osm.materializeGeometries),  "Materialize geometries - faster, but requires more memory")
+		("shard-stores", po::bool_switch(&options.osm.shardStores),  "Shard stores - use an alternate reading/writing strategy for low-memory machines")
+		("verbose",po::bool_switch(&options.verbose),                                   "verbose error output")
+		("skip-integrity",po::bool_switch(&options.osm.skipIntegrity),                       "don't enforce way/node integrity")
+		("log-tile-timings", po::bool_switch(&options.logTileTimings), "log how long each tile takes")
+		("threads",po::value< uint >(&options.threadNum)->default_value(0),              "number of threads (automatically detected if 0)");
+	po::options_description performance("Performance options");
+	performance.add_options()
+			("help-module", po::value<std::string>(),
+					"produce a help for a given module")
+			("version", "output the version number")
+			;
+
+	desc.add(performance);
+	return desc;
+}
+
+void OptionsParser::showHelp() {
+	Options options;
+	auto parser = getParser(options);
+	std::cout << parser << std::endl;
+}
+
+OptionsParser::Options OptionsParser::parse(const int argc, const char* argv[]) {
+	Options options;
+	po::options_description desc = getParser(options);
+	po::positional_options_description p;
+	p.add("input", 1).add("output", 1);
+
+	po::variables_map vm;
+	try {
+		po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+	} catch (const po::unknown_option& ex) {
+		throw OptionException{"Unknown option: " + ex.get_option_name()};
+	}
+	po::notify(vm);
+	
+	if (vm.count("help")) {
+		options.showHelp = true;
+		return options;
+	}
+	if (vm.count("output") == 0) {
+		throw OptionException{ "You must specify an output file or directory. Run with --help to find out more." };
+	}
+
+	if (vm.count("input") == 0) {
+		throw OptionException{ "No source .osm.pbf file supplied" };
+	}
+
+	if (ends_with(options.outputFile, ".mbtiles") || ends_with(options.outputFile, ".sqlite")) {
+		options.outputMode = OutputMode::MBTiles;
+	} else if (ends_with(options.outputFile, ".pmtiles")) {
+		options.outputMode = OutputMode::PMTiles;
+	}
+
+	if (options.threadNum == 0) {
+		options.threadNum = max(thread::hardware_concurrency(), 1u);
+	}
+
+	// ---- Check config
+	if (!boost::filesystem::exists(options.jsonFile)) {
+		throw OptionException{ "Couldn't open .json config: " + options.jsonFile };
+	}
+	if (!boost::filesystem::exists(options.luaFile)) {
+		throw OptionException{"Couldn't open .lua script: " + options.luaFile };
+	}
+
+	return options;
+}

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -350,7 +350,9 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 
 			if(CorrectGeometry(p) == CorrectGeometryResult::Invalid) return;
 
-			NodeID id = osmMemTiles.storePoint(p);
+			NodeID id = USE_NODE_STORE | originalOsmID;
+			if (materializeGeometries)
+				id = osmMemTiles.storePoint(p);
 			OutputObject oo(geomType, layers.layerMap[layerName], id, 0, layerMinZoom);
 			outputs.push_back(std::make_pair(std::move(oo), attributes));
 			return;

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -468,7 +468,21 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName) {
 		return;
 	}
 
-	NodeID id = osmMemTiles.storePoint(geomp);
+	NodeID id = 0;
+	// We don't do lazy centroids for relations - calculating their centroid
+	// can be quite expensive, and there's not as many of them as there are
+	// ways.
+	if (materializeGeometries || isRelation) {
+		id = osmMemTiles.storePoint(geomp);
+	} else if (!isRelation && !isWay) {
+		// Sometimes people call LayerAsCentroid(...) on a node, because they're
+		// writing a generic handler that doesn't know if it's a node or a way,
+		// e.g. POIs.
+		id = USE_NODE_STORE | originalOsmID;
+	} else {
+		id = USE_WAY_STORE | originalOsmID;
+		wayEmitted = true;
+	}
 	OutputObject oo(POINT_, layers.layerMap[layerName], id, 0, layerMinZoom);
 	outputs.push_back(std::make_pair(std::move(oo), attributes));
 }

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -18,6 +18,27 @@ OsmMemTiles::OsmMemTiles(
 {
 }
 
+LatpLon OsmMemTiles::buildNodeGeometry(
+	OutputGeometryType const geomType, 
+	NodeID const objectID,
+	const TileBbox &bbox
+) const {
+	if (objectID < OSM_THRESHOLD) {
+		return TileDataSource::buildNodeGeometry(geomType, objectID, bbox);
+	}
+
+	switch(geomType) {
+		case POINT_: {
+			return nodeStore.at(OSM_ID(objectID));
+		}
+
+		default:
+			break;
+	}
+
+	throw std::runtime_error("Geometry type is not point");			
+}
+
 Geometry OsmMemTiles::buildWayGeometry(
 	const OutputGeometryType geomType, 
 	const NodeID objectID,

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -19,24 +19,27 @@ OsmMemTiles::OsmMemTiles(
 }
 
 LatpLon OsmMemTiles::buildNodeGeometry(
-	OutputGeometryType const geomType, 
 	NodeID const objectID,
 	const TileBbox &bbox
 ) const {
 	if (objectID < OSM_THRESHOLD) {
-		return TileDataSource::buildNodeGeometry(geomType, objectID, bbox);
+		return TileDataSource::buildNodeGeometry(objectID, bbox);
 	}
 
-	switch(geomType) {
-		case POINT_: {
-			return nodeStore.at(OSM_ID(objectID));
-		}
+	if (IS_NODE(objectID))
+		return nodeStore.at(OSM_ID(objectID));
 
-		default:
-			break;
+
+	if (IS_WAY(objectID)) {
+		Linestring& ls = getOrBuildLinestring(objectID);
+		Point centroid;
+		Polygon p;
+		geom::assign_points(p, ls);
+		geom::centroid(p, centroid);
+		return LatpLon{(int32_t)(centroid.y()*10000000.0), (int32_t)(centroid.x()*10000000.0)};
 	}
 
-	throw std::runtime_error("Geometry type is not point");			
+	throw std::runtime_error("OsmMemTiles::buildNodeGeometry: unsupported objectID");
 }
 
 Geometry OsmMemTiles::buildWayGeometry(
@@ -79,7 +82,7 @@ Geometry OsmMemTiles::buildWayGeometry(
 	throw std::runtime_error("buildWayGeometry: unexpected objectID: " + std::to_string(objectID));
 }
 
-void OsmMemTiles::populateLinestring(Linestring& ls, NodeID objectID) {
+void OsmMemTiles::populateLinestring(Linestring& ls, NodeID objectID) const {
 	std::vector<LatpLon> nodes = wayStore.at(OSM_ID(objectID));
 
 	for (const LatpLon& node : nodes) {
@@ -87,7 +90,7 @@ void OsmMemTiles::populateLinestring(Linestring& ls, NodeID objectID) {
 	}
 }
 
-Linestring& OsmMemTiles::getOrBuildLinestring(NodeID objectID) {
+Linestring& OsmMemTiles::getOrBuildLinestring(NodeID objectID) const {
 	// Note: this function returns a reference, not a shared_ptr.
 	//
 	// This is safe, because this function is the only thing that can

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -87,9 +87,12 @@ void OutputObject::writeAttributes(
 int OutputObject::findValue(const vector<vector_tile::Tile_Value>* valueList, const AttributePair& value) const {
 	for (size_t i=0; i<valueList->size(); i++) {
 		const vector_tile::Tile_Value& v = valueList->at(i);
-		if (v.has_string_value() && value.hasStringValue() && v.string_value()==value.stringValue()) { return i; }
-		if (v.has_float_value()  && value.hasFloatValue()  && v.float_value() ==value.floatValue() ) { return i; }
-		if (v.has_bool_value()	 && value.hasBoolValue()   && v.bool_value()  ==value.boolValue()	) { return i; }
+		if (v.has_string_value() && value.hasStringValue()) {
+			const size_t valueSize = value.pooledString().size();
+			if (valueSize == v.string_value().size() && memcmp(v.string_value().data(), value.pooledString().data(), valueSize) == 0)
+				return i;
+		} else if (v.has_float_value()  && value.hasFloatValue()  && v.float_value() ==value.floatValue() ) { return i; }
+		else if (v.has_bool_value()	 && value.hasBoolValue()   && v.bool_value()  ==value.boolValue()	) { return i; }
 	}
 	return -1;
 }

--- a/src/pooled_string.cpp
+++ b/src/pooled_string.cpp
@@ -148,3 +148,23 @@ std::string PooledStringNS::PooledString::toString() const {
 	const std::string* str = *(const std::string**)((void*)(storage + 8));
 	return *str;
 }
+
+void PooledStringNS::PooledString::ensureStringIsOwned() {
+	uint8_t kind = storage[0] >> 6;
+
+	if (kind != StdString)
+		return;
+
+	*this = PooledString(toString());
+}
+
+bool PooledStringNS::PooledString::operator<(const PooledString& other) const {
+	size_t mySize = size();
+	size_t otherSize = other.size();
+
+	if (mySize != otherSize)
+		return mySize < otherSize;
+
+	return memcmp(data(), other.data(), mySize) < 0;
+}
+

--- a/src/pooled_string.cpp
+++ b/src/pooled_string.cpp
@@ -1,0 +1,98 @@
+#include "pooled_string.h"
+#include <mutex>
+#include <cstring>
+
+namespace PooledStringNS {
+	std::vector<char*> tables;
+	std::mutex mutex;
+
+	// Each thread has its own string table, we only take a lock
+	// to push a new table onto the vector.
+	thread_local int64_t tableIndex = -1;
+	thread_local int64_t spaceLeft = -1;
+}
+
+PooledString::PooledString(const std::string& str) {
+	if (str.size() >= 65536)
+		throw std::runtime_error("cannot store string longer than 64K");
+
+	if (str.size() <= 15) {
+		storage[0] = str.size();
+		memcpy(storage + 1, str.data(), str.size());
+		memset(storage + 1 + str.size(), 0, 16 - 1 - str.size());
+	} else {
+		memset(storage + 8, 0, 8);
+		storage[0] = 1 << 7;
+
+		if (spaceLeft < 0 || spaceLeft < str.size()) {
+			std::lock_guard<std::mutex> lock(mutex);
+			spaceLeft = 65536;
+			char* buffer = (char*)malloc(spaceLeft);
+			if (buffer == 0)
+				throw std::runtime_error("PooledString could not malloc");
+			tables.push_back(buffer);
+			tableIndex = tables.size() - 1;
+		}
+
+		storage[1] = tableIndex >> 16;
+		storage[2] = tableIndex >> 8;
+		storage[3] = tableIndex;
+
+		uint16_t offset = 65536 - spaceLeft;
+		storage[4] = offset >> 8;
+		storage[5] = offset;
+
+		uint16_t length = str.size();
+		storage[6] = length >> 8;
+		storage[7] = length;
+
+		memcpy(tables[tableIndex] + offset, str.data(), str.size());
+
+		spaceLeft -= str.size();
+	}
+}
+
+bool PooledStringNS::PooledString::operator==(const PooledString& other) const {
+	// NOTE: We have surprising equality semantics!
+	//
+	// For short strings, you are equal if the strings are equal.
+	//
+	// For large strings, you are equal if you use the same heap memory locations.
+	// This implies that someone outside of PooledString is managing pooling! In our
+	// case, it is the responsibility of AttributePairStore.
+	return memcmp(storage, other.storage, 16) == 0;
+}
+
+bool PooledStringNS::PooledString::operator!=(const PooledString& other) const {
+	return !(*this == other);
+}
+
+size_t PooledStringNS::PooledString::size() const {
+	// If the uppermost bit is set, we're in heap.
+	if (storage[0] >> 7) {
+		uint16_t length = (storage[6] << 8) + storage[7];
+		return length;
+	}
+
+	// Otherwise it's stored in the lower 7 bits of the highest byte.
+	return storage[0] & 0b01111111;
+}
+
+std::string PooledStringNS::PooledString::toString() const {
+	std::string rv;
+	if (storage[0] == 1 << 7) {
+		// heap
+		rv.reserve(size());
+
+		uint32_t tableIndex = (storage[1] << 16) + (storage[2] << 8) + storage[3];
+		uint16_t offset = (storage[4] << 8) + storage[5];
+
+		char* data = tables[tableIndex] + offset;
+		rv.append(data, size());
+		return rv;
+	}
+
+	for (int i = 0; i < storage[0]; i++)
+		rv += storage[i + 1];
+	return rv;
+}

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -272,8 +272,9 @@ bool PbfReader::ReadBlock(
 		{
 			if (ioMutex.try_lock()) {
 				std::ostringstream str;
+				str << "\r";
 				void_mmap_allocator::reportStoreSize(str);
-				str << "\rBlock " << blocksProcessed.load() << "/" << blocksToProcess.load() << " ways " << pg.ways_size() << " relations " << pg.relations_size() << "                  ";
+				str << "Block " << blocksProcessed.load() << "/" << blocksToProcess.load() << " ways " << pg.ways_size() << " relations " << pg.relations_size() << "                  ";
 				std::cout << str.str();
 				std::cout.flush();
 				ioMutex.unlock();

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -398,7 +398,9 @@ int PbfReader::ReadPbfFile(
 	unordered_set<string> const& nodeKeys,
 	unsigned int threadNum,
 	const pbfreader_generate_stream& generate_stream,
-	const pbfreader_generate_output& generate_output
+	const pbfreader_generate_output& generate_output,
+	const NodeStore& nodeStore,
+	const WayStore& wayStore
 )
 {
 	auto infile = generate_stream();
@@ -499,6 +501,11 @@ int PbfReader::ReadPbfFile(
 			effectiveShards = shards;
 
 		for (int shard = 0; shard < effectiveShards; shard++) {
+			// If we're in ReadPhase::Ways, only do a pass if there is at least one
+			// entry in the pass's shard.
+			if (phase == ReadPhase::Ways && nodeStore.shard(shard).size() == 0)
+				continue;
+
 #ifdef CLOCK_MONOTONIC
 			timespec start, end;
 			clock_gettime(CLOCK_MONOTONIC, &start);

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -243,7 +243,7 @@ bool PbfReader::ReadRelations(
 					if (role==innerKey || role==outerKey) isInnerOuter=true;
 					WayID wayId = static_cast<WayID>(lastID);
 
-					if (firstWay && effectiveShards > 0 && !osmStore.ways.contains(shard, wayId)) {
+					if (firstWay && effectiveShards > 1 && !osmStore.ways.contains(shard, wayId)) {
 						skipToNext = true;
 						break;
 					}

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -294,8 +294,11 @@ bool PbfReader::ReadBlock(
 			osmStore.ensureUsedWaysInited();
 			bool done = ScanRelations(output, pg, pb);
 			if(done) { 
-				std::cout << "\r(Scanning for ways used in relations: " << (100*blocksProcessed.load()/blocksToProcess.load()) << "%)           ";
-				std::cout.flush();
+				if (ioMutex.try_lock()) {
+					std::cout << "\r(Scanning for ways used in relations: " << (100*blocksProcessed.load()/blocksToProcess.load()) << "%)           ";
+					std::cout.flush();
+					ioMutex.unlock();
+				}
 				continue;
 			}
 		}

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -235,6 +235,7 @@ bool PbfReader::ReadRelations(
 				int64_t lastID = 0;
 				bool isInnerOuter = isBoundary || isMultiPolygon;
 				bool skipToNext = false;
+				bool firstWay = true;
 				for (int n=0; n < pbfRelation.memids_size(); n++) {
 					lastID += pbfRelation.memids(n);
 					if (pbfRelation.types(n) != Relation_MemberType_WAY) { continue; }
@@ -242,10 +243,12 @@ bool PbfReader::ReadRelations(
 					if (role==innerKey || role==outerKey) isInnerOuter=true;
 					WayID wayId = static_cast<WayID>(lastID);
 
-					if (n == 0 && effectiveShards > 0 && !osmStore.ways.contains(shard, wayId)) {
+					if (firstWay && effectiveShards > 0 && !osmStore.ways.contains(shard, wayId)) {
 						skipToNext = true;
 						break;
 					}
+					if (firstWay)
+						firstWay = false;
 					(role == innerKey ? innerWayVec : outerWayVec).push_back(wayId);
 				}
 

--- a/src/sharded_node_store.cpp
+++ b/src/sharded_node_store.cpp
@@ -53,13 +53,19 @@ size_t pickStore(const LatpLon& el) {
 	// Europe still basically gets its own bucket, but probably should be split up
 	// more.
 
-	const size_t z3x = lon2tilex(el.lon / 10000000, 3);
-	const size_t z3y = latp2tiley(el.latp / 10000000, 3);
+	const size_t z4x = lon2tilex(el.lon / 10000000, 4);
+	const size_t z4y = latp2tiley(el.latp / 10000000, 4);
 
-	if (z3x == 4 && z3y == 2) return 4; // Central Europe
+	const size_t z3x = z4x / 2;
+	const size_t z3y = z4y / 2;
+
 	if (z3x == 5 && z3y == 2) return 5; // Western Russia
-	if (z3x == 4 && z3y == 3) return 6; // North Africa
-	if (z3x == 5 && z3y == 3) return 7; // India
+	if (z3x == 4 && z3y == 3) return 5; // North Africa
+	if (z3x == 5 && z3y == 3) return 5; // India
+
+	if (z4x == 8 && z4y == 5) return 4; // some of Central Europe
+
+	if (z3x == 4 && z3y == 2) return 3; // rest of Central Europe
 
 	const size_t z2x = z3x / 2;
 	const size_t z2y = z3y / 2;
@@ -69,7 +75,7 @@ size_t pickStore(const LatpLon& el) {
 	if (z2x == 0 && z2y == 1) return 1; // North America
 
 //	std::cout << "z2x=" << std::to_string(z2x) << ", z2y=" << std::to_string(z2y) << std::endl;
-	return 0; // Artic, Antartcica, Oceania
+	return 0; // Artic, Antartcica, Oceania, South Africa, South America
 }
 
 void ShardedNodeStore::insert(const std::vector<element_t>& elements) {
@@ -90,5 +96,5 @@ bool ShardedNodeStore::contains(size_t shard, NodeID id) const {
 }
 
 size_t ShardedNodeStore::shards() const {
-	return 8;
+	return 6;
 }

--- a/src/sharded_node_store.cpp
+++ b/src/sharded_node_store.cpp
@@ -99,5 +99,5 @@ bool ShardedNodeStore::contains(size_t shard, NodeID id) const {
 }
 
 size_t ShardedNodeStore::shards() const {
-	return 7;
+	return 6;
 }

--- a/src/sharded_node_store.cpp
+++ b/src/sharded_node_store.cpp
@@ -61,12 +61,12 @@ size_t pickStore(const LatpLon& el) {
 	const size_t z3x = z4x / 2;
 	const size_t z3y = z4y / 2;
 
-	if (z3x == 5 && z3y == 2) return 6; // Western Russia
-	if (z3x == 4 && z3y == 3) return 6; // North Africa
-	if (z3x == 5 && z3y == 3) return 6; // India
+	if (z3x == 5 && z3y == 2) return 5; // Western Russia
+	if (z3x == 4 && z3y == 3) return 5; // North Africa
+	if (z3x == 5 && z3y == 3) return 5; // India
 
-	if ((z5x == 16 && z5y == 10) || (z5x == 16 && z5y == 11)) return 5; // some of Central Europe
-	if ((z5x == 17 && z5y == 10) || (z5x == 17 && z5y == 11)) return 4; // some more of Central Europe
+	if ((z5x == 16 && z5y == 10) || (z5x == 16 && z5y == 11)) return 4; // some of Central Europe
+	if ((z5x == 17 && z5y == 10) || (z5x == 17 && z5y == 11)) return 1; // some more of Central Europe
 
 	if (z3x == 4 && z3y == 2) return 3; // rest of Central Europe
 

--- a/src/sharded_node_store.cpp
+++ b/src/sharded_node_store.cpp
@@ -1,0 +1,86 @@
+#include "sharded_node_store.h"
+
+ShardedNodeStore::ShardedNodeStore(std::function<std::shared_ptr<NodeStore>()> createNodeStore):
+	createNodeStore(createNodeStore) {
+	for (int i = 0; i < shards(); i++)
+		stores.push_back(createNodeStore());
+}
+
+ShardedNodeStore::~ShardedNodeStore() {
+}
+
+void ShardedNodeStore::reopen() {
+	for (auto& store : stores)
+		store->reopen();
+}
+
+void ShardedNodeStore::finalize(size_t threadNum) {
+	for (auto& store : stores)
+		store->finalize(threadNum);
+}
+
+LatpLon ShardedNodeStore::at(NodeID id) const {
+	// TODO: look in the last store we successfully found something, using
+	// a thread local
+	for (int i = 0; i < shards(); i++)
+		if (stores[i]->contains(0, id) || i == shards() - 1)
+			return stores[i]->at(id);
+}
+
+size_t ShardedNodeStore::size() const {
+	size_t rv = 0;
+	for (auto& store : stores)
+		rv += store->size();
+
+	return rv;
+}
+
+void ShardedNodeStore::batchStart() {
+	for (auto& store : stores)
+		store->batchStart();
+}
+
+size_t pickStore(const LatpLon& el) {
+	// Assign the element to a store. This is pretty naive, we could likely do better--
+	// Europe still basically gets its own bucket, but probably should be split up
+	// more.
+
+	const size_t z3x = lon2tilex(el.lon / 10000000, 3);
+	const size_t z3y = latp2tiley(el.latp / 10000000, 3);
+
+	if (z3x == 4 && z3y == 2) return 4; // Central Europe
+	if (z3x == 5 && z3y == 2) return 5; // Western Russia
+	if (z3x == 4 && z3y == 3) return 6; // North Africa
+	if (z3x == 5 && z3y == 3) return 7; // India
+
+	const size_t z2x = z3x / 2;
+	const size_t z2y = z3y / 2;
+
+	if (z2x == 3 && z2y == 1) return 3; // Asia, Russia
+	if (z2x == 1 && z2y == 1) return 2; // North Atlantic Ocean and bordering countries
+	if (z2x == 0 && z2y == 1) return 1; // North America
+
+//	std::cout << "z2x=" << std::to_string(z2x) << ", z2y=" << std::to_string(z2y) << std::endl;
+	return 0; // Artic, Antartcica, Oceania
+}
+
+void ShardedNodeStore::insert(const std::vector<element_t>& elements) {
+	std::vector<std::vector<element_t>> perStore(shards());
+
+	for (const auto& el : elements) {
+		perStore[pickStore(el.second)].push_back(el);
+	}
+
+	for (int i = 0; i < shards(); i++) {
+		if (!perStore[i].empty())
+			stores[i]->insert(perStore[i]);
+	}
+}
+
+bool ShardedNodeStore::contains(size_t shard, NodeID id) const {
+	return stores[shard]->contains(0, id);
+}
+
+size_t ShardedNodeStore::shards() const {
+	return 8;
+}

--- a/src/sharded_node_store.cpp
+++ b/src/sharded_node_store.cpp
@@ -49,21 +49,24 @@ void ShardedNodeStore::batchStart() {
 }
 
 size_t pickStore(const LatpLon& el) {
-	// Assign the element to a store. This is pretty naive, we could likely do better--
-	// Europe still basically gets its own bucket, but probably should be split up
-	// more.
+	// Assign the element to a shard. This is a pretty naive division
+	// of the globe, tuned to have max ~10GB of nodes/ways per shard.
 
-	const size_t z4x = lon2tilex(el.lon / 10000000, 4);
-	const size_t z4y = latp2tiley(el.latp / 10000000, 4);
+	const size_t z5x = lon2tilex(el.lon / 10000000, 5);
+	const size_t z5y = latp2tiley(el.latp / 10000000, 5);
+
+	const size_t z4x = z5x / 2;
+	const size_t z4y = z5y / 2;
 
 	const size_t z3x = z4x / 2;
 	const size_t z3y = z4y / 2;
 
-	if (z3x == 5 && z3y == 2) return 5; // Western Russia
-	if (z3x == 4 && z3y == 3) return 5; // North Africa
-	if (z3x == 5 && z3y == 3) return 5; // India
+	if (z3x == 5 && z3y == 2) return 6; // Western Russia
+	if (z3x == 4 && z3y == 3) return 6; // North Africa
+	if (z3x == 5 && z3y == 3) return 6; // India
 
-	if (z4x == 8 && z4y == 5) return 4; // some of Central Europe
+	if ((z5x == 16 && z5y == 10) || (z5x == 16 && z5y == 11)) return 5; // some of Central Europe
+	if ((z5x == 17 && z5y == 10) || (z5x == 17 && z5y == 11)) return 4; // some more of Central Europe
 
 	if (z3x == 4 && z3y == 2) return 3; // rest of Central Europe
 
@@ -96,5 +99,5 @@ bool ShardedNodeStore::contains(size_t shard, NodeID id) const {
 }
 
 size_t ShardedNodeStore::shards() const {
-	return 6;
+	return 7;
 }

--- a/src/sharded_way_store.cpp
+++ b/src/sharded_way_store.cpp
@@ -1,0 +1,77 @@
+#include "sharded_way_store.h"
+#include "node_store.h"
+
+thread_local size_t lastWayShard = 0;
+
+ShardedWayStore::ShardedWayStore(std::function<std::shared_ptr<WayStore>()> createWayStore, const NodeStore& nodeStore):
+	createWayStore(createWayStore),
+	nodeStore(nodeStore) {
+	for (int i = 0; i < shards(); i++)
+		stores.push_back(createWayStore());
+}
+
+ShardedWayStore::~ShardedWayStore() {
+}
+
+void ShardedWayStore::reopen() {
+	for (auto& store : stores)
+		store->reopen();
+}
+
+void ShardedWayStore::batchStart() {
+	for (auto& store : stores)
+		store->batchStart();
+}
+
+std::vector<LatpLon> ShardedWayStore::at(WayID wayid) const {
+	for (int i = 0; i < shards(); i++) {
+		size_t index = (lastWayShard + i) % shards();
+		if (stores[index]->contains(0, wayid)) {
+			lastWayShard = index;
+			return stores[index]->at(wayid);
+		}
+	}
+
+	// Superfluous return to silence a compiler warning
+	return stores[shards() - 1]->at(wayid);
+}
+
+bool ShardedWayStore::requiresNodes() const {
+	return stores[0]->requiresNodes();
+}
+
+void ShardedWayStore::insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) {
+	throw std::runtime_error("ShardedWayStore::insertLatpLons: don't call this directly");
+}
+
+void ShardedWayStore::insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) {
+	throw std::runtime_error("ShardedWayStore::insertNodes: don't call this directly");
+}
+
+void ShardedWayStore::clear() {
+	for (auto& store : stores)
+		store->clear();
+}
+
+std::size_t ShardedWayStore::size() const {
+	size_t rv = 0;
+	for (auto& store : stores)
+		rv += store->size();
+	return rv;
+}
+
+void ShardedWayStore::finalize(unsigned int threadNum) {
+	for (auto& store : stores)
+		store->finalize(threadNum);
+}
+
+bool ShardedWayStore::contains(size_t shard, WayID id) const {
+	return stores[shard]->contains(0, id);
+}
+
+WayStore& ShardedWayStore::shard(size_t shard) {
+	return *stores[shard].get();
+}
+
+size_t ShardedWayStore::shards() const { return nodeStore.shards(); }
+

--- a/src/sharded_way_store.cpp
+++ b/src/sharded_way_store.cpp
@@ -73,5 +73,9 @@ WayStore& ShardedWayStore::shard(size_t shard) {
 	return *stores[shard].get();
 }
 
+const WayStore& ShardedWayStore::shard(size_t shard) const {
+	return *stores[shard].get();
+}
+
 size_t ShardedWayStore::shards() const { return nodeStore.shards(); }
 

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -10,7 +10,7 @@ using namespace rapidjson;
 
 SharedData::SharedData(Config &configIn, const class LayerDefinition &layers)
 	: layers(layers), config(configIn) {
-	outputMode=OUTPUT_FILE;
+	outputMode=OptionsParser::OutputMode::File;
 	mergeSqlite=false;
 }
 

--- a/src/sorted_node_store.cpp
+++ b/src/sorted_node_store.cpp
@@ -42,13 +42,13 @@ namespace SortedNodeStoreTypes {
 	};
 
 	thread_local ThreadStorage threadStorage;
+
+	ThreadStorage& storage() {
+		return threadStorage;
+	}
 }
 
 using namespace SortedNodeStoreTypes;
-
-ThreadStorage& storage() {
-	return threadStorage;
-}
 
 SortedNodeStore::SortedNodeStore(bool compressNodes): compressNodes(compressNodes) {
 	reopen();

--- a/src/sorted_node_store.cpp
+++ b/src/sorted_node_store.cpp
@@ -58,6 +58,7 @@ namespace SortedNodeStoreTypes {
 using namespace SortedNodeStoreTypes;
 
 SortedNodeStore::SortedNodeStore(bool compressNodes): compressNodes(compressNodes) {
+	s(this); // allocate our ThreadStorage before multi-threading
 	reopen();
 }
 
@@ -320,7 +321,7 @@ void SortedNodeStore::finalize(size_t threadNum) {
 
 	orphanage.clear();
 
-	std::cout << "SortedNodeStore: " << totalGroups << " groups, " << totalChunks << " chunks, " << totalNodes.load() << " nodes, " << totalGroupSpace.load() << " bytes (" << (1000ull * (totalAllocatedSpace.load() - totalGroupSpace.load()) / totalAllocatedSpace.load()) / 10.0 << "% wasted)" << std::endl;
+	std::cout << "SortedNodeStore: " << totalGroups << " groups, " << totalChunks << " chunks, " << totalNodes.load() << " nodes, " << totalGroupSpace.load() << " bytes (" << (1000ull * (totalAllocatedSpace.load() - totalGroupSpace.load()) / (totalAllocatedSpace.load() + 1)) / 10.0 << "% wasted)" << std::endl;
 	/*
 	for (int i = 0; i < 257; i++)
 		std::cout << "chunkSizeFreqs[ " << i << " ]= " << chunkSizeFreqs[i].load() << std::endl;

--- a/src/sorted_node_store.cpp
+++ b/src/sorted_node_store.cpp
@@ -87,6 +87,8 @@ void SortedNodeStore::reopen()
 SortedNodeStore::~SortedNodeStore() {
 	for (const auto entry: allocatedMemory)
 		void_mmap_allocator::deallocate(entry.first, entry.second);
+
+	s(this) = ThreadStorage();
 }
 
 LatpLon SortedNodeStore::at(const NodeID id) const {

--- a/src/sorted_way_store.cpp
+++ b/src/sorted_way_store.cpp
@@ -208,7 +208,7 @@ void SortedWayStore::insertLatpLons(std::vector<WayStore::ll_element_t> &newWays
 	throw std::runtime_error("SortedWayStore does not support insertLatpLons");
 }
 
-const void SortedWayStore::insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) {
+void SortedWayStore::insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) {
 	// read_pbf can call with an empty array if the only ways it read were unable to
 	// be processed due to missing nodes, so be robust against empty way vector.
 	if (newWays.empty())

--- a/src/sorted_way_store.cpp
+++ b/src/sorted_way_store.cpp
@@ -59,6 +59,7 @@ namespace SortedWayStoreTypes {
 using namespace SortedWayStoreTypes;
 
 SortedWayStore::SortedWayStore(bool compressWays, const NodeStore& nodeStore): compressWays(compressWays), nodeStore(nodeStore) {
+	s(this); // allocate our ThreadStorage before multi-threading
 	reopen();
 }
 
@@ -116,7 +117,6 @@ bool SortedWayStore::contains(size_t shard, WayID id) const {
 	}
 
 	ChunkInfo* chunkPtr = (ChunkInfo*)((char*)groupPtr + groupPtr->chunkOffsets[chunkOffset]);
-	const size_t numWays = popcnt(chunkPtr->smallWayMask, 32) + popcnt(chunkPtr->bigWayMask, 32);
 
 	{
 		size_t wayOffset = 0;

--- a/src/sorted_way_store.cpp
+++ b/src/sorted_way_store.cpp
@@ -1,4 +1,3 @@
-#include <atomic>
 #include <algorithm>
 #include <bitset>
 #include <cstring>
@@ -34,20 +33,12 @@ namespace SortedWayStoreTypes {
 	thread_local int32_t int32Buffer[2000];
 	thread_local uint8_t uint8Buffer[8192];
 
-	std::atomic<uint64_t> totalWays;
-	std::atomic<uint64_t> totalNodes;
-	std::atomic<uint64_t> totalGroups;
-	std::atomic<uint64_t> totalGroupSpace;
-	std::atomic<uint64_t> totalChunks;
 }
 
 using namespace SortedWayStoreTypes;
 
 SortedWayStore::SortedWayStore(bool compressWays, const NodeStore& nodeStore): compressWays(compressWays), nodeStore(nodeStore) {
-	// Each group can store 64K ways. If we allocate 32K slots,
-	// we support 2^31 = 2B ways, or about twice the number used
-	// by OSM as of December 2023.
-	groups.resize(32 * 1024);
+	reopen();
 }
 
 SortedWayStore::~SortedWayStore() {
@@ -67,8 +58,12 @@ void SortedWayStore::reopen() {
 	totalChunks = 0;
 	orphanage.clear();
 	workerBuffers.clear();
+
+	// Each group can store 64K ways. If we allocate 32K slots,
+	// we support 2^31 = 2B ways, or about twice the number used
+	// by OSM as of December 2023.
 	groups.clear();
-	groups.resize(256 * 1024);
+	groups.resize(32 * 1024);
 
 }
 

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -47,7 +47,9 @@ TileDataSource::TileDataSource(size_t threadNum, unsigned int baseZoom, bool inc
 	z6OffsetDivisor(baseZoom >= CLUSTER_ZOOM ? (1 << (baseZoom - CLUSTER_ZOOM)) : 1),
 	objectsMutex(threadNum * 4),
 	objects(CLUSTER_ZOOM_AREA),
+	lowZoomObjects(CLUSTER_ZOOM_AREA),
 	objectsWithIds(CLUSTER_ZOOM_AREA),
+	lowZoomObjectsWithIds(CLUSTER_ZOOM_AREA),
 	baseZoom(baseZoom),
 	pointStores(threadNum),
 	linestringStores(threadNum),
@@ -149,8 +151,6 @@ void TileDataSource::collectObjectsForTile(
 	size_t iStart = 0;
 	size_t iEnd = objects.size();
 
-	// TODO: we could also narrow the search space for z1..z5, too.
-	//       They're less important, as they have fewer tiles.
 	if (zoom >= CLUSTER_ZOOM) {
 		// Compute the x, y at the base zoom level
 		TileCoordinate z6x = dstIndex.x / (1 << (zoom - CLUSTER_ZOOM));

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -47,9 +47,7 @@ TileDataSource::TileDataSource(size_t threadNum, unsigned int baseZoom, bool inc
 	z6OffsetDivisor(baseZoom >= CLUSTER_ZOOM ? (1 << (baseZoom - CLUSTER_ZOOM)) : 1),
 	objectsMutex(threadNum * 4),
 	objects(CLUSTER_ZOOM_AREA),
-	lowZoomObjects(1),
 	objectsWithIds(CLUSTER_ZOOM_AREA),
-	lowZoomObjectsWithIds(1),
 	baseZoom(baseZoom),
 	pointStores(threadNum),
 	linestringStores(threadNum),
@@ -143,8 +141,9 @@ void TileDataSource::collectObjectsForTile(
 	std::vector<OutputObjectID>& output
 ) {
 	if (zoom < CLUSTER_ZOOM) {
-		collectObjectsForTileTemplate<OutputObjectXY>(baseZoom, lowZoomObjects.begin(), 0, 1, zoom, dstIndex, output);
-		collectObjectsForTileTemplate<OutputObjectXYID>(baseZoom, lowZoomObjectsWithIds.begin(), 0, 1, zoom, dstIndex, output);
+		collectLowZoomObjectsForTile<OutputObjectXY>(baseZoom, lowZoomObjects, zoom, dstIndex, output);
+		collectLowZoomObjectsForTile<OutputObjectXYID>(baseZoom, lowZoomObjectsWithIds, zoom, dstIndex, output);
+		return;
 	}
 
 	size_t iStart = 0;

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -196,11 +196,7 @@ Geometry TileDataSource::buildWayGeometry(OutputGeometryType const geomType,
                                           NodeID const objectID, const TileBbox &bbox) {
 	switch(geomType) {
 		case POINT_: {
-			auto p = retrievePoint(objectID);
-			if (geom::within(p, bbox.clippingBox)) {
-				return p;
-			} 
-			return MultiLinestring();
+			throw std::runtime_error("unexpected geomType in buildWayGeometry");
 		}
 
 		case LINESTRING_: {

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -339,22 +339,12 @@ Geometry TileDataSource::buildWayGeometry(OutputGeometryType const geomType,
 	}
 }
 
-LatpLon TileDataSource::buildNodeGeometry(OutputGeometryType const geomType, 
-                                          NodeID const objectID, const TileBbox &bbox) const {
-	switch(geomType) {
-		case POINT_: {
-			auto p = retrievePoint(objectID);
-			LatpLon out;
-			out.latp = p.y();
-			out.lon  = p.x();
-			return out;
-		}
-
-		default:
-			break;
-	}
-
-	throw std::runtime_error("Geometry type is not point");			
+LatpLon TileDataSource::buildNodeGeometry(NodeID const objectID, const TileBbox &bbox) const {
+	auto p = retrievePoint(objectID);
+	LatpLon out;
+	out.latp = p.y();
+	out.lon  = p.x();
+	return out;
 }
 
 
@@ -538,7 +528,7 @@ NodeID TileDataSource::storePoint(const Point& input) {
 
 	NodeID offset = store.second->size();
 	store.second->emplace_back(input);
-	NodeID rv = (store.first << (35 - shardBits)) + offset;
+	NodeID rv = (store.first << (TILE_DATA_ID_SIZE - shardBits)) + offset;
 	return rv;
 }
 
@@ -548,7 +538,7 @@ NodeID TileDataSource::storeLinestring(const Linestring& src) {
 
 	NodeID offset = store.second->size();
 	store.second->emplace_back(std::move(dst));
-	NodeID rv = (store.first << (35 - shardBits)) + offset;
+	NodeID rv = (store.first << (TILE_DATA_ID_SIZE - shardBits)) + offset;
 	return rv;
 }
 
@@ -570,7 +560,7 @@ NodeID TileDataSource::storeMultiPolygon(const MultiPolygon& src) {
 
 	NodeID offset = store.second->size();
 	store.second->emplace_back(std::move(dst));
-	NodeID rv = (store.first << (35 - shardBits)) + offset;
+	NodeID rv = (store.first << (TILE_DATA_ID_SIZE - shardBits)) + offset;
 	return rv;
 }
 
@@ -585,7 +575,7 @@ NodeID TileDataSource::storeMultiLinestring(const MultiLinestring& src) {
 
 	NodeID offset = store.second->size();
 	store.second->emplace_back(std::move(dst));
-	NodeID rv = (store.first << (35 - shardBits)) + offset;
+	NodeID rv = (store.first << (TILE_DATA_ID_SIZE - shardBits)) + offset;
 	return rv;
 }
 

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -74,8 +74,8 @@ TileDataSource::TileDataSource(size_t threadNum, unsigned int baseZoom, bool inc
 }
 
 void TileDataSource::finalize(size_t threadNum) {
-	finalizeObjects<OutputObjectXY>(threadNum, baseZoom, objects.begin(), objects.end(), lowZoomObjects);
-	finalizeObjects<OutputObjectXYID>(threadNum, baseZoom, objectsWithIds.begin(), objectsWithIds.end(), lowZoomObjectsWithIds);
+	finalizeObjects<OutputObjectXY>(name(), threadNum, baseZoom, objects.begin(), objects.end(), lowZoomObjects);
+	finalizeObjects<OutputObjectXYID>(name(), threadNum, baseZoom, objectsWithIds.begin(), objectsWithIds.end(), lowZoomObjectsWithIds);
 
 }
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -378,13 +378,13 @@ void outputProc(
 
 	// Write to file or sqlite
 	string outputdata, compressed;
-	if (sharedData.outputMode == OUTPUT_MBTILES) {
+	if (sharedData.outputMode == OptionsParser::OutputMode::MBTiles) {
 		// Write to sqlite
 		tile.SerializeToString(&outputdata);
 		if (sharedData.config.compress) { compressed = compress_string(outputdata, Z_DEFAULT_COMPRESSION, sharedData.config.gzip); }
 		sharedData.mbtiles.saveTile(zoom, bbox.index.x, bbox.index.y, sharedData.config.compress ? &compressed : &outputdata, sharedData.mergeSqlite);
 
-	} else if (sharedData.outputMode == OUTPUT_PMTILES) {
+	} else if (sharedData.outputMode == OptionsParser::OutputMode::PMTiles) {
 		// Write to pmtiles
 		tile.SerializeToString(&outputdata);
 		sharedData.pmtiles.saveTile(zoom, bbox.index.x, bbox.index.y, outputdata);

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -176,7 +176,7 @@ void ProcessObjects(
 
 		if (oo.oo.geomType == POINT_) {
 			vector_tile::Tile_Feature *featurePtr = vtLayer->add_features();
-			LatpLon pos = source->buildNodeGeometry(oo.oo.geomType, oo.oo.objectID, bbox);
+			LatpLon pos = source->buildNodeGeometry(oo.oo.objectID, bbox);
 			featurePtr->add_geometry(9);					// moveTo, repeat x1
 			pair<int,int> xy = bbox.scaleLatpLon(pos.latp/10000000.0, pos.lon/10000000.0);
 			featurePtr->add_geometry((xy.first  << 1) ^ (xy.first  >> 31));

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -405,7 +405,9 @@ int main(int argc, char* argv[]) {
 				[&]() {
 					thread_local std::shared_ptr<OsmLuaProcessing> osmLuaProcessing(new OsmLuaProcessing(osmStore, config, layers, luaFile, shpMemTiles, osmMemTiles, attributeStore, materializeGeometries));
 					return osmLuaProcessing;
-				}
+				},
+				*nodeStore,
+				*wayStore
 			);
 			if (ret != 0) return ret;
 		} 
@@ -492,7 +494,9 @@ int main(int argc, char* argv[]) {
 				},
 				[&]() {
 					return std::make_unique<OsmLuaProcessing>(osmStore, config, layers, luaFile, shpMemTiles, osmMemTiles, attributeStore, materializeGeometries);
-				}
+				},
+				*nodeStore,
+				*wayStore
 			);
 			if (ret != 0) return ret;
 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -163,7 +163,6 @@ vector<string> parseBox(const string& bbox) {
  * Worker threads write the output tiles, and start in the outputProc function.
  */
 int main(int argc, char* argv[]) {
-
 	// ----	Read command-line options
 	vector<string> inputFiles;
 	string luaFile;

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -492,7 +492,7 @@ int main(int argc, char* argv[]) {
 		// The clipping bbox check is expensive - as an optimization, compute the set of
 		// z6 tiles that are wholly covered by the clipping box. Membership in this
 		// set is quick to test.
-		std::set<TileCoordinates> coveredZ6Tiles;
+		TileCoordinatesSet coveredZ6Tiles(6);
 		if (hasClippingBox) {
 			for (int x = 0; x < 1 << 6; x++) {
 				for (int y = 0; y < 1 << 6; y++) {
@@ -500,7 +500,7 @@ int main(int argc, char* argv[]) {
 								TileBbox(TileCoordinates(x, y), 6, false, false).getTileBox(),
 								clippingBox
 							))
-						coveredZ6Tiles.insert(TileCoordinates(x, y));
+						coveredZ6Tiles.set(x, y);
 				}
 			}
 		}
@@ -533,7 +533,7 @@ int main(int argc, char* argv[]) {
 						if (zoom >= 6) {
 							TileCoordinate z6x = x / (1 << (zoom - 6));
 							TileCoordinate z6y = y / (1 << (zoom - 6));
-							isInAWhollyCoveredZ6Tile = coveredZ6Tiles.find(TileCoordinates(z6x, z6y)) != coveredZ6Tiles.end();
+							isInAWhollyCoveredZ6Tile = coveredZ6Tiles.test(z6x, z6y);
 						}
 
 						if(!isInAWhollyCoveredZ6Tile && !boost::geometry::intersects(TileBbox(TileCoordinates(x, y), zoom, false, false).getTileBox(), clippingBox)) 

--- a/src/way_stores.cpp
+++ b/src/way_stores.cpp
@@ -14,6 +14,14 @@ void BinarySearchWayStore::reopen() {
 	mLatpLonLists = std::make_unique<map_t>();
 }
 
+bool BinarySearchWayStore::contains(size_t shard, WayID id) const {
+	auto iter = std::lower_bound(mLatpLonLists->begin(), mLatpLonLists->end(), id, [](auto const &e, auto id) { 
+		return e.first < id; 
+	});
+
+	return !(iter == mLatpLonLists->end() || iter->first != id);
+}
+
 std::vector<LatpLon> BinarySearchWayStore::at(WayID wayid) const {
 	std::lock_guard<std::mutex> lock(mutex);
 	

--- a/src/way_stores.cpp
+++ b/src/way_stores.cpp
@@ -47,7 +47,7 @@ void BinarySearchWayStore::insertLatpLons(std::vector<WayStore::ll_element_t> &n
 	std::copy(std::make_move_iterator(newWays.begin()), std::make_move_iterator(newWays.end()), mLatpLonLists->begin() + i); 
 }
 
-const void BinarySearchWayStore::insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) {
+void BinarySearchWayStore::insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) {
 	throw std::runtime_error("BinarySearchWayStore does not support insertNodes");
 }
 

--- a/test/append_vector.test.cpp
+++ b/test/append_vector.test.cpp
@@ -6,8 +6,11 @@
 using namespace AppendVectorNS;
 
 MU_TEST(test_append_vector) {
-	AppendVector<uint32_t> vec;
+	AppendVector<int32_t> vec;
+	AppendVector<int32_t> vec2;
 	mu_check(vec.size() == 0);
+	mu_check(vec.begin() == vec.end());
+	mu_check(vec.begin() != vec2.begin());
 
 	for (int i = 0; i < 10000; i++) {
 		vec.push_back(i);
@@ -16,7 +19,7 @@ MU_TEST(test_append_vector) {
 
 	mu_check(vec[25] == 25);
 
-	const AppendVector<uint32_t>::Iterator& it = vec.begin();
+	const AppendVector<int32_t>::Iterator& it = vec.begin();
 	mu_check(*it == 0);
 	mu_check(*(it + 1) == 1);
 	mu_check(*(it + 2) == 2);
@@ -52,7 +55,7 @@ MU_TEST(test_append_vector) {
 		vec.begin(),
 		vec.end(),
 		123,
-		[](const uint32_t& a, const uint32_t& toFind) {
+		[](const int32_t& a, const int32_t& toFind) {
 			return a < toFind;
 		}
 	);
@@ -64,13 +67,23 @@ MU_TEST(test_append_vector) {
 		vec.begin(),
 		vec.end(),
 		123123,
-		[](const uint32_t& a, const uint32_t& toFind) {
+		[](const int32_t& a, const int32_t& toFind) {
 			return a < toFind;
 		}
 	);
 
 	mu_check(iter == vec.end());
 
+	iter = std::lower_bound(
+		vec.begin(),
+		vec.end(),
+		-2,
+		[](const int32_t& a, const int32_t& toFind) {
+			return a < toFind;
+		}
+	);
+
+	mu_check(iter == vec.begin());
 }
 
 MU_TEST_SUITE(test_suite_append_vector) {

--- a/test/append_vector.test.cpp
+++ b/test/append_vector.test.cpp
@@ -1,0 +1,85 @@
+#include <iostream>
+#include <boost/sort/sort.hpp>
+#include "external/minunit.h"
+#include "append_vector.h"
+
+using namespace AppendVectorNS;
+
+MU_TEST(test_append_vector) {
+	AppendVector<uint32_t> vec;
+	mu_check(vec.size() == 0);
+
+	for (int i = 0; i < 10000; i++) {
+		vec.push_back(i);
+	}
+	mu_check(vec.size() == 10000);
+
+	mu_check(vec[25] == 25);
+
+	const AppendVector<uint32_t>::Iterator& it = vec.begin();
+	mu_check(*it == 0);
+	mu_check(*(it + 1) == 1);
+	mu_check(*(it + 2) == 2);
+	mu_check(*(it + 9000) == 9000);
+	mu_check(*(it + 1 - 1) == 0);
+	mu_check(*(vec.end() + -1) == 9999);
+	mu_check(*(vec.end() - 1) == 9999);
+	mu_check(*(vec.end() - 2) == 9998);
+	mu_check(*(vec.end() - 9000) == 1000);
+	mu_check(*(vec.begin() - -1) == 1);
+
+	boost::sort::block_indirect_sort(
+		vec.begin(),
+		vec.end(),
+		[](auto const &a, auto const&b) { return b < a; },
+		1
+	);
+
+	mu_check(vec[0] == 9999);
+	mu_check(vec[9999] == 0);
+
+	boost::sort::block_indirect_sort(
+		vec.begin(),
+		vec.end(),
+		[](auto const &a, auto const&b) { return a < b; },
+		1
+	);
+
+	mu_check(vec[0] == 0);
+	mu_check(vec[9999] == 9999);
+
+	auto iter = std::lower_bound(
+		vec.begin(),
+		vec.end(),
+		123,
+		[](const uint32_t& a, const uint32_t& toFind) {
+			return a < toFind;
+		}
+	);
+
+	mu_check(iter != vec.end());
+	mu_check(*iter == 123);
+
+	iter = std::lower_bound(
+		vec.begin(),
+		vec.end(),
+		123123,
+		[](const uint32_t& a, const uint32_t& toFind) {
+			return a < toFind;
+		}
+	);
+
+	mu_check(iter == vec.end());
+
+}
+
+MU_TEST_SUITE(test_suite_append_vector) {
+	MU_RUN_TEST(test_append_vector);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_append_vector);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}
+

--- a/test/attribute_store.test.cpp
+++ b/test/attribute_store.test.cpp
@@ -5,6 +5,7 @@
 
 MU_TEST(test_attribute_store) {
 	AttributeStore store;
+	store.reset();
 
 	mu_check(store.size() == 0);
 
@@ -56,11 +57,44 @@ MU_TEST(test_attribute_store) {
 	mu_check(float1 != s1Pairs.end());
 	mu_check((*float1)->hasFloatValue());
 	mu_check((*float1)->floatValue() == 42);
+}
+
+MU_TEST(test_attribute_store_reuses) {
+	AttributeStore store;
+	store.reset();
+
+	mu_check(store.size() == 0);
+
+	{
+		AttributeSet s1a;
+		store.addAttribute(s1a, "str1", std::string("someval"), 0);
+		const auto s1aIndex = store.add(s1a);
+
+		AttributeSet s1b;
+		store.addAttribute(s1b, "str1", std::string("someval"), 0);
+		const auto s1bIndex = store.add(s1b);
+
+		mu_check(s1aIndex == s1bIndex);
+	}
+
+	{
+		AttributeSet s1a;
+		store.addAttribute(s1a, "str1", std::string("this is a very long string"), 0);
+		const auto s1aIndex = store.add(s1a);
+
+		AttributeSet s1b;
+		store.addAttribute(s1b, "str1", std::string("this is a very long string"), 0);
+		const auto s1bIndex = store.add(s1b);
+
+		mu_check(s1aIndex == s1bIndex);
+	}
+
 
 }
 
 MU_TEST_SUITE(test_suite_attribute_store) {
 	MU_RUN_TEST(test_attribute_store);
+	MU_RUN_TEST(test_attribute_store_reuses);
 }
 
 int main() {

--- a/test/attribute_store.test.cpp
+++ b/test/attribute_store.test.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <algorithm>
+#include "external/minunit.h"
+#include "attribute_store.h"
+
+MU_TEST(test_attribute_store) {
+	AttributeStore store;
+
+	mu_check(store.size() == 0);
+
+	AttributeSet s1;
+	store.addAttribute(s1, "str1", std::string("someval"), 0);
+	store.addAttribute(s1, "str2", std::string("a very long string"), 0);
+	store.addAttribute(s1, "bool1", false, 0);
+	store.addAttribute(s1, "bool2", true, 0);
+	store.addAttribute(s1, "float1", (float)42.0, 0);
+
+	const auto s1Index = store.add(s1);
+
+	mu_check(store.size() == 1);
+
+	const auto s1Pairs = store.getUnsafe(s1Index);
+	mu_check(s1Pairs.size() == 5);
+
+	const auto str1 = std::find_if(s1Pairs.begin(), s1Pairs.end(), [&store](auto ap) {
+			return ap->keyIndex == store.keyStore.key2index("str1");
+	});
+	mu_check(str1 != s1Pairs.end());
+	mu_check((*str1)->hasStringValue());
+	mu_check((*str1)->stringValue() == "someval");
+
+	const auto str2 = std::find_if(s1Pairs.begin(), s1Pairs.end(), [&store](auto ap) {
+			return ap->keyIndex == store.keyStore.key2index("str2");
+	});
+	mu_check(str2 != s1Pairs.end());
+	mu_check((*str2)->hasStringValue());
+	mu_check((*str2)->stringValue() == "a very long string");
+
+	const auto bool1 = std::find_if(s1Pairs.begin(), s1Pairs.end(), [&store](auto ap) {
+			return ap->keyIndex == store.keyStore.key2index("bool1");
+	});
+	mu_check(bool1 != s1Pairs.end());
+	mu_check((*bool1)->hasBoolValue());
+	mu_check((*bool1)->boolValue() == false);
+
+	const auto bool2 = std::find_if(s1Pairs.begin(), s1Pairs.end(), [&store](auto ap) {
+			return ap->keyIndex == store.keyStore.key2index("bool2");
+	});
+	mu_check(bool2 != s1Pairs.end());
+	mu_check((*bool2)->hasBoolValue());
+	mu_check((*bool2)->boolValue() == true);
+
+	const auto float1 = std::find_if(s1Pairs.begin(), s1Pairs.end(), [&store](auto ap) {
+			return ap->keyIndex == store.keyStore.key2index("float1");
+	});
+	mu_check(float1 != s1Pairs.end());
+	mu_check((*float1)->hasFloatValue());
+	mu_check((*float1)->floatValue() == 42);
+
+}
+
+MU_TEST_SUITE(test_suite_attribute_store) {
+	MU_RUN_TEST(test_attribute_store);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_attribute_store);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}

--- a/test/attribute_store.test.cpp
+++ b/test/attribute_store.test.cpp
@@ -22,7 +22,6 @@ MU_TEST(test_attribute_store) {
 
 	const auto s1Pairs = store.getUnsafe(s1Index);
 	mu_check(s1Pairs.size() == 5);
-
 	const auto str1 = std::find_if(s1Pairs.begin(), s1Pairs.end(), [&store](auto ap) {
 			return ap->keyIndex == store.keyStore.key2index("str1");
 	});

--- a/test/deque_map.test.cpp
+++ b/test/deque_map.test.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <algorithm>
+#include "external/minunit.h"
+#include "deque_map.h"
+
+MU_TEST(test_deque_map) {
+	DequeMap<std::string> strs;
+
+	mu_check(strs.size() == 0);
+	mu_check(!strs.full());
+	mu_check(strs.find("foo") == -1);
+	mu_check(strs.add("foo") == 0);
+	mu_check(!strs.full());
+	mu_check(strs.find("foo") == 0);
+	mu_check(strs.size() == 1);
+	mu_check(strs.add("foo") == 0);
+	mu_check(strs.size() == 1);
+	mu_check(strs.add("bar") == 1);
+	mu_check(strs.size() == 2);
+	mu_check(strs.add("aardvark") == 2);
+	mu_check(strs.size() == 3);
+	mu_check(strs.add("foo") == 0);
+	mu_check(strs.add("bar") == 1);
+	mu_check(strs.add("quux") == 3);
+	mu_check(strs.size() == 4);
+
+	mu_check(strs.at(0) == "foo");
+	mu_check(strs.at(1) == "bar");
+	mu_check(strs.at(2) == "aardvark");
+	mu_check(strs.at(3) == "quux");
+
+	std::vector<std::string> rv;
+	for (std::string x : strs) {
+		rv.push_back(x);
+	}
+	mu_check(rv[0] == "aardvark");
+	mu_check(rv[1] == "bar");
+	mu_check(rv[2] == "foo");
+	mu_check(rv[3] == "quux");
+
+	DequeMap<std::string> boundedMap(1);
+	mu_check(!boundedMap.full());
+	mu_check(boundedMap.add("foo") == 0);
+	mu_check(boundedMap.add("foo") == 0);
+	mu_check(boundedMap.full());
+	mu_check(boundedMap.add("bar") == -1);
+	boundedMap.clear();
+	mu_check(!boundedMap.full());
+	mu_check(boundedMap.find("foo") == -1);
+	mu_check(boundedMap.add("bar") == 0);
+	mu_check(boundedMap.add("bar") == 0);
+	mu_check(boundedMap.full());
+}
+
+MU_TEST_SUITE(test_suite_deque_map) {
+	MU_RUN_TEST(test_deque_map);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_deque_map);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}

--- a/test/options_parser.test.cpp
+++ b/test/options_parser.test.cpp
@@ -49,6 +49,34 @@ MU_TEST(test_options_parser) {
 		mu_check(opts.inputFiles[0] == "ontario.pbf");
 		mu_check(opts.outputFile == "foo.mbtiles");
 		mu_check(opts.outputMode == OutputMode::MBTiles);
+		mu_check(opts.osm.materializeGeometries);
+		mu_check(!opts.osm.shardStores);
+	}
+
+	// --store should optimize for reduced memory
+	{
+		std::vector<std::string> args = {"--output", "foo.mbtiles", "--input", "ontario.pbf", "--store", "/tmp/store"};
+		auto opts = parse(args);
+		mu_check(opts.inputFiles.size() == 1);
+		mu_check(opts.inputFiles[0] == "ontario.pbf");
+		mu_check(opts.outputFile == "foo.mbtiles");
+		mu_check(opts.outputMode == OutputMode::MBTiles);
+		mu_check(opts.osm.storeFile == "/tmp/store");
+		mu_check(!opts.osm.materializeGeometries);
+		mu_check(opts.osm.shardStores);
+	}
+
+	// --store --fast should optimize for speed
+	{
+		std::vector<std::string> args = {"--output", "foo.mbtiles", "--input", "ontario.pbf", "--store", "/tmp/store", "--fast"};
+		auto opts = parse(args);
+		mu_check(opts.inputFiles.size() == 1);
+		mu_check(opts.inputFiles[0] == "ontario.pbf");
+		mu_check(opts.outputFile == "foo.mbtiles");
+		mu_check(opts.outputMode == OutputMode::MBTiles);
+		mu_check(opts.osm.storeFile == "/tmp/store");
+		mu_check(opts.osm.materializeGeometries);
+		mu_check(!opts.osm.shardStores);
 	}
 
 	ASSERT_THROWS("Couldn't open .json config", "--input", "foo", "--output", "bar", "--config", "nonexistent-config.json");

--- a/test/options_parser.test.cpp
+++ b/test/options_parser.test.cpp
@@ -68,12 +68,12 @@ MU_TEST(test_options_parser) {
 
 	// --store --fast should optimize for speed
 	{
-		std::vector<std::string> args = {"--output", "foo.mbtiles", "--input", "ontario.pbf", "--store", "/tmp/store", "--fast"};
+		std::vector<std::string> args = {"--output", "foo.pmtiles", "--input", "ontario.pbf", "--store", "/tmp/store", "--fast"};
 		auto opts = parse(args);
 		mu_check(opts.inputFiles.size() == 1);
 		mu_check(opts.inputFiles[0] == "ontario.pbf");
-		mu_check(opts.outputFile == "foo.mbtiles");
-		mu_check(opts.outputMode == OutputMode::MBTiles);
+		mu_check(opts.outputFile == "foo.pmtiles");
+		mu_check(opts.outputMode == OutputMode::PMTiles);
 		mu_check(opts.osm.storeFile == "/tmp/store");
 		mu_check(opts.osm.materializeGeometries);
 		mu_check(!opts.osm.shardStores);

--- a/test/options_parser.test.cpp
+++ b/test/options_parser.test.cpp
@@ -53,6 +53,19 @@ MU_TEST(test_options_parser) {
 		mu_check(!opts.osm.shardStores);
 	}
 
+	// --lazy-geometries overrides default
+	{
+		std::vector<std::string> args = {"--output", "foo.mbtiles", "--input", "ontario.pbf", "--lazy-geometries"};
+		auto opts = parse(args);
+		mu_check(opts.inputFiles.size() == 1);
+		mu_check(opts.inputFiles[0] == "ontario.pbf");
+		mu_check(opts.outputFile == "foo.mbtiles");
+		mu_check(opts.outputMode == OutputMode::MBTiles);
+		mu_check(!opts.osm.materializeGeometries);
+		mu_check(opts.osm.lazyGeometries);
+		mu_check(!opts.osm.shardStores);
+	}
+
 	// --store should optimize for reduced memory
 	{
 		std::vector<std::string> args = {"--output", "foo.mbtiles", "--input", "ontario.pbf", "--store", "/tmp/store"};
@@ -75,7 +88,7 @@ MU_TEST(test_options_parser) {
 		mu_check(opts.outputFile == "foo.pmtiles");
 		mu_check(opts.outputMode == OutputMode::PMTiles);
 		mu_check(opts.osm.storeFile == "/tmp/store");
-		mu_check(opts.osm.materializeGeometries);
+		mu_check(!opts.osm.materializeGeometries);
 		mu_check(!opts.osm.shardStores);
 	}
 

--- a/test/options_parser.test.cpp
+++ b/test/options_parser.test.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include "external/minunit.h"
+#include "options_parser.h"
+
+const char* PROGRAM_NAME = "./tilemaker";
+using namespace OptionsParser;
+
+Options parse(std::vector<std::string>& args) {
+	const char* argv[100];
+
+	argv[0] = PROGRAM_NAME;
+	for(int i = 0; i < args.size(); i++)
+		argv[1 + i] = args[i].data();
+
+	return parse(1 + args.size(), argv);
+}
+
+#define ASSERT_THROWS(MESSAGE, ...) \
+{ \
+	std::vector<std::string> args = { __VA_ARGS__ }; \
+	bool threw = false; \
+	try { \
+		auto opts = parse(args); \
+	} catch(OptionsParser::OptionException& e) { \
+		threw = std::string(e.what()).find(MESSAGE) != std::string::npos; \
+	} \
+	if (!threw) mu_check((std::string("expected exception with ") + MESSAGE).empty()); \
+}
+
+MU_TEST(test_options_parser) {
+	// No args is invalid.
+	ASSERT_THROWS("You must specify an output file");
+
+	// Output without input is invalid
+	ASSERT_THROWS("No source .osm.pbf", "--output", "foo.mbtiles");
+
+	// You can ask for --help.
+	{
+		std::vector<std::string> args = {"--help"};
+		auto opts = parse(args);
+		mu_check(opts.showHelp);
+	}
+
+	// Minimal valid is output and input
+	{
+		std::vector<std::string> args = {"--output", "foo.mbtiles", "--input", "ontario.pbf"};
+		auto opts = parse(args);
+		mu_check(opts.inputFiles.size() == 1);
+		mu_check(opts.inputFiles[0] == "ontario.pbf");
+		mu_check(opts.outputFile == "foo.mbtiles");
+		mu_check(opts.outputMode == OutputMode::MBTiles);
+	}
+
+	ASSERT_THROWS("Couldn't open .json config", "--input", "foo", "--output", "bar", "--config", "nonexistent-config.json");
+	ASSERT_THROWS("Couldn't open .lua script", "--input", "foo", "--output", "bar", "--process", "nonexistent-script.lua");
+}
+
+MU_TEST_SUITE(test_suite_options_parser) {
+	MU_RUN_TEST(test_options_parser);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_options_parser);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}

--- a/test/pooled_string.test.cpp
+++ b/test/pooled_string.test.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include "external/minunit.h"
+#include "pooled_string.h"
+
+MU_TEST(test_pooled_string) {
+	mu_check(PooledString("").size() == 0);
+	mu_check(PooledString("").toString() == "");
+	mu_check(PooledString("f").size() == 1);
+	mu_check(PooledString("f").toString() == "f");
+	mu_check(PooledString("hi").size() == 2);
+	mu_check(PooledString("f") == PooledString("f"));
+	mu_check(PooledString("f") != PooledString("g"));
+
+	mu_check(PooledString("this is more than fifteen bytes").size() == 31);
+	mu_check(PooledString("this is more than fifteen bytes") != PooledString("f"));
+
+	PooledString big("this is also a really long string");
+	mu_check(big == big);
+	mu_check(big.toString() == "this is also a really long string");
+
+	PooledString big2("this is also a quite long string");
+	mu_check(big != big2);
+	mu_check(big.toString() != big2.toString());
+}
+
+MU_TEST_SUITE(test_suite_pooled_string) {
+	MU_RUN_TEST(test_pooled_string);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_pooled_string);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}

--- a/test/pooled_string.test.cpp
+++ b/test/pooled_string.test.cpp
@@ -21,6 +21,27 @@ MU_TEST(test_pooled_string) {
 	PooledString big2("this is also a quite long string");
 	mu_check(big != big2);
 	mu_check(big.toString() != big2.toString());
+
+	std::string shortString("short");
+	std::string longString("this is a very long string");
+
+	PooledString stdShortString(&shortString);
+	mu_check(stdShortString.size() == 5);
+	mu_check(stdShortString.toString() == "short");
+
+	PooledString stdLongString(&longString);
+	mu_check(stdLongString.size() == 26);
+	mu_check(stdLongString.toString() == "this is a very long string");
+
+	// PooledStrings that are backed by std::string have the usual
+	// == semantics.
+	mu_check(stdShortString == PooledString("short"));
+	mu_check(PooledString("short") == stdShortString);
+
+	mu_check(stdLongString == PooledString("this is a very long string"));
+	mu_check(PooledString("this is a very long string") == stdLongString);
+
+	mu_check(stdShortString != stdLongString);
 }
 
 MU_TEST_SUITE(test_suite_pooled_string) {

--- a/test/sorted_node_store.test.cpp
+++ b/test/sorted_node_store.test.cpp
@@ -3,17 +3,23 @@
 #include "sorted_node_store.h"
 
 MU_TEST(test_sorted_node_store) {
-	SortedNodeStore sns(true);
-	mu_check(sns.size() == 0);
+	SortedNodeStore s1(true), s2(true);
+	mu_check(s1.size() == 0);
+	mu_check(s2.size() == 0);
 
-	sns.batchStart();
+	s1.batchStart();
+	s2.batchStart();
 
-	sns.insert({ {1, {2, 3 } } });
+	s1.insert({ {1, {2, 3 } } });
+	s2.insert({ {2, {3, 4 } } });
 
-	sns.finalize(1);
+	s1.finalize(1);
+	s2.finalize(1);
 
-	mu_check(sns.size() == 1);
-
+	mu_check(s1.size() == 1);
+	mu_check(s1.at(1) == LatpLon({2, 3}));
+	mu_check(s2.size() == 1);
+	mu_check(s2.at(2) == LatpLon({3, 4}));
 }
 
 MU_TEST_SUITE(test_suite_sorted_node_store) {

--- a/test/sorted_node_store.test.cpp
+++ b/test/sorted_node_store.test.cpp
@@ -3,23 +3,31 @@
 #include "sorted_node_store.h"
 
 MU_TEST(test_sorted_node_store) {
-	SortedNodeStore s1(true), s2(true);
-	mu_check(s1.size() == 0);
-	mu_check(s2.size() == 0);
+	bool compressed = true;
 
-	s1.batchStart();
-	s2.batchStart();
+	for (int i = 0; i < 2; i++) {
+		compressed = !compressed;
+		SortedNodeStore s1(compressed), s2(compressed);
+		mu_check(s1.size() == 0);
+		mu_check(s2.size() == 0);
 
-	s1.insert({ {1, {2, 3 } } });
-	s2.insert({ {2, {3, 4 } } });
+		s1.batchStart();
+		s2.batchStart();
 
-	s1.finalize(1);
-	s2.finalize(1);
+		s1.insert({ {1, {2, 3 } } });
+		s2.insert({ {2, {3, 4 } } });
 
-	mu_check(s1.size() == 1);
-	mu_check(s1.at(1) == LatpLon({2, 3}));
-	mu_check(s2.size() == 1);
-	mu_check(s2.at(2) == LatpLon({3, 4}));
+		s1.finalize(1);
+		s2.finalize(1);
+
+		mu_check(s1.size() == 1);
+		mu_check(s1.at(1) == LatpLon({2, 3}));
+		mu_check(s1.contains(0, 1));
+		mu_check(!s1.contains(0, 2));
+		mu_check(!s1.contains(0, 1ull << 34));
+		mu_check(s2.size() == 1);
+		mu_check(s2.at(2) == LatpLon({3, 4}));
+	}
 }
 
 MU_TEST_SUITE(test_suite_sorted_node_store) {

--- a/test/sorted_node_store.test.cpp
+++ b/test/sorted_node_store.test.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+#include "external/minunit.h"
+#include "sorted_node_store.h"
+
+MU_TEST(test_sorted_node_store) {
+	SortedNodeStore sns(true);
+	mu_check(sns.size() == 0);
+
+	sns.batchStart();
+
+	sns.insert({ {1, {2, 3 } } });
+
+	sns.finalize(1);
+
+	mu_check(sns.size() == 1);
+
+}
+
+MU_TEST_SUITE(test_suite_sorted_node_store) {
+	MU_RUN_TEST(test_sorted_node_store);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_sorted_node_store);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}

--- a/test/sorted_way_store.test.cpp
+++ b/test/sorted_way_store.test.cpp
@@ -13,6 +13,10 @@ class TestNodeStore : public NodeStore {
 		return { (int32_t)id, -(int32_t)id };
 	}
 	void insert(const std::vector<std::pair<NodeID, LatpLon>>& elements) override {}
+
+	bool contains(size_t shard, NodeID id) const override { return true; }
+	size_t shard() const override { return 0; }
+	size_t shards() const override { return 1; }
 };
 
 void roundtripWay(const std::vector<NodeID>& way) {

--- a/test/sorted_way_store.test.cpp
+++ b/test/sorted_way_store.test.cpp
@@ -74,6 +74,22 @@ MU_TEST(test_encode_way) {
 	}
 }
 
+MU_TEST(test_multiple_stores) {
+	TestNodeStore ns;
+	SortedWayStore s1(true, ns), s2(true, ns);
+	s1.batchStart();
+	s2.batchStart();
+
+	s1.insertNodes({{ 1, { 1 } }});
+	s2.insertNodes({{ 2, { 2 } }});
+
+	s1.finalize(1);
+	s2.finalize(1);
+
+	mu_check(s1.size() == 1);
+	mu_check(s2.size() == 1);
+}
+
 MU_TEST(test_way_store) {
 	TestNodeStore ns;
 	SortedWayStore sws(true, ns);
@@ -182,6 +198,7 @@ MU_TEST(test_populate_mask) {
 
 MU_TEST_SUITE(test_suite_sorted_way_store) {
 	MU_RUN_TEST(test_encode_way);
+	MU_RUN_TEST(test_multiple_stores);
 	MU_RUN_TEST(test_way_store);
 }
 


### PR DESCRIPTION
This PR lets Tilemaker build the planet on smaller machines.

On a Vultr 16-core, 32GB, 500GB SSD machine:

```
$ time tilemaker --store /tmp/store --input planet-latest.osm.pbf --output tiles.mbtiles --shard-stores
real	195m7.819s
user	2473m52.322s
sys	73m13.116s
```

Runtime for non-memory constrained boxes isn't affected, e.g. on a Hetzner 48-core, 192 GB machine:

```
$ time tilemaker --store /tmp/store --input planet-latest.osm.pbf --output tiles.mbtiles
real	65m20.082s
user	2570m33.530s
sys	41m15.420s
```

On a $ basis, if you're renting a machine to do the work, it's cheaper to use a bigger box. But for folks who need to use what they already have, this may be a useful PR.

The changes are a mix of using less memory, spilling more things to disk, and thrashing less when things are backed by disk.

Using less memory:

- ~1GB: extend `--materialize-geometries` to points -- points from `Layer(...)` can be looked up in the NodeStore. `LayerAsCentroid(...)` still needs the point store
- ~1.5GB: rejig `AttributePair` 
  - eliminate padding
  - use a union for the string and float values
  - replace `std::string` with `PooledString`
- ~4GB: use a custom container (`AppendVector`) rather than a vector of vectors for storing `OutputObject`s
  - vector's grow-by-doubling behaviour results in some wasted memory. I initially tried to replace it with a deque, but deque's 512-byte allocation size results in poor locality on the disk

Spill more things to disk:

- ~12GB: the `OutputObject`s now spill to disk when `--store` is used

Thrash less:

- materialize the list of low-zoom objects, so that we only scan the list of 1.3B output objects a single time, not 1,365 times
- compute the set of tiles with objects simultaneously for all zooms, so that we only scan the list of 1.3B output objects a single time, not 15 times
- when `--shard-stores` is set, split the `NodeStore` and `WayStore` into 7 stores that cover different parts of the globe
  - the idea is to have roughly equal sized splits in terms of nodes/ways/relations, I started with a best guess than iterated a couple of times based on memory usage reported by the stores: https://geojson.io/#id=gist:cldellow/00d9d9d627494c522c31fc5a63909749
  - in this mode, `ReadPhase::Ways` will run 7 times, populating a single `WayStore` on each pass. Only those ways whose first node is in the corresponding `NodeStore` get populated. Because nodes in ways generally are geographically near each other, we'll mostly be accessing a single `NodeStore` to process the way. That `NodeStore` fits into memory for the duration of the pass, avoiding disk I/O.
  - `ReadPhase::Relations` behaves similarly, using the ID of the first way to decide whether to process the relation.
  - when writing, since we group by z6 tile, we'll have long runs that use the same stores, which means we'll only need to do new disk I/O when the writer starts a new region

Potential future improvements:

- We still need ~14GB of RAM to read everything. It might be worthwhile to try to account for all of it, 14GB feels excessive. Possible culprits: protobuf reader (~160MB/core, I think), attribute store and friends, the r-tree index for large items.
- The sharding is tuned for the planet on a 32GB box. Being able to dynamically pick the shards based on the bounding box and actual memory available could be useful.
- The runtime benefit of multiple passes for relations is thwarted a bit by straggler relations that take an abnormally long time to process (Antarctica, Hudson Bay, etc). If we could cheaply identify the blocks that have such relations, we could start processing them earlier in the hopes that they'd be done by the time we were done the other relations.
  - ...actually, maybe it's the boost thread pool more generally? You see a similar effect when reading ways. I don't know how it works under the covers - maybe threads grab a batch of tasks at once, and you end up with a single thread hoarding some work items while the rest of the threads starve. If that's the case, a task-stealing approach might get better utilization towards the end of the work queue.

These are mostly smaller issues that can be happily ignored forever, just wanted to write them down so I can forget about them.