### PR TITLE
PMTiles support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ file(GLOB tilemaker_src_files
 	src/osm_store.cpp
 	src/output_object.cpp
 	src/pbf_blocks.cpp
+	src/pmtiles.cpp
 	src/read_pbf.cpp
 	src/read_shp.cpp
 	src/shared_data.cpp

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ tilemaker: \
 	src/osm_store.o \
 	src/output_object.o \
 	src/pbf_blocks.o \
+	src/pmtiles.o \
 	src/read_pbf.o \
 	src/read_shp.o \
 	src/shared_data.o \

--- a/README.md
+++ b/README.md
@@ -99,4 +99,5 @@ Licenses of third-party libraries:
 - sqlite_modern_cpp (Amin Roosta) is licensed under MIT
 - [kaguya](https://github.com/satoren/kaguya) is licensed under the Boost Software Licence
 - [libpopcnt](https://github.com/kimwalisch/libpopcnt) is licensed under BSD 2-clause
+- [pmtiles](https://github.com/protomaps/PMTiles) is licensed under BSD 3-clause
 - [streamvbyte](https://github.com/lemire/streamvbyte) is licensed under Apache 2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Tilemaker
+# tilemaker
 
-Tilemaker creates vector tiles (in Mapbox Vector Tile format) from an .osm.pbf planet extract, as typically downloaded from providers like Geofabrik. It aims to be 'stack-free': you need no database and there is only one executable to install.
+tilemaker creates vector tiles (in Mapbox Vector Tile format) from an .osm.pbf planet extract, as typically downloaded from providers like Geofabrik. It aims to be 'stack-free': you need no database and there is only one executable to install.
 
-Vector tiles are used by many in-browser/app renderers, and can also power server-side raster rendering. They enable on-the-fly style changes and greater interactivity, while imposing less of a storage burden. You can output them to individual files, or to a SQLite (.mbtiles) database.
+Vector tiles are used by many in-browser/app renderers, and can also power server-side raster rendering. They enable on-the-fly style changes and greater interactivity, while imposing less of a storage burden. tilemaker can output them to individual files, or to .mbtiles or .pmtiles tile containers.
 
 See an example of a vector tile map produced by tilemaker at [tilemaker.org](https://tilemaker.org).
 
@@ -10,7 +10,7 @@ See an example of a vector tile map produced by tilemaker at [tilemaker.org](htt
 
 ## Installing
 
-Tilemaker is written in C++14. The chief dependencies are:
+tilemaker is written in C++14. The chief dependencies are:
 
 * Google Protocol Buffers
 * Boost (latest version advised, 1.66 minimum)
@@ -30,7 +30,7 @@ For detailed installation instructions for your operating system, see [INSTALL.m
 
 ## Out-of-the-box setup
 
-Tilemaker comes with configuration files compatible with the popular [OpenMapTiles](https://openmaptiles.org) schema, and a demonstration map server. You'll run tilemaker to make vector tiles from your `.osm.pbf` source data. To create the tiles, run this from the tilemaker directory:
+tilemaker comes with configuration files compatible with the popular [OpenMapTiles](https://openmaptiles.org) schema, and a demonstration map server. You'll run tilemaker to make vector tiles from your `.osm.pbf` source data. To create the tiles, run this from the tilemaker directory:
 
     tilemaker --input /path/to/your/input.osm.pbf \
         --output /path/to/your/output.mbtiles
@@ -88,7 +88,7 @@ Formatting: braces and indents as shown, hard tabs (4sp). (Yes, I know.) Please 
 
 ## Copyright
 
-Tilemaker is maintained by Richard Fairhurst and supported by [many contributors](https://github.com/systemed/tilemaker/graphs/contributors).
+tilemaker is maintained by Richard Fairhurst and supported by [many contributors](https://github.com/systemed/tilemaker/graphs/contributors).
 
 Copyright tilemaker contributors, 2015-2023.
 

--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -19,9 +19,10 @@ The `--config` and `--process` arguments are the paths of your JSON config file 
 processing script. These are described in CONFIGURATION.md. Here we're using the ready-made 
 OpenMapTiles-compatible script.
 
-You'll usually want to write to an .mbtiles file (which, under the hood, is an sqlite database 
-containing the vector tiles). However, you can write tiles directly to the filesystem if you 
-like, by specifying a directory path for `--output`.
+You can output to an .mbtiles or .pmtiles file. mbtiles is widely supported and easy to serve 
+(it's an sqlite database under the hood). [pmtiles](https://github.com/protomaps/PMTiles) is 
+a newer format optimised for serving over the cloud. You can also write tiles directly to the 
+filesystem by specifying a directory path for `--output`.
 
 This is all you need to know, but if you want to reduce memory requirements, read on.
 

--- a/include/external/pmtiles.hpp
+++ b/include/external/pmtiles.hpp
@@ -1,0 +1,644 @@
+#ifndef PMTILES_HPP
+#define PMTILES_HPP
+
+#include <cstdint>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <tuple>
+#include <functional>
+#include <algorithm>
+#include <limits> // for std::numeric_limits<>
+
+namespace pmtiles {
+
+const uint8_t TILETYPE_UNKNOWN = 0x0;
+const uint8_t TILETYPE_MVT = 0x1;
+const uint8_t TILETYPE_PNG = 0x2;
+const uint8_t TILETYPE_JPEG = 0x3;
+const uint8_t TILETYPE_WEBP = 0x4;
+const uint8_t TILETYPE_AVIF = 0x5;
+
+const uint8_t COMPRESSION_UNKNOWN = 0x0;
+const uint8_t COMPRESSION_NONE = 0x1;
+const uint8_t COMPRESSION_GZIP = 0x2;
+const uint8_t COMPRESSION_BROTLI = 0x3;
+const uint8_t COMPRESSION_ZSTD = 0x4;
+
+#ifdef PMTILES_MSB
+template<class T>
+inline void swap_byte_order_if_msb(T* ptr) {
+    unsigned char* ptrBytes = reinterpret_cast<unsigned char*>(ptr);
+    for (size_t i = 0; i < sizeof(T)/2; ++i) {
+        std::swap(ptrBytes[i], ptrBytes[sizeof(T)-1-i]);
+    }
+}
+#else
+template<class T>
+inline void swap_byte_order_if_msb(T* /*ptr*/)
+{
+}
+#endif
+
+template<class T>
+inline void copy_to_lsb(std::stringstream& ss, T val) {
+    swap_byte_order_if_msb(&val);
+    ss.write(reinterpret_cast<char*>(&val), sizeof(T));
+}
+
+template<>
+inline void copy_to_lsb<uint8_t>(std::stringstream& ss, uint8_t val) {
+    ss.write(reinterpret_cast<char*>(&val), 1);
+}
+
+struct headerv3 {
+	uint64_t root_dir_offset;
+	uint64_t root_dir_bytes;
+	uint64_t json_metadata_offset;
+	uint64_t json_metadata_bytes;
+	uint64_t leaf_dirs_offset;
+	uint64_t leaf_dirs_bytes;
+	uint64_t tile_data_offset;
+	uint64_t tile_data_bytes;
+	uint64_t addressed_tiles_count;
+	uint64_t tile_entries_count;
+	uint64_t tile_contents_count;
+	bool clustered;
+	uint8_t internal_compression;
+	uint8_t tile_compression;
+	uint8_t tile_type;
+	uint8_t min_zoom;
+	uint8_t max_zoom;
+	int32_t min_lon_e7;
+	int32_t min_lat_e7;
+	int32_t max_lon_e7;
+	int32_t max_lat_e7;
+	uint8_t center_zoom;
+	int32_t center_lon_e7;
+	int32_t center_lat_e7;
+
+	// WARNING: this is limited to little-endian
+	std::string serialize() {
+		std::stringstream ss;
+		ss << "PMTiles";
+		uint8_t version = 3;
+		copy_to_lsb(ss, version);
+		copy_to_lsb(ss, root_dir_offset);
+		copy_to_lsb(ss, root_dir_bytes);
+		copy_to_lsb(ss, json_metadata_offset);
+		copy_to_lsb(ss, json_metadata_bytes);
+		copy_to_lsb(ss, leaf_dirs_offset);
+		copy_to_lsb(ss, leaf_dirs_bytes);
+		copy_to_lsb(ss, tile_data_offset);
+		copy_to_lsb(ss, tile_data_bytes);
+		copy_to_lsb(ss, addressed_tiles_count);
+		copy_to_lsb(ss, tile_entries_count);
+		copy_to_lsb(ss, tile_contents_count);
+
+		uint8_t clustered_val = 0x0;
+		if (clustered) {
+			clustered_val = 0x1;
+		}
+
+		copy_to_lsb(ss, clustered_val);
+		copy_to_lsb(ss, internal_compression);
+		copy_to_lsb(ss, tile_compression);
+		copy_to_lsb(ss, tile_type);
+		copy_to_lsb(ss, min_zoom);
+		copy_to_lsb(ss, max_zoom);
+		copy_to_lsb(ss, min_lon_e7);
+		copy_to_lsb(ss, min_lat_e7);
+		copy_to_lsb(ss, max_lon_e7);
+		copy_to_lsb(ss, max_lat_e7);
+		copy_to_lsb(ss, center_zoom);
+		copy_to_lsb(ss, center_lon_e7);
+		copy_to_lsb(ss, center_lat_e7);
+
+		return ss.str();
+	}
+};
+
+struct pmtiles_magic_number_exception : std::exception {
+	const char *what() const noexcept override {
+		return "pmtiles magic number exception";
+	}
+};
+
+struct pmtiles_version_exception : std::exception {
+	const char *what() const noexcept override {
+		return "pmtiles version: must be 3";
+	}
+};
+
+template<class T>
+inline void copy_from_lsb(T* ptr, const std::string &s, size_t offset) {
+    s.copy(reinterpret_cast<char *>(ptr), sizeof(T), offset);
+	swap_byte_order_if_msb(ptr);
+}
+
+inline headerv3 deserialize_header(const std::string &s) {
+	if (s.substr(0, 7) != "PMTiles") {
+		throw pmtiles_magic_number_exception{};
+	}
+	if (s.size() != 127 || s[7] != 0x3) {
+		throw pmtiles_version_exception{};
+	}
+	headerv3 h;
+	copy_from_lsb(&h.root_dir_offset, s, 8);
+	copy_from_lsb(&h.root_dir_bytes, s, 16);
+	copy_from_lsb(&h.json_metadata_offset, s, 24);
+	copy_from_lsb(&h.json_metadata_bytes, s, 32);
+	copy_from_lsb(&h.leaf_dirs_offset, s, 40);
+	copy_from_lsb(&h.leaf_dirs_bytes, s, 48);
+	copy_from_lsb(&h.tile_data_offset, s, 56);
+	copy_from_lsb(&h.tile_data_bytes, s, 64);
+	copy_from_lsb(&h.addressed_tiles_count, s, 72);
+	copy_from_lsb(&h.tile_entries_count, s, 80);
+	copy_from_lsb(&h.tile_contents_count, s, 88);
+	if (s[96] == 0x1) {
+		h.clustered = true;
+	} else {
+		h.clustered = false;
+	}
+	h.internal_compression = s[97];
+	h.tile_compression = s[98];
+	h.tile_type = s[99];
+	h.min_zoom = s[100];
+	h.max_zoom = s[101];
+	copy_from_lsb(&h.min_lon_e7, s, 102);
+	copy_from_lsb(&h.min_lat_e7, s, 106);
+	copy_from_lsb(&h.max_lon_e7, s, 110);
+	copy_from_lsb(&h.max_lat_e7, s, 114);
+	h.center_zoom = s[118];
+	copy_from_lsb(&h.center_lon_e7, s, 119);
+	copy_from_lsb(&h.center_lat_e7, s, 123);
+	return h;
+}
+
+struct zxy {
+	uint8_t z;
+	uint32_t x;
+	uint32_t y;
+
+	zxy(uint8_t _z, int _x, int _y)
+	    : z(_z), x(_x), y(_y) {
+	}
+};
+
+struct entryv3 {
+	uint64_t tile_id;
+	uint64_t offset;
+	uint32_t length;
+	uint32_t run_length;
+
+	entryv3()
+	    : tile_id(0), offset(0), length(0), run_length(0) {
+	}
+
+	entryv3(uint64_t _tile_id, uint64_t _offset, uint32_t _length, uint32_t _run_length)
+	    : tile_id(_tile_id), offset(_offset), length(_length), run_length(_run_length) {
+	}
+};
+
+struct {
+	bool operator()(entryv3 a, entryv3 b) const {
+		return a.tile_id < b.tile_id;
+	}
+} entryv3_cmp;
+
+struct entry_zxy {
+	uint8_t z;
+	uint32_t x;
+	uint32_t y;
+	uint64_t offset;
+	uint32_t length;
+
+	entry_zxy(uint8_t _z, uint32_t _x, uint32_t _y, uint64_t _offset, uint32_t _length)
+	    : z(_z), x(_x), y(_y), offset(_offset), length(_length) {
+	}
+};
+
+struct varint_too_long_exception : std::exception {
+	const char *what() const noexcept override {
+		return "varint too long exception";
+	}
+};
+
+struct end_of_buffer_exception : std::exception {
+	const char *what() const noexcept override {
+		return "end of buffer exception";
+	}
+};
+
+namespace {
+constexpr const int8_t max_varint_length = sizeof(uint64_t) * 8 / 7 + 1;
+
+// from https://github.com/mapbox/protozero/blob/master/include/protozero/varint.hpp
+uint64_t decode_varint_impl(const char **data, const char *end) {
+	const auto *begin = reinterpret_cast<const int8_t *>(*data);
+	const auto *iend = reinterpret_cast<const int8_t *>(end);
+	const int8_t *p = begin;
+	uint64_t val = 0;
+
+	if (iend - begin >= max_varint_length) {  // fast path
+		do {
+			int64_t b = *p++;
+			val = ((uint64_t(b) & 0x7fU));
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 7U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 14U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 21U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 28U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 35U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 42U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 49U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x7fU) << 56U);
+			if (b >= 0) {
+				break;
+			}
+			b = *p++;
+			val |= ((uint64_t(b) & 0x01U) << 63U);
+			if (b >= 0) {
+				break;
+			}
+			throw varint_too_long_exception{};
+		} while (false);
+	} else {
+		unsigned int shift = 0;
+		while (p != iend && *p < 0) {
+			val |= (uint64_t(*p++) & 0x7fU) << shift;
+			shift += 7;
+		}
+		if (p == iend) {
+			throw end_of_buffer_exception{};
+		}
+		val |= uint64_t(*p++) << shift;
+	}
+
+	*data = reinterpret_cast<const char *>(p);
+	return val;
+}
+
+uint64_t decode_varint(const char **data, const char *end) {
+	// If this is a one-byte varint, decode it here.
+	if (end != *data && ((static_cast<uint64_t>(**data) & 0x80U) == 0)) {
+		const auto val = static_cast<uint64_t>(**data);
+		++(*data);
+		return val;
+	}
+	// If this varint is more than one byte, defer to complete implementation.
+	return decode_varint_impl(data, end);
+}
+
+void rotate(int64_t n, int64_t &x, int64_t &y, int64_t rx, int64_t ry) {
+	if (ry == 0) {
+		if (rx == 1) {
+			x = n - 1 - x;
+			y = n - 1 - y;
+		}
+		int64_t t = x;
+		x = y;
+		y = t;
+	}
+}
+
+zxy t_on_level(uint8_t z, uint64_t pos) {
+	int64_t n = 1LL << z;
+	int64_t rx, ry, s, t = pos;
+	int64_t tx = 0;
+	int64_t ty = 0;
+
+	for (s = 1; s < n; s *= 2) {
+		rx = 1LL & (t / 2);
+		ry = 1LL & (t ^ rx);
+		rotate(s, tx, ty, rx, ry);
+		tx += s * rx;
+		ty += s * ry;
+		t /= 4;
+	}
+	return zxy(z, static_cast<int>(tx), static_cast<int>(ty));
+}
+
+int write_varint(std::back_insert_iterator<std::string> data, uint64_t value) {
+	int n = 1;
+
+	while (value >= 0x80U) {
+		*data++ = char((value & 0x7fU) | 0x80U);
+		value >>= 7U;
+		++n;
+	}
+	*data = char(value);
+
+	return n;
+}
+
+// TMS order
+struct {
+	bool operator()(entry_zxy a, entry_zxy b) const {
+		if (a.z != b.z) {
+			return a.z < b.z;
+		}
+		if (a.x != b.x) {
+			return a.x < b.x;
+		}
+		return a.y > b.y;
+	}
+} colmajor_cmp;
+
+// use a 0 length entry as a null value.
+entryv3 find_tile(const std::vector<entryv3> &entries, uint64_t tile_id) {
+	int m = 0;
+	int n = static_cast<int>(entries.size()) - 1;
+	while (m <= n) {
+		int k = (n + m) >> 1;
+		if (tile_id > entries[k].tile_id) {
+			m = k + 1;
+		} else if (tile_id < entries[k].tile_id) {
+			n = k - 1;
+		} else {
+			return entries[k];
+		}
+	}
+
+	if (n >= 0) {
+		if (entries[n].run_length == 0) {
+			return entries[n];
+		}
+		if (tile_id - entries[n].tile_id < entries[n].run_length) {
+			return entries[n];
+		}
+	}
+
+	return entryv3{0, 0, 0, 0};
+}
+
+}  // end anonymous namespace
+
+inline zxy tileid_to_zxy(uint64_t tileid) {
+	uint64_t acc = 0;
+	for (uint8_t t_z = 0; t_z < 32; t_z++) {
+		uint64_t num_tiles = (1LL << t_z) * (1LL << t_z);
+		if (acc + num_tiles > tileid) {
+			return t_on_level(t_z, tileid - acc);
+		}
+		acc += num_tiles;
+	}
+	throw std::overflow_error("tile zoom exceeds 64-bit limit");
+}
+
+inline uint64_t zxy_to_tileid(uint8_t z, uint32_t x, uint32_t y) {
+	if (z > 31) {
+		throw std::overflow_error("tile zoom exceeds 64-bit limit");
+	}
+	if (x > (1U << z) - 1U || y > (1U << z) - 1U) {
+		throw std::overflow_error("tile x/y outside zoom level bounds");
+	}
+	uint64_t acc = 0;
+	for (uint8_t t_z = 0; t_z < z; t_z++) acc += (1LL << t_z) * (1LL << t_z);
+	int64_t n = 1LL << z;
+	int64_t rx, ry, s, d = 0;
+	int64_t tx = x;
+	int64_t ty = y;
+	for (s = n / 2; s > 0; s /= 2) {
+		rx = (tx & s) > 0;
+		ry = (ty & s) > 0;
+		d += s * s * ((3LL * rx) ^ ry);
+		rotate(s, tx, ty, rx, ry);
+	}
+	return acc + d;
+}
+
+// returns an uncompressed byte buffer
+inline std::string serialize_directory(const std::vector<entryv3> &entries) {
+	std::string data;
+
+	write_varint(std::back_inserter(data), entries.size());
+
+	uint64_t last_id = 0;
+	for (auto const &entry : entries) {
+		write_varint(std::back_inserter(data), entry.tile_id - last_id);
+		last_id = entry.tile_id;
+	}
+
+	for (auto const &entry : entries) {
+		write_varint(std::back_inserter(data), entry.run_length);
+	}
+
+	for (auto const &entry : entries) {
+		write_varint(std::back_inserter(data), entry.length);
+	}
+
+	for (size_t i = 0; i < entries.size(); i++) {
+		if (i > 0 && entries[i].offset == entries[i - 1].offset + entries[i - 1].length) {
+			write_varint(std::back_inserter(data), 0);
+		} else {
+			write_varint(std::back_inserter(data), entries[i].offset + 1);
+		}
+	}
+
+	return data;
+}
+
+struct malformed_directory_exception : std::exception {
+	const char *what() const noexcept override {
+		return "malformed directory exception";
+	}
+};
+
+// takes an uncompressed byte buffer
+inline std::vector<entryv3> deserialize_directory(const std::string &decompressed) {
+	const char *t = decompressed.data();
+	const char *end = t + decompressed.size();
+
+	const uint64_t num_entries_64bit = decode_varint(&t, end);
+	// Sanity check to avoid excessive memory allocation attempt:
+	// each directory entry takes at least 4 bytes
+	if (num_entries_64bit / 4U > decompressed.size()) {
+		throw malformed_directory_exception();
+	}
+	const size_t num_entries = static_cast<size_t>(num_entries_64bit);
+
+	std::vector<entryv3> result;
+	result.resize(num_entries);
+
+	uint64_t last_id = 0;
+	for (size_t i = 0; i < num_entries; i++) {
+		const uint64_t val = decode_varint(&t, end);
+		if (val > std::numeric_limits<uint64_t>::max() - last_id) {
+			throw malformed_directory_exception();
+		}
+		const uint64_t tile_id = last_id + val;
+		result[i].tile_id = tile_id;
+		last_id = tile_id;
+	}
+
+	for (size_t i = 0; i < num_entries; i++) {
+		const uint64_t val = decode_varint(&t, end);
+		if (val > std::numeric_limits<uint32_t>::max()) {
+			throw malformed_directory_exception();
+		}
+		result[i].run_length = static_cast<uint32_t>(val);
+	}
+
+	for (size_t i = 0; i < num_entries; i++) {
+		const uint64_t val = decode_varint(&t, end);
+		if (val > std::numeric_limits<uint32_t>::max()) {
+			throw malformed_directory_exception();
+		}
+		result[i].length = static_cast<uint32_t>(val);
+	}
+
+	for (size_t i = 0; i < num_entries; i++) {
+		uint64_t tmp = decode_varint(&t, end);
+
+		if (i > 0 && tmp == 0) {
+			if (result[i - 1].offset > std::numeric_limits<uint64_t>::max() - result[i - 1].length) {
+				throw malformed_directory_exception();
+			}
+			result[i].offset = result[i - 1].offset + result[i - 1].length;
+		} else {
+			result[i].offset = tmp - 1;
+		}
+	}
+
+	// assert the directory has been fully consumed
+	if (t != end) {
+		throw malformed_directory_exception();
+	}
+
+	return result;
+}
+
+inline std::tuple<std::string, std::string, int> build_root_leaves(const std::function<std::string(const std::string &, uint8_t)> mycompress, uint8_t compression, const std::vector<pmtiles::entryv3> &entries, int leaf_size) {
+	std::vector<pmtiles::entryv3> root_entries;
+	std::string leaves_bytes;
+	int num_leaves = 0;
+	for (size_t i = 0; i < entries.size(); i += leaf_size) {
+		num_leaves++;
+		size_t end = i + leaf_size;
+		if (i + leaf_size > entries.size()) {
+			end = entries.size();
+		}
+		std::vector<pmtiles::entryv3> subentries = {entries.begin() + i, entries.begin() + end};
+		auto uncompressed_leaf = pmtiles::serialize_directory(subentries);
+		auto compressed_leaf = mycompress(uncompressed_leaf, compression);
+		root_entries.emplace_back(entries[i].tile_id, leaves_bytes.size(), static_cast<uint32_t>(compressed_leaf.size()), 0);
+		leaves_bytes += compressed_leaf;
+	}
+	auto uncompressed_root = pmtiles::serialize_directory(root_entries);
+	auto compressed_root = mycompress(uncompressed_root, compression);
+	return std::make_tuple(compressed_root, leaves_bytes, num_leaves);
+}
+
+inline std::tuple<std::string, std::string, int> make_root_leaves(const std::function<std::string(const std::string &, uint8_t)> mycompress, uint8_t compression, const std::vector<pmtiles::entryv3> &entries) {
+	auto test_bytes = pmtiles::serialize_directory(entries);
+	auto compressed = mycompress(test_bytes, compression);
+	if (compressed.size() <= 16384 - 127) {
+		return std::make_tuple(compressed, "", 0);
+	}
+	int leaf_size = 4096;
+	while (true) {
+		std::string root_bytes;
+		std::string leaves_bytes;
+		int num_leaves;
+		std::tie(root_bytes, leaves_bytes, num_leaves) = build_root_leaves(mycompress, compression, entries, leaf_size);
+		if (root_bytes.length() < 16384 - 127) {
+			return std::make_tuple(root_bytes, leaves_bytes, num_leaves);
+		}
+		leaf_size *= 2;
+	}
+}
+
+inline void collect_entries(const std::function<std::string(const std::string &, uint8_t)> decompress, std::vector<entry_zxy> &tile_entries, const char *pmtiles_map, const headerv3 &h, uint64_t dir_offset, uint64_t dir_len) {
+	std::string dir_s{pmtiles_map + dir_offset, static_cast<size_t>(dir_len)};
+	std::string decompressed_dir = decompress(dir_s, h.internal_compression);
+
+	auto dir_entries = pmtiles::deserialize_directory(decompressed_dir);
+	for (auto const &entry : dir_entries) {
+		if (entry.run_length == 0) {
+			collect_entries(decompress, tile_entries, pmtiles_map, h, h.leaf_dirs_offset + entry.offset, entry.length);
+		} else {
+			for (uint64_t i = entry.tile_id; i < entry.tile_id + entry.run_length; i++) {
+				pmtiles::zxy zxy = pmtiles::tileid_to_zxy(i);
+				tile_entries.emplace_back(zxy.z, zxy.x, zxy.y, h.tile_data_offset + entry.offset, entry.length);
+			}
+		}
+	}
+}
+
+inline std::vector<entry_zxy> entries_tms(const std::function<std::string(const std::string &, uint8_t)> decompress, const char *pmtiles_map) {
+	std::string header_s{pmtiles_map, 127};
+	auto header = pmtiles::deserialize_header(header_s);
+
+	std::vector<entry_zxy> tile_entries;
+
+	collect_entries(decompress, tile_entries, pmtiles_map, header, header.root_dir_offset, header.root_dir_bytes);
+	std::sort(tile_entries.begin(), tile_entries.end(), colmajor_cmp);
+	return tile_entries;
+}
+
+inline std::pair<uint64_t, uint32_t> get_tile(const std::function<std::string(const std::string &, uint8_t)> decompress, const char *pmtiles_map, uint8_t z, uint32_t x, uint32_t y) {
+	uint64_t tile_id = pmtiles::zxy_to_tileid(z, x, y);
+
+	std::string header_s{pmtiles_map, 127};
+	auto h = pmtiles::deserialize_header(header_s);
+
+	uint64_t dir_offset = h.root_dir_offset;
+    if (h.root_dir_bytes > std::numeric_limits<uint32_t>::max()) {
+		throw malformed_directory_exception();
+	}
+	uint32_t dir_length = static_cast<uint32_t>(h.root_dir_bytes);
+	for (int depth = 0; depth <= 3; depth++) {
+		std::string dir_s{pmtiles_map + dir_offset, dir_length};
+		std::string decompressed_dir = decompress(dir_s, h.internal_compression);
+		auto dir_entries = pmtiles::deserialize_directory(decompressed_dir);
+		auto entry = find_tile(dir_entries, tile_id);
+
+		if (entry.length > 0) {
+			if (entry.run_length > 0) {
+				return std::make_pair(h.tile_data_offset + entry.offset, entry.length);
+			} else {
+				dir_offset = h.leaf_dirs_offset + entry.offset;
+				dir_length = entry.length;
+			}
+		} else {
+			return std::make_pair(0, 0);
+		}
+	}
+
+	return std::make_pair(0, 0);
+}
+
+}  // namespace pmtiles
+#endif

--- a/include/external/pmtiles.hpp
+++ b/include/external/pmtiles.hpp
@@ -200,12 +200,6 @@ struct entryv3 {
 	}
 };
 
-struct {
-	bool operator()(entryv3 a, entryv3 b) const {
-		return a.tile_id < b.tile_id;
-	}
-} entryv3_cmp;
-
 struct entry_zxy {
 	uint8_t z;
 	uint32_t x;

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -27,6 +27,10 @@ inline std::vector<std::string> split_string(std::string &inputStr, char sep) {
 	return res;
 }
 
+double bboxElementFromStr(const std::string& number);
+
+std::vector<std::string> parseBox(const std::string& bbox);
+
 std::string decompress_string(const std::string& str, bool asGzip = false);
 
 std::string compress_string(const std::string& str,

--- a/include/pmtiles.h
+++ b/include/pmtiles.h
@@ -19,6 +19,8 @@ struct TileOffset {
 #define HEADER_ROOT 16384
 // Tile ID at which to start using leaf directories (=z6/0/0)
 #define FIRST_LEAF_TILE 1365
+// Threshold for using the root directory only
+#define ROOT_ONLY 2200
 // Maximum size in bytes of tiles considered "tiny" (i.e. potentially repeatable)
 #define TINY_LENGTH 100
 // Expire the tiny cache when it reaches this size

--- a/include/pmtiles.h
+++ b/include/pmtiles.h
@@ -2,6 +2,19 @@
 #ifndef _PMTILES_H
 #define _PMTILES_H
 
+#include <fstream>
+#include "external/pmtiles.hpp"
+
+struct TileOffset {
+	uint64_t offset : 40;
+	size_t length : 24;
+
+	TileOffset(uint64_t offset, size_t length) : offset(offset),length(length) { }
+	TileOffset();
+};
+
+#define LEAF_DIRECTORY_SIZE 10000000
+
 class PMTiles { 
 //	sqlite::database db;
 //	std::vector<sqlite::database_binder> preparedStatements;
@@ -17,11 +30,21 @@ class PMTiles {
 public:
 	PMTiles();
 	virtual ~PMTiles();
-//	void openForWriting(std::string &filename);
+
+	void open(std::string &filename);
 //	void writeMetadata(std::string key, std::string value);
-//	void saveTile(int zoom, int x, int y, std::string *data, bool isMerge);
-//	void closeForWriting();
+	void saveTile(int zoom, int x, int y, std::string &data);
+	void close();
+
+private:
+	std::ofstream outputStream;
+	std::mutex fileMutex;
+	bool isSparse = true;
+	std::map<uint64_t, TileOffset> sparseIndex;
+	std::vector<TileOffset> denseIndex;
+
+	void appendTileEntry(uint64_t tileId, TileOffset offset, std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries);
+	void flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries);
 };
 
 #endif //_PMTILES_H
-

--- a/include/pmtiles.h
+++ b/include/pmtiles.h
@@ -19,39 +19,37 @@ struct TileOffset {
 #define HEADER_ROOT 16384
 // Tile ID at which to start using leaf directories (=z6/0/0)
 #define FIRST_LEAF_TILE 1365
+// Maximum size in bytes of tiles considered "tiny" (i.e. potentially repeatable)
+#define TINY_LENGTH 100
+// Expire the tiny cache when it reaches this size
+#define TINY_MAX_SIZE 10000
 
 class PMTiles { 
-//	sqlite::database db;
-//	std::vector<sqlite::database_binder> preparedStatements;
-//	std::mutex m;
-//	bool inTransaction;
-
-//	std::shared_ptr<std::vector<PendingStatement>> pendingStatements1, pendingStatements2;
-//	std::mutex pendingStatementsMutex;
-
-//	void insertOrReplace(int zoom, int x, int y, const std::string& data, bool isMerge);
-//	void flushPendingStatements();
 
 public:
 	PMTiles();
 	virtual ~PMTiles();
 
 	pmtiles::headerv3 header;
+	bool isSparse = true;
 
 	void open(std::string &filename);
-//	void writeMetadata(std::string key, std::string value);
 	void saveTile(int zoom, int x, int y, std::string &data);
 	void close(std::string &metadata);
 
 private:
 	std::ofstream outputStream;
-	std::mutex fileMutex;
-	bool isSparse = true;
+	std::mutex fileMutex;	// guards file writes, numTilesWritten
+	std::mutex indexMutex;	// guards access to sparseIndex, denseIndex, tinyCache, numTilesAddressed
 	uint64_t leafStart = 0;
 	uint64_t numTilesWritten = 0;
+	uint64_t numTilesAddressed = 0;
+	uint64_t numTileEntries = 0;
 	std::map<uint64_t, TileOffset> sparseIndex;
 	std::vector<TileOffset> denseIndex;
+	std::unordered_map<std::string, TileOffset> tinyCache;
 
+	void appendWithRLE(std::vector<pmtiles::entryv3> &entries, pmtiles::entryv3 &entry);
 	void appendTileEntry(uint64_t tileId, TileOffset offset, std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries);
 	void flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries);
 };

--- a/include/pmtiles.h
+++ b/include/pmtiles.h
@@ -13,7 +13,12 @@ struct TileOffset {
 	TileOffset();
 };
 
+// Maximum number of tiles in a leaf directory
 #define LEAF_DIRECTORY_SIZE 10000000
+// Combined size of header and root directory (= start of tile data)
+#define HEADER_ROOT 16384
+// Tile ID at which to start using leaf directories (=z6/0/0)
+#define FIRST_LEAF_TILE 1365
 
 class PMTiles { 
 //	sqlite::database db;

--- a/include/pmtiles.h
+++ b/include/pmtiles.h
@@ -31,15 +31,19 @@ public:
 	PMTiles();
 	virtual ~PMTiles();
 
+	pmtiles::headerv3 header;
+
 	void open(std::string &filename);
 //	void writeMetadata(std::string key, std::string value);
 	void saveTile(int zoom, int x, int y, std::string &data);
-	void close();
+	void close(std::string &metadata);
 
 private:
 	std::ofstream outputStream;
 	std::mutex fileMutex;
 	bool isSparse = true;
+	uint64_t leafStart = 0;
+	uint64_t numTilesWritten = 0;
 	std::map<uint64_t, TileOffset> sparseIndex;
 	std::vector<TileOffset> denseIndex;
 

--- a/include/pmtiles.h
+++ b/include/pmtiles.h
@@ -1,0 +1,27 @@
+/*! \file */ 
+#ifndef _PMTILES_H
+#define _PMTILES_H
+
+class PMTiles { 
+//	sqlite::database db;
+//	std::vector<sqlite::database_binder> preparedStatements;
+//	std::mutex m;
+//	bool inTransaction;
+
+//	std::shared_ptr<std::vector<PendingStatement>> pendingStatements1, pendingStatements2;
+//	std::mutex pendingStatementsMutex;
+
+//	void insertOrReplace(int zoom, int x, int y, const std::string& data, bool isMerge);
+//	void flushPendingStatements();
+
+public:
+	PMTiles();
+	virtual ~PMTiles();
+//	void openForWriting(std::string &filename);
+//	void writeMetadata(std::string key, std::string value);
+//	void saveTile(int zoom, int x, int y, std::string *data, bool isMerge);
+//	void closeForWriting();
+};
+
+#endif //_PMTILES_H
+

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -105,6 +105,8 @@ public:
 	void writeMBTilesProjectData();
 	void writeMBTilesMetadata(rapidjson::Document const &jsonConfig);
 	void writeFileMetadata(rapidjson::Document const &jsonConfig);	
+	std::string pmTilesMetadata();
+	void writePMTilesBounds();
 };
 
 #endif //_SHARED_DATA_H

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -60,6 +60,10 @@ public:
 	std::string serialiseToJSON() const;
 };
 
+const int OUTPUT_FILE = 0;
+const int OUTPUT_MBTILES = 1;
+const int OUTPUT_PMTILES = 2;
+
 ///\brief Config read from JSON to control behavior of program
 class Config {
 	
@@ -86,7 +90,7 @@ class SharedData {
 
 public:
 	const class LayerDefinition &layers;
-	bool sqlite;
+	int outputMode;
 	bool mergeSqlite;
 	MBTiles mbtiles;
 	std::string outputFile;
@@ -95,6 +99,10 @@ public:
 
 	SharedData(Config &configIn, const class LayerDefinition &layers);
 	virtual ~SharedData();
+
+	void writeMBTilesProjectData();
+	void writeMBTilesMetadata(rapidjson::Document const &jsonConfig);
+	void writeFileMetadata(rapidjson::Document const &jsonConfig);	
 };
 
 #endif //_SHARED_DATA_H

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -10,6 +10,7 @@
 #include "osm_store.h"
 #include "output_object.h"
 #include "mbtiles.h"
+#include "pmtiles.h"
 #include "tile_data.h"
 
 ///\brief Defines map single layer appearance
@@ -93,6 +94,7 @@ public:
 	int outputMode;
 	bool mergeSqlite;
 	MBTiles mbtiles;
+	PMTiles pmtiles;
 	std::string outputFile;
 
 	Config &config;

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -1,4 +1,3 @@
-#include "helpers.h"
 #include <string>
 #include <stdexcept>
 #include <iostream>
@@ -6,12 +5,38 @@
 #include <sstream>
 #include <cstring>
 
+#include "helpers.h"
+
 #define MOD_GZIP_ZLIB_WINDOWSIZE 15
 #define MOD_GZIP_ZLIB_CFACTOR 9
 #define MOD_GZIP_ZLIB_BSIZE 8096
 
 namespace geom = boost::geometry;
 using namespace std;
+
+// Bounding box string parsing
+
+double bboxElementFromStr(const std::string& number) {
+	try {
+		return boost::lexical_cast<double>(number);
+	} catch (boost::bad_lexical_cast&) {
+		std::cerr << "Failed to parse coordinate " << number << std::endl;
+		exit(1);
+	}
+}
+
+// Split bounding box provided as a comma-separated list of coordinates.
+std::vector<std::string> parseBox(const std::string& bbox) {
+	std::vector<std::string> bboxParts;
+	if (!bbox.empty()) {
+		boost::split(bboxParts, bbox, boost::is_any_of(","));
+		if (bboxParts.size() != 4) {
+			std::cerr << "Bounding box must contain 4 elements: minlon,minlat,maxlon,maxlat" << std::endl;
+			exit(1);
+		}
+	}
+	return bboxParts;
+}
 
 // zlib routines from http://panthema.net/2007/0328-ZLibString.html
 

--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -41,7 +41,7 @@ void PMTiles::close(std::string &metadata) {
 		}
 	} else {
 		for (size_t tileId=0; tileId<denseIndex.size(); tileId++) {
-			if (denseIndex[tileId].length != 0) appendTileEntry(tileId, denseIndex[tileId], rootEntries, entries);
+			if (denseIndex[tileId].length != 0xffffff) appendTileEntry(tileId, denseIndex[tileId], rootEntries, entries);
 		}
 	}
 	flushEntries(rootEntries,entries);
@@ -163,7 +163,7 @@ void PMTiles::saveTile(int zoom, int x, int y, std::string &data) {
 	if (isSparse) {
 		sparseIndex[tileId] = offset;
 	} else {
-		if (tileId>denseIndex.size()) denseIndex.resize(tileId+10000);
+		if (tileId >= denseIndex.size()) denseIndex.resize(tileId+10000, { 0, 0xffffff });
 		denseIndex[tileId] = offset;
 	}
 

--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <mutex>
 
 #include "pmtiles.h"
@@ -12,28 +13,7 @@
 /*
 	Future enhancements:
 	- order tile-writing so it's in tileid order
-	- run-length encoding for sea tiles etc. [would be better to do this before compressing the tile]
-
-	Useful stuff in pmtiles.hpp:
-	- pmtiles::TILETYPE_MVT = 1
-	- pmtiles::[compression types]
-	- pmtiles::serialize (headerv3 object)
-	- structs:
-		pmtiles::zxy
-		pmtiles::entryv3
-	- pmtiles::zxy_to_tileid
-	- pmtiles::serialize_directory
-	- pmtiles::build_root_leaves (what does this do?)
-	- pmtiles::make_root_leaves (? - calls build_root_leaves)
-
-const tzValues: number[] = [
-  z0 z1 z2 z3  z4  z5   z6    z7    z8
-  0, 1, 5, 21, 85, 341, 1365, 5461, 21845, 87381, 349525, 1398101, 5592405,
-  22369621, 89478485, 357913941, 1431655765, 5726623061, 22906492245,
-  91625968981, 366503875925, 1466015503701, 5864062014805, 23456248059221,
-  93824992236885, 375299968947541, 1501199875790165,
-];
-
+	- store up writes as per mbtiles.cpp?
 */
 
 TileOffset::TileOffset() { }
@@ -41,9 +21,8 @@ PMTiles::PMTiles() { }
 PMTiles::~PMTiles() { }
 
 void PMTiles::open(std::string &filename) {
-	std::cout << "Opening PMTiles file " << filename << std::endl;
+	std::cout << "Creating pmtiles at " << filename << std::endl;
 	outputStream.open(filename);
-	// **** set isSparse according to the number of tiles
 	// dummy header/root directory for now - we'll write it all later
 	char header[HEADER_ROOT] = "PMTiles";
 	outputStream.write(header, HEADER_ROOT);
@@ -51,7 +30,7 @@ void PMTiles::open(std::string &filename) {
 
 // Finish writing the .pmtiles file
 void PMTiles::close(std::string &metadata) {
-	std::cout << "Closing PMTiles file" << std::endl;
+	std::cout << "\nClosing pmtiles file" << std::flush;
 
 	// add all tiles to directories, writing leaf directories as we go
 	std::vector<pmtiles::entryv3> rootEntries;
@@ -73,14 +52,12 @@ void PMTiles::close(std::string &metadata) {
 	uint64_t jsonStart = static_cast<uint64_t>(outputStream.tellp());
 	int jsonLength = compressed.size();
 	outputStream.write(compressed.c_str(), jsonLength);
-	std::cout << "Written JSON metadata at " << jsonStart << " for " << jsonLength << std::endl;
 	
 	// write root directory
 	std::string directory = pmtiles::serialize_directory(rootEntries);
 	compressed = compress_string(directory, Z_DEFAULT_COMPRESSION, true);
 	int rootLength = compressed.size();
 	if (rootLength > (HEADER_ROOT-127)) { throw std::runtime_error(".pmtiles root directory was too large - please file an issue"); }
-	std::cout << "Root directory has " << rootEntries.size() << " entries and is " << rootLength << " bytes" << std::endl;
 	outputStream.seekp(127);
 	outputStream.write(compressed.c_str(), rootLength);
 
@@ -93,8 +70,8 @@ void PMTiles::close(std::string &metadata) {
 	header.leaf_dirs_bytes = leafLength;
 	header.tile_data_offset = HEADER_ROOT;
 	header.tile_data_bytes = leafStart - HEADER_ROOT;
-	header.addressed_tiles_count = numTilesWritten; // TODO - change this when we use RLE
-	header.tile_entries_count = numTilesWritten; // TODO - change this when we use RLE
+	header.addressed_tiles_count = numTilesAddressed;
+	header.tile_entries_count = numTileEntries;
 	header.tile_contents_count = numTilesWritten;
 	header.clustered = false;
 	header.internal_compression = pmtiles::COMPRESSION_GZIP;
@@ -115,20 +92,32 @@ void PMTiles::appendTileEntry(uint64_t tileId, TileOffset offset, std::vector<pm
 	pmtiles::entryv3 entry = pmtiles::entryv3(tileId, offset.offset, offset.length, 1); // 1=RLE
 	if (tileId<FIRST_LEAF_TILE) {
 		// <z6 so root directory
-		rootEntries.emplace_back(entry);
+		appendWithRLE(rootEntries, entry);
 	} else {
-		entries.emplace_back(entry);
+		appendWithRLE(entries, entry);
 		if (entries.size()>=LEAF_DIRECTORY_SIZE) flushEntries(rootEntries, entries);
 	}
 }
 
+// Handle run-length encoding for appendTileEntry
+void PMTiles::appendWithRLE(std::vector<pmtiles::entryv3> &entries, pmtiles::entryv3 &entry) {
+	if (entries.empty() ||
+		entries.back().offset != entry.offset ||
+		entries.back().tile_id != (entry.tile_id-entries.back().run_length)) { 
+			entries.emplace_back(entry); 
+			numTileEntries++;
+			return;
+	}
+	entries.back().run_length++;
+}
+
 // Write a leaf directory to file, and add a reference to it to the root directory
 void PMTiles::flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries) {
-	std::cout << "Flushing leaf directory with " << entries.size() << " entries" << std::endl;
 	if (entries.size()==0) return;
 	uint64_t startId = entries[0].tile_id;
 	std::string directory = pmtiles::serialize_directory(entries);
 	std::string compressed = compress_string(directory, Z_DEFAULT_COMPRESSION, true);
+	entries.clear();
 
 	// write the leaf directory to disk
 	std::lock_guard<std::mutex> lock(fileMutex);
@@ -136,7 +125,6 @@ void PMTiles::flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vect
 	if (leafStart==0) leafStart=location;
 	uint64_t length = compressed.size();
 	outputStream << compressed;
-	std::cout << "Written leaf directory starting at " << startId << " at " << location << " for " << length << std::endl;
 
 	// append reference to the root directory
 	pmtiles::entryv3 rootEntry = pmtiles::entryv3(startId, location-leafStart, length, 0);
@@ -144,18 +132,44 @@ void PMTiles::flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vect
 }
 
 // Write a tile to file and store it in the index
+// - if the tile is small and has already been written, reuse that instead
+// - we're a bit fussy about mutexs because compress_string is expensive
 void PMTiles::saveTile(int zoom, int x, int y, std::string &data) {
+	TileOffset offset;
+	bool isNew = false;
 	uint64_t tileId = pmtiles::zxy_to_tileid(zoom,x,y);
-	std::lock_guard<std::mutex> lock(fileMutex);
-	// write to file
-	TileOffset offset = TileOffset(static_cast<uint64_t>(outputStream.tellp()) - HEADER_ROOT, data.size());
-	outputStream << data;
-	numTilesWritten++;
+
+	// if it's a tiny tile (e.g. sea), see if we've written it already
+	std::unique_lock<std::mutex> indexLock1(indexMutex);
+	if (data.size()<TINY_LENGTH && tinyCache.find(data) != tinyCache.end()) {
+		offset = tinyCache[data];
+		indexLock1.unlock();
+
+	// otherwise, compress it and write
+	} else {
+		indexLock1.unlock();
+		std::string compressed = compress_string(data, Z_DEFAULT_COMPRESSION, true);
+		std::lock_guard<std::mutex> lock(fileMutex);
+		// write to file
+		offset = TileOffset(static_cast<uint64_t>(outputStream.tellp()) - HEADER_ROOT, compressed.size());
+		outputStream << compressed;
+		numTilesWritten++;
+		isNew = true;
+	}
+	
 	// store in index
+	std::lock_guard<std::mutex> indexLock2(indexMutex);
+	numTilesAddressed++;
 	if (isSparse) {
 		sparseIndex[tileId] = offset;
 	} else {
-		if (tileId>denseIndex.size()) denseIndex.resize(tileId+1000);
+		if (tileId>denseIndex.size()) denseIndex.resize(tileId+10000);
 		denseIndex[tileId] = offset;
+	}
+
+	// add to cache if tiny
+	if (isNew && data.size()<TINY_LENGTH) {
+		if (tinyCache.size()>TINY_MAX_SIZE) tinyCache.clear();
+		tinyCache.insert({ data, offset });
 	}
 }

--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -43,7 +43,12 @@ void PMTiles::close(std::string &metadata) {
 			if (denseIndex[tileId].length != 0xffffff) appendTileEntry(tileId, denseIndex[tileId], rootEntries, entries);
 		}
 	}
-	flushEntries(rootEntries,entries);
+	if (numTileEntries < ROOT_ONLY) {
+		rootEntries.insert(rootEntries.end(), entries.begin(), entries.end());
+		entries.clear();
+	} else {
+		flushEntries(rootEntries,entries);
+	}
 	uint64_t leafLength = static_cast<uint64_t>(outputStream.tellp()) - leafStart;
 
 	// create JSON metadata

--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -9,12 +9,6 @@
 #include "pmtiles.h"
 #include "helpers.h"
 
-/*
-	Future enhancements:
-	- order tile-writing so it's in tileid order
-	- store up writes as per mbtiles.cpp?
-*/
-
 TileOffset::TileOffset() { }
 PMTiles::PMTiles() { }
 PMTiles::~PMTiles() { }

--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 
 #include "pmtiles.h"
+#include "helpers.h"
 #include "external/pmtiles.hpp"
 
 /*
@@ -48,8 +49,11 @@ void PMTiles::open(std::string &filename) {
 	outputStream.write(header, 16384);
 }
 
-void PMTiles::close() {
+// Finish writing the .pmtiles file
+void PMTiles::close(std::string &metadata) {
 	std::cout << "Closing PMTiles file" << std::endl;
+
+	// add all tiles to directories, writing leaf directories as we go
 	std::vector<pmtiles::entryv3> rootEntries;
 	std::vector<pmtiles::entryv3> entries;
 	if (isSparse) {
@@ -62,13 +66,51 @@ void PMTiles::close() {
 		}
 	}
 	flushEntries(rootEntries,entries);
-	// write leaf directories
-	// create 127-byte header
-	// create root directory
+	uint64_t leafLength = static_cast<uint64_t>(outputStream.tellp()) - leafStart;
+
 	// create JSON metadata
+	std::string compressed = compress_string(metadata, Z_DEFAULT_COMPRESSION, true);
+	uint64_t jsonStart = static_cast<uint64_t>(outputStream.tellp());
+	int jsonLength = compressed.size();
+	outputStream.write(compressed.c_str(), jsonLength);
+	std::cout << "Written JSON metadata at " << jsonStart << " for " << jsonLength << std::endl;
+	
+	// write root directory
+	std::string directory = pmtiles::serialize_directory(rootEntries);
+	compressed = compress_string(directory, Z_DEFAULT_COMPRESSION, true);
+	int rootLength = compressed.size();
+	if (rootLength > 16257) { throw std::runtime_error(".pmtiles root directory was too large - please file an issue"); }
+	std::cout << "Root directory has " << rootEntries.size() << " entries and is " << rootLength << " bytes" << std::endl;
+	outputStream.seekp(127);
+	outputStream.write(compressed.c_str(), rootLength);
+
+	// add all sizes to 127-byte header
+	header.root_dir_offset = 127;
+	header.root_dir_bytes = rootLength;
+	header.json_metadata_offset = jsonStart;
+	header.json_metadata_bytes = jsonLength;
+	header.leaf_dirs_offset = leafStart;
+	header.leaf_dirs_bytes = leafLength;
+	header.tile_data_offset = 16384;
+	header.tile_data_bytes = leafStart - 16384;
+	header.addressed_tiles_count = numTilesWritten; // TODO - change this when we use RLE
+	header.tile_entries_count = numTilesWritten; // TODO - change this when we use RLE
+	header.tile_contents_count = numTilesWritten;
+	header.clustered = false;
+	header.internal_compression = pmtiles::COMPRESSION_GZIP;
+	header.tile_compression = pmtiles::COMPRESSION_GZIP;
+	header.tile_type = pmtiles::TILETYPE_MVT;
+
+	// write header
+	std::string headerString = header.serialize();
+	outputStream.seekp(0);
+	outputStream.write(headerString.c_str(), headerString.size());
+
+	// ...and we're done!
 	outputStream.close();
 }
 
+// Add an entry either to the current leaf directory, or (for lowzoom) the root directory
 void PMTiles::appendTileEntry(uint64_t tileId, TileOffset offset, std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries) {
 	pmtiles::entryv3 entry = pmtiles::entryv3(tileId, offset.offset, offset.length, 1); // 1=RLE
 	if (tileId<1365) {
@@ -79,27 +121,37 @@ void PMTiles::appendTileEntry(uint64_t tileId, TileOffset offset, std::vector<pm
 		if (entries.size()>=LEAF_DIRECTORY_SIZE) flushEntries(rootEntries, entries);
 	}
 }
+
+// Write a leaf directory to file, and add a reference to it to the root directory
 void PMTiles::flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries) {
+	std::cout << "Flushing leaf directory with " << entries.size() << " entries" << std::endl;
 	if (entries.size()==0) return;
 	uint64_t startId = entries[0].tile_id;
 	std::string directory = pmtiles::serialize_directory(entries);
+	std::string compressed = compress_string(directory, Z_DEFAULT_COMPRESSION, true);
+
 	// write the leaf directory to disk
 	std::lock_guard<std::mutex> lock(fileMutex);
 	uint64_t location = outputStream.tellp();
-	uint64_t length = directory.size();
-	outputStream << directory;
+	if (leafStart==0) leafStart=location;
+	uint64_t length = compressed.size();
+	outputStream << compressed;
+	std::cout << "Written leaf directory starting at " << startId << " at " << location << " for " << length << std::endl;
+
 	// append reference to the root directory
 	pmtiles::entryv3 rootEntry = pmtiles::entryv3(startId, location, length, 0);
 	rootEntries.emplace_back(rootEntry);
 }
 
+// Write a tile to file and store it in the index
 void PMTiles::saveTile(int zoom, int x, int y, std::string &data) {
 	uint64_t tileId = pmtiles::zxy_to_tileid(zoom,x,y);
-	std::cout << "Writing tile " << zoom << "/" << x << "/" << y << " = " << tileId << std::endl;
+//	std::cout << "Writing tile " << zoom << "/" << x << "/" << y << " = " << tileId << std::endl;
 	std::lock_guard<std::mutex> lock(fileMutex);
 	// write to file
 	TileOffset offset = TileOffset(static_cast<uint64_t>(outputStream.tellp()), data.size());
 	outputStream << data;
+	numTilesWritten++;
 	// store in index
 	if (isSparse) {
 		sparseIndex[tileId] = offset;

--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -1,0 +1,110 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <map>
+#include <mutex>
+
+#include "pmtiles.h"
+#include "external/pmtiles.hpp"
+
+/*
+	Future enhancements:
+	- order tile-writing so it's in tileid order
+	- run-length encoding for sea tiles etc. [would be better to do this before compressing the tile]
+
+	Useful stuff in pmtiles.hpp:
+	- pmtiles::TILETYPE_MVT = 1
+	- pmtiles::[compression types]
+	- pmtiles::serialize (headerv3 object)
+	- structs:
+		pmtiles::zxy
+		pmtiles::entryv3
+	- pmtiles::zxy_to_tileid
+	- pmtiles::serialize_directory
+	- pmtiles::build_root_leaves (what does this do?)
+	- pmtiles::make_root_leaves (? - calls build_root_leaves)
+
+const tzValues: number[] = [
+  z0 z1 z2 z3  z4  z5   z6    z7    z8
+  0, 1, 5, 21, 85, 341, 1365, 5461, 21845, 87381, 349525, 1398101, 5592405,
+  22369621, 89478485, 357913941, 1431655765, 5726623061, 22906492245,
+  91625968981, 366503875925, 1466015503701, 5864062014805, 23456248059221,
+  93824992236885, 375299968947541, 1501199875790165,
+];
+
+*/
+
+TileOffset::TileOffset() { }
+PMTiles::PMTiles() { }
+PMTiles::~PMTiles() { }
+
+void PMTiles::open(std::string &filename) {
+	std::cout << "Opening PMTiles file " << filename << std::endl;
+	outputStream.open(filename);
+	// **** set isSparse according to the number of tiles
+	// dummy header/root directory for now - we'll write it all later
+	char header[16384] = "PMTiles";
+	outputStream.write(header, 16384);
+}
+
+void PMTiles::close() {
+	std::cout << "Closing PMTiles file" << std::endl;
+	std::vector<pmtiles::entryv3> rootEntries;
+	std::vector<pmtiles::entryv3> entries;
+	if (isSparse) {
+		for (auto it : sparseIndex) {
+			appendTileEntry(it.first, it.second, rootEntries, entries);
+		}
+	} else {
+		for (size_t tileId=0; tileId<denseIndex.size(); tileId++) {
+			if (denseIndex[tileId].length != 0) appendTileEntry(tileId, denseIndex[tileId], rootEntries, entries);
+		}
+	}
+	flushEntries(rootEntries,entries);
+	// write leaf directories
+	// create 127-byte header
+	// create root directory
+	// create JSON metadata
+	outputStream.close();
+}
+
+void PMTiles::appendTileEntry(uint64_t tileId, TileOffset offset, std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries) {
+	pmtiles::entryv3 entry = pmtiles::entryv3(tileId, offset.offset, offset.length, 1); // 1=RLE
+	if (tileId<1365) {
+		// <z6 so root directory
+		rootEntries.emplace_back(entry);
+	} else {
+		entries.emplace_back(entry);
+		if (entries.size()>=LEAF_DIRECTORY_SIZE) flushEntries(rootEntries, entries);
+	}
+}
+void PMTiles::flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vector<pmtiles::entryv3> &entries) {
+	if (entries.size()==0) return;
+	uint64_t startId = entries[0].tile_id;
+	std::string directory = pmtiles::serialize_directory(entries);
+	// write the leaf directory to disk
+	std::lock_guard<std::mutex> lock(fileMutex);
+	uint64_t location = outputStream.tellp();
+	uint64_t length = directory.size();
+	outputStream << directory;
+	// append reference to the root directory
+	pmtiles::entryv3 rootEntry = pmtiles::entryv3(startId, location, length, 0);
+	rootEntries.emplace_back(rootEntry);
+}
+
+void PMTiles::saveTile(int zoom, int x, int y, std::string &data) {
+	uint64_t tileId = pmtiles::zxy_to_tileid(zoom,x,y);
+	std::cout << "Writing tile " << zoom << "/" << x << "/" << y << " = " << tileId << std::endl;
+	std::lock_guard<std::mutex> lock(fileMutex);
+	// write to file
+	TileOffset offset = TileOffset(static_cast<uint64_t>(outputStream.tellp()), data.size());
+	outputStream << data;
+	// store in index
+	if (isSparse) {
+		sparseIndex[tileId] = offset;
+	} else {
+		if (tileId>denseIndex.size()) denseIndex.resize(tileId+1000);
+		denseIndex[tileId] = offset;
+	}
+}

--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -8,7 +8,6 @@
 
 #include "pmtiles.h"
 #include "helpers.h"
-#include "external/pmtiles.hpp"
 
 /*
 	Future enhancements:

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -103,6 +103,32 @@ void SharedData::writeFileMetadata(rapidjson::Document const &jsonConfig) {
 	fclose(fp);
 }
 
+// Create JSON string with .pmtiles-format metadata
+std::string SharedData::pmTilesMetadata() {
+	rapidjson::Document document;
+	document.SetObject();
+	document.AddMember("name",          rapidjson::Value().SetString(config.projectName.c_str(), document.GetAllocator()), document.GetAllocator());
+	document.AddMember("description",   rapidjson::Value().SetString(config.projectDesc.c_str(), document.GetAllocator()), document.GetAllocator());
+	document.AddMember("vector_layers", layers.serialiseToJSONValue(document.GetAllocator()), document.GetAllocator());
+	// we don't currently write "attribution" or "type" fields, see .pmtiles spec
+	rapidjson::StringBuffer buffer;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+	document.Accept(writer);
+	std::string json(buffer.GetString(), buffer.GetSize());
+	return json;
+}
+
+void SharedData::writePMTilesBounds() {
+	pmtiles.header.min_zoom = config.startZoom;
+	pmtiles.header.max_zoom = config.endZoom;
+	pmtiles.header.center_zoom = (config.startZoom + config.endZoom) / 2;
+	pmtiles.header.min_lon_e7 = config.minLon * 10000000;
+	pmtiles.header.min_lat_e7 = config.minLat * 10000000;
+	pmtiles.header.max_lon_e7 = config.maxLon * 10000000;
+	pmtiles.header.max_lat_e7 = config.maxLat * 10000000;
+	pmtiles.header.center_lon_e7 = (pmtiles.header.min_lon_e7 + pmtiles.header.max_lon_e7) / 2;
+	pmtiles.header.center_lat_e7 = (pmtiles.header.min_lat_e7 + pmtiles.header.max_lat_e7) / 2;
+}
 
 
 // *****************************************************************

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -387,8 +387,7 @@ void outputProc(
 	} else if (sharedData.outputMode == OUTPUT_PMTILES) {
 		// Write to pmtiles
 		tile.SerializeToString(&outputdata);
-		compressed = compress_string(outputdata, Z_DEFAULT_COMPRESSION, sharedData.config.gzip);
-		sharedData.pmtiles.saveTile(zoom, bbox.index.x, bbox.index.y, compressed);
+		sharedData.pmtiles.saveTile(zoom, bbox.index.x, bbox.index.y, outputdata);
 
 	} else {
 		// Write to file

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -384,6 +384,12 @@ void outputProc(
 		if (sharedData.config.compress) { compressed = compress_string(outputdata, Z_DEFAULT_COMPRESSION, sharedData.config.gzip); }
 		sharedData.mbtiles.saveTile(zoom, bbox.index.x, bbox.index.y, sharedData.config.compress ? &compressed : &outputdata, sharedData.mergeSqlite);
 
+	} else if (sharedData.outputMode == OUTPUT_PMTILES) {
+		// Write to pmtiles
+		tile.SerializeToString(&outputdata);
+		compressed = compress_string(outputdata, Z_DEFAULT_COMPRESSION, sharedData.config.gzip);
+		sharedData.pmtiles.saveTile(zoom, bbox.index.x, bbox.index.y, compressed);
+
 	} else {
 		// Write to file
 		stringstream dirname, filename;

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -378,7 +378,7 @@ void outputProc(
 
 	// Write to file or sqlite
 	string outputdata, compressed;
-	if (sharedData.sqlite) {
+	if (sharedData.outputMode == OUTPUT_MBTILES) {
 		// Write to sqlite
 		tile.SerializeToString(&outputdata);
 		if (sharedData.config.compress) { compressed = compress_string(outputdata, Z_DEFAULT_COMPRESSION, sharedData.config.gzip); }

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -407,6 +407,12 @@ int main(int argc, char* argv[]) {
 			}
 		}
 
+		// For large areas (arbitrarily defined as 100 z6 tiles), use a dense index for pmtiles
+		if (coveredZ6Tiles.size()>100 && outputMode==OUTPUT_PMTILES) {
+			std::cout << "Using dense index for .pmtiles" << std::endl;
+			sharedData.pmtiles.isSparse = false;
+		}
+
 		std::deque<std::pair<unsigned int, TileCoordinates>> tileCoordinates;
 		for (uint zoom=sharedData.config.startZoom; zoom <= sharedData.config.endZoom; zoom++) {
 			auto zoomResult = getTilesAtZoom(sources, zoom);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -573,7 +573,9 @@ int main(int argc, char* argv[]) {
 		sharedData.writeMBTilesMetadata(jsonConfig);
 		sharedData.mbtiles.closeForWriting();
 	} else if (outputMode==OUTPUT_PMTILES) {
-		sharedData.pmtiles.close();
+		sharedData.writePMTilesBounds();
+		std::string metadata = sharedData.pmTilesMetadata();
+		sharedData.pmtiles.close(metadata);
 	} else {
 		sharedData.writeFileMetadata(jsonConfig);
 	}


### PR DESCRIPTION
This adds support for generating [.pmtiles](https://github.com/protomaps/PMTiles) archives. Format is autodetected from the output filename (i.e. `.pmtiles`->PMTiles, `.mbtiles`->MBTiles).

This does not produce the most efficient .pmtiles archives possible. Threading means tilemaker's tile output order isn't sequential, so we can't set `.clustered`. We also don't do anything smart with optimising directory sizes.

Memory usage and execution time will be higher than with .mbtiles. In particular, we need to keep an index of the file location (offset) of each tile we write. This is then compiled into root/leaf directories after tile generation. There's probably scope to improve this!

Some implementation details:

- File order is header, root directory, tile data, leaf directories, metadata.
- We keep an index of any tiles under 100 bytes (uncompressed), such as a typical sea tile, so we only need to write these out once.
- Tiles below z6 are written to the root directory. All other tiles go to leaf directories with a maximum size of 10000000 entries.
- For areas of <100 z6 tiles (Europe and below), we use a map for the tile offset index. For larger areas (planet), we use a vector.
- Compression is always gzip.
- There's a small amount of refactoring to move MBTiles-specific code out of tilemaker.cpp.

[PMTiles Viewer](https://protomaps.github.io/PMTiles/) seems happy with the results at county level. I've successfully generated a Great Britain .pmtiles and verified it with `pmtiles verify` (both with sparse and dense index) but not viewed it yet.

/cc @bdon