### PR TITLE
extend NextRelation/FindInRelation to nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ file(GLOB tilemaker_src_files
 	src/pbf_reader.cpp
 	src/pmtiles.cpp
 	src/pooled_string.cpp
+	src/relation_roles.cpp
 	src/sharded_node_store.cpp
 	src/sharded_way_store.cpp
 	src/shared_data.cpp

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ tilemaker: \
 	src/pbf_reader.o \
 	src/pmtiles.o \
 	src/pooled_string.o \
+	src/relation_roles.o \
 	src/sharded_node_store.o \
 	src/sharded_way_store.o \
 	src/shared_data.o \
@@ -133,6 +134,7 @@ test: \
 	test_deque_map \
 	test_pbf_reader \
 	test_pooled_string \
+	test_relation_roles \
 	test_sorted_node_store \
 	test_sorted_way_store
 
@@ -162,6 +164,11 @@ test_pooled_string: \
 	src/pooled_string.o \
 	test/pooled_string.test.o
 	$(CXX) $(CXXFLAGS) -o test.pooled_string $^ $(INC) $(LIB) $(LDFLAGS) && ./test.pooled_string
+
+test_relation_roles: \
+	src/relation_roles.o \
+	test/relation_roles.test.o
+	$(CXX) $(CXXFLAGS) -o test.relation_roles $^ $(INC) $(LIB) $(LDFLAGS) && ./test.relation_roles
 
 test_sorted_node_store: \
 	src/external/streamvbyte_decode.o \

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -134,7 +134,10 @@ public:
 	
 	// Return centroid lat/lon
 	std::vector<double> Centroid();
-	Point calculateCentroid();
+
+	enum class CentroidAlgorithm: char { Centroid = 0, Polylabel = 1 };
+	const CentroidAlgorithm defaultCentroidAlgorithm() const { return CentroidAlgorithm::Polylabel; }
+	Point calculateCentroid(CentroidAlgorithm algorithm);
 
 	enum class CorrectGeometryResult: char { Invalid = 0, Valid = 1, Corrected = 2 };
 	// ----	Requests from Lua to write this way/node to a vector tile's Layer

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -174,7 +174,7 @@ public:
 
 	struct OptionalRelation {
 		bool done;
-		int id;
+		lua_Integer id;
 		std::string role;
 	};
 	OptionalRelation NextRelation();

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -256,7 +256,7 @@ private:
 	bool isWay, isRelation, isClosed;		///< Way, node, relation?
 
 	bool relationAccepted;					// in scanRelation, whether we're using a non-MP relation
-	std::vector<std::pair<WayID, std::string>> relationList;		// in processNode/processWay, list of relations this entity is in, and its role
+	std::vector<std::pair<WayID, uint16_t>> relationList;		// in processNode/processWay, list of relations this entity is in, and its role
 	int relationSubscript = -1;				// in processWay, position in the relation list
 
 	int32_t lon,latp;						///< Node coordinates

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -133,10 +133,11 @@ public:
 	double Length();
 	
 	// Return centroid lat/lon
-	std::vector<double> Centroid();
+	std::vector<double> Centroid(kaguya::VariadicArgType algorithm);
 
 	enum class CentroidAlgorithm: char { Centroid = 0, Polylabel = 1 };
-	const CentroidAlgorithm defaultCentroidAlgorithm() const { return CentroidAlgorithm::Polylabel; }
+	CentroidAlgorithm defaultCentroidAlgorithm() const { return CentroidAlgorithm::Polylabel; }
+	CentroidAlgorithm parseCentroidAlgorithm(const std::string& algorithm) const;
 	Point calculateCentroid(CentroidAlgorithm algorithm);
 
 	enum class CorrectGeometryResult: char { Invalid = 0, Valid = 1, Corrected = 2 };

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -171,7 +171,13 @@ public:
 	void ZOrder(const double z);
 	
 	// Relation scan support
-	kaguya::optional<int> NextRelation();
+
+	struct OptionalRelation {
+		bool done;
+		int id;
+		std::string role;
+	};
+	OptionalRelation NextRelation();
 	void RestartRelations();
 	std::string FindInRelation(const std::string &key);
 	void Accept();
@@ -213,6 +219,7 @@ private:
 		polygonInited = false;
 		multiPolygonInited = false;
 		relationAccepted = false;
+		relationList.clear();
 		relationSubscript = -1;
 		lastStoredGeometryId = 0;
 	}
@@ -235,7 +242,7 @@ private:
 	bool isWay, isRelation, isClosed;		///< Way, node, relation?
 
 	bool relationAccepted;					// in scanRelation, whether we're using a non-MP relation
-	std::vector<WayID> relationList;		// in processWay, list of relations this way is in
+	std::vector<std::pair<WayID, std::string>> relationList;		// in processNode/processWay, list of relations this entity is in, and its role
 	int relationSubscript = -1;				// in processWay, position in the relation list
 
 	int32_t lon,latp;						///< Node coordinates

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -13,6 +13,7 @@
 #include "shp_mem_tiles.h"
 #include "osm_mem_tiles.h"
 #include "helpers.h"
+#include "pbf_reader.h"
 #include <protozero/data_view.hpp>
 
 #include <boost/container/flat_map.hpp>
@@ -87,7 +88,15 @@ public:
 	 * (note that we store relations as ways with artificial IDs, and that
 	 *  we use decrementing positive IDs to give a bit more space for way IDs)
 	 */
-	void setRelation(int64_t relationId, WayVec const &outerWayVec, WayVec const &innerWayVec, const tag_map_t &tags, bool isNativeMP, bool isInnerOuter);
+	void setRelation(
+		const std::vector<protozero::data_view>& stringTable,
+		const PbfReader::Relation& relation,
+		const WayVec& outerWayVec,
+		const WayVec& innerWayVec,
+		const tag_map_t& tags,
+		bool isNativeMP,
+		bool isInnerOuter
+	);
 
 	// ----	Metadata queries called from Lua
 
@@ -158,7 +167,7 @@ public:
 
 	// Add layer
 	void Layer(const std::string &layerName, bool area);
-	void LayerAsCentroid(const std::string &layerName);
+	void LayerAsCentroid(const std::string &layerName, kaguya::VariadicArgType nodeSources);
 	
 	// Set attributes in a vector tile's Attributes table
 	void Attribute(const std::string &key, const std::string &val);
@@ -211,6 +220,8 @@ private:
 	/// Internal: clear current cached state
 	inline void reset() {
 		outputs.clear();
+		currentRelation = nullptr;
+		stringTable = nullptr;
 		llVecPtr = nullptr;
 		outerWayVecPtr = nullptr;
 		innerWayVecPtr = nullptr;
@@ -267,6 +278,8 @@ private:
 
 	std::vector<std::pair<OutputObject, AttributeSet>> outputs;		// All output objects that have been created
 	const boost::container::flat_map<protozero::data_view, protozero::data_view, DataViewLessThan>* currentTags;
+	const PbfReader::Relation* currentRelation;
+	const std::vector<protozero::data_view>* stringTable;
 
 	std::vector<OutputObject> finalizeOutputs();
 

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -5,6 +5,7 @@
 #include "geom.h"
 #include "coordinates.h"
 #include "mmap_allocator.h"
+#include "relation_roles.h"
 
 #include <utility>
 #include <vector>
@@ -81,19 +82,22 @@ class RelationScanStore {
 
 private:
 	using tag_map_t = boost::container::flat_map<std::string, std::string>;
-	std::map<WayID, std::vector<std::pair<WayID, std::string>>> relationsForWays;
-	std::map<NodeID, std::vector<std::pair<WayID, std::string>>> relationsForNodes;
+	std::map<WayID, std::vector<std::pair<WayID, uint16_t>>> relationsForWays;
+	std::map<NodeID, std::vector<std::pair<WayID, uint16_t>>> relationsForNodes;
 	std::map<WayID, tag_map_t> relationTags;
 	mutable std::mutex mutex;
+	RelationRoles relationRoles;
 
 public:
 	void relation_contains_way(WayID relid, WayID wayid, std::string role) {
+		uint16_t roleId = relationRoles.getOrAddRole(role);
 		std::lock_guard<std::mutex> lock(mutex);
-		relationsForWays[wayid].emplace_back(std::make_pair(relid, role));
+		relationsForWays[wayid].emplace_back(std::make_pair(relid, roleId));
 	}
 	void relation_contains_node(WayID relid, NodeID nodeId, std::string role) {
+		uint16_t roleId = relationRoles.getOrAddRole(role);
 		std::lock_guard<std::mutex> lock(mutex);
-		relationsForNodes[nodeId].emplace_back(std::make_pair(relid, role));
+		relationsForNodes[nodeId].emplace_back(std::make_pair(relid, roleId));
 	}
 	void store_relation_tags(WayID relid, const tag_map_t &tags) {
 		std::lock_guard<std::mutex> lock(mutex);
@@ -105,10 +109,11 @@ public:
 	bool node_in_any_relations(NodeID nodeId) {
 		return relationsForNodes.find(nodeId) != relationsForNodes.end();
 	}
-	std::vector<std::pair<WayID, std::string>> relations_for_way(WayID wayid) {
+	std::string getRole(uint16_t roleId) const { return relationRoles.getRole(roleId); }
+	const std::vector<std::pair<WayID, uint16_t>>& relations_for_way(WayID wayid) {
 		return relationsForWays[wayid];
 	}
-	std::vector<std::pair<WayID, std::string>> relations_for_node(NodeID nodeId) {
+	const std::vector<std::pair<WayID, uint16_t>>& relations_for_node(NodeID nodeId) {
 		return relationsForNodes[nodeId];
 	}
 	std::string get_relation_tag(WayID relid, const std::string &key) {
@@ -187,6 +192,7 @@ class OSMStore
 public:
 	NodeStore& nodes;
 	WayStore& ways;
+	RelationScanStore scannedRelations;
 
 protected:	
 	bool use_compact_nodes = false;
@@ -194,7 +200,6 @@ protected:
 
 	RelationStore relations; // unused
 	UsedWays used_ways;
-	RelationScanStore scanned_relations;
 
 public:
 
@@ -222,14 +227,6 @@ public:
 	void ensureUsedWaysInited();
 
 	using tag_map_t = boost::container::flat_map<std::string, std::string>;
-	void relation_contains_way(WayID relid, WayID wayid, std::string role) { scanned_relations.relation_contains_way(relid, wayid, role); }
-	void relation_contains_node(WayID relid, NodeID nodeId, std::string role) { scanned_relations.relation_contains_node(relid, nodeId, role); }
-	void store_relation_tags(WayID relid, const tag_map_t &tags) { scanned_relations.store_relation_tags(relid,tags); }
-	bool way_in_any_relations(WayID wayid) { return scanned_relations.way_in_any_relations(wayid); }
-	bool node_in_any_relations(NodeID nodeId) { return scanned_relations.node_in_any_relations(nodeId); }
-	std::vector<std::pair<WayID, std::string>> relations_for_way(WayID wayid) { return scanned_relations.relations_for_way(wayid); }
-	std::vector<std::pair<NodeID, std::string>> relations_for_node(NodeID nodeId) { return scanned_relations.relations_for_node(nodeId); }
-	std::string get_relation_tag(WayID relid, const std::string &key) { return scanned_relations.get_relation_tag(relid, key); }
 
 	void clear();
 	void reportSize() const;

--- a/include/polylabel.h
+++ b/include/polylabel.h
@@ -1,0 +1,209 @@
+#pragma once
+
+// Original source from https://github.com/mapbox/polylabel, licensed
+// under ISC.
+//
+// Adapted to use Boost Geometry instead of MapBox's geometry library.
+//
+// Changes:
+// - Default precision changed from 1 to 0.00001.
+//   @mourner has some comments about what a reasonable precision value is
+//   for latitude/longitude coordinates, see
+//   https://github.com/mapbox/polylabel/issues/68#issuecomment-694906027
+//   https://github.com/mapbox/polylabel/issues/103#issuecomment-1516623862
+//
+// Possible future changes:
+// - Port the change described in https://github.com/mapbox/polylabel/issues/33,
+//   implemented in Mapnik's Java renderer, to C++.
+//   - But see counterexample: https://github.com/mapbox/polylabel/pull/63
+//     @Fil also proposes an alternative approach there.
+// - Pick precision as a function of the input geometry.
+
+#include "geom.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <queue>
+
+namespace mapbox {
+
+namespace detail {
+
+// get squared distance from a point to a segment
+double getSegDistSq(const Point& p,
+               const Point& a,
+               const Point& b) {
+    auto x = a.get<0>();
+    auto y = a.get<1>();
+    auto dx = b.get<0>() - x;
+    auto dy = b.get<1>() - y;
+
+    if (dx != 0 || dy != 0) {
+
+        auto t = ((p.get<0>() - x) * dx + (p.get<1>() - y) * dy) / (dx * dx + dy * dy);
+
+        if (t > 1) {
+            x = b.get<0>();
+            y = b.get<1>();
+
+        } else if (t > 0) {
+            x += dx * t;
+            y += dy * t;
+        }
+    }
+
+    dx = p.get<0>() - x;
+    dy = p.get<1>() - y;
+
+    return dx * dx + dy * dy;
+}
+
+// signed distance from point to polygon outline (negative if point is outside)
+auto pointToPolygonDist(const Point& point, const Polygon& polygon) {
+    bool inside = false;
+    auto minDistSq = std::numeric_limits<double>::infinity();
+
+    {
+        const auto& ring = polygon.outer();
+        for (std::size_t i = 0, len = ring.size(), j = len - 1; i < len; j = i++) {
+            const auto& a = ring[i];
+            const auto& b = ring[j];
+
+            if ((a.get<1>() > point.get<1>()) != (b.get<1>() > point.get<1>()) &&
+                (point.get<0>() < (b.get<0>() - a.get<0>()) * (point.get<1>() - a.get<1>()) / (b.get<1>() - a.get<1>()) + a.get<0>())) inside = !inside;
+
+            minDistSq = std::min(minDistSq, getSegDistSq(point, a, b));
+        }
+    }
+
+    for (const auto& ring : polygon.inners()) {
+        for (std::size_t i = 0, len = ring.size(), j = len - 1; i < len; j = i++) {
+            const auto& a = ring[i];
+            const auto& b = ring[j];
+
+            if ((a.get<1>() > point.get<1>()) != (b.get<1>() > point.get<1>()) &&
+                (point.get<0>() < (b.get<0>() - a.get<0>()) * (point.get<1>() - a.get<1>()) / (b.get<1>() - a.get<1>()) + a.get<0>())) inside = !inside;
+
+            minDistSq = std::min(minDistSq, getSegDistSq(point, a, b));
+        }
+    }
+
+    return (inside ? 1 : -1) * std::sqrt(minDistSq);
+}
+
+struct Cell {
+    Cell(const Point& c_, double h_, const Polygon& polygon)
+        : c(c_),
+          h(h_),
+          d(pointToPolygonDist(c, polygon)),
+          max(d + h * std::sqrt(2))
+        {}
+
+    Point c; // cell center
+    double h; // half the cell size
+    double d; // distance from cell center to polygon
+    double max; // max distance to polygon within a cell
+};
+
+// get polygon centroid
+Cell getCentroidCell(const Polygon& polygon) {
+    double area = 0;
+    double cx = 0, cy = 0;
+    const auto& ring = polygon.outer();
+
+    for (std::size_t i = 0, len = ring.size(), j = len - 1; i < len; j = i++) {
+        const Point& a = ring[i];
+        const Point& b = ring[j];
+        auto f = a.get<0>() * b.get<1>() - b.get<0>() * a.get<1>();
+        cx += (a.get<0>() + b.get<0>()) * f;
+        cy += (a.get<1>() + b.get<1>()) * f;
+        area += f * 3;
+    }
+
+    Point c { cx, cy };
+    return Cell(area == 0 ? ring.at(0) : Point { cx / area, cy / area }, 0, polygon);
+}
+
+} // namespace detail
+
+Point polylabel(const Polygon& polygon, double precision = 0.00001, bool debug = false) {
+    using namespace detail;
+
+    // find the bounding box of the outer ring
+    Box envelope;
+    geom::envelope(polygon.outer(), envelope);
+
+    const Point size {
+        envelope.max_corner().get<0>() - envelope.min_corner().get<0>(),
+        envelope.max_corner().get<1>() - envelope.min_corner().get<1>()
+    };
+
+    const double cellSize = std::min(size.get<0>(), size.get<1>());
+    double h = cellSize / 2;
+
+    // a priority queue of cells in order of their "potential" (max distance to polygon)
+    auto compareMax = [] (const Cell& a, const Cell& b) {
+        return a.max < b.max;
+    };
+    using Queue = std::priority_queue<Cell, std::vector<Cell>, decltype(compareMax)>;
+    Queue cellQueue(compareMax);
+
+    if (cellSize == 0) {
+        return envelope.min_corner();
+    }
+
+    // cover polygon with initial cells
+
+    for (double x = envelope.min_corner().get<0>(); x < envelope.max_corner().get<0>(); x += cellSize) {
+        for (double y = envelope.min_corner().get<1>(); y < envelope.max_corner().get<1>(); y += cellSize) {
+            cellQueue.push(Cell({x + h, y + h}, h, polygon));
+        }
+    }
+
+    // take centroid as the first best guess
+    auto bestCell = getCentroidCell(polygon);
+
+    // second guess: bounding box centroid
+    Cell bboxCell(
+        Point {
+            envelope.min_corner().get<0>() + size.get<0>() / 2.0,
+            envelope.min_corner().get<1>() + size.get<1>() / 2.0
+        }, 0, polygon);
+    if (bboxCell.d > bestCell.d) {
+        bestCell = bboxCell;
+    }
+
+    auto numProbes = cellQueue.size();
+    while (!cellQueue.empty()) {
+        // pick the most promising cell from the queue
+        auto cell = cellQueue.top();
+        cellQueue.pop();
+
+        // update the best cell if we found a better one
+        if (cell.d > bestCell.d) {
+            bestCell = cell;
+            if (debug) std::cout << "found best " << ::round(1e4 * cell.d) / 1e4 << " after " << numProbes << " probes" << std::endl;
+        }
+
+        // do not drill down further if there's no chance of a better solution
+        if (cell.max - bestCell.d <= precision) continue;
+
+        // split the cell into four cells
+        h = cell.h / 2;
+        cellQueue.push(Cell({cell.c.get<0>() - h, cell.c.get<1>() - h}, h, polygon));
+        cellQueue.push(Cell({cell.c.get<0>() + h, cell.c.get<1>() - h}, h, polygon));
+        cellQueue.push(Cell({cell.c.get<0>() - h, cell.c.get<1>() + h}, h, polygon));
+        cellQueue.push(Cell({cell.c.get<0>() + h, cell.c.get<1>() + h}, h, polygon));
+        numProbes += 4;
+    }
+
+    if (debug) {
+        std::cout << "num probes: " << numProbes << std::endl;
+        std::cout << "best distance: " << bestCell.d << std::endl;
+    }
+
+    return bestCell.c;
+}
+
+} // namespace mapbox

--- a/include/relation_roles.h
+++ b/include/relation_roles.h
@@ -1,0 +1,22 @@
+#ifndef RELATION_ROLES_H
+#define RELATION_ROLES_H
+
+#include <boost/container/flat_map.hpp>
+#include <mutex>
+#include <vector>
+#include <string>
+
+class RelationRoles {
+public:
+	RelationRoles();
+	uint16_t getOrAddRole(const std::string& role);
+	std::string getRole(uint16_t role) const;
+
+private:
+	std::vector<std::string> popularRoleStrings;
+	std::vector<std::string> rareRoleStrings;
+	std::mutex mutex;
+	boost::container::flat_map<std::string, uint16_t> popularRoles;
+	boost::container::flat_map<std::string, uint16_t> rareRoles;
+};
+#endif

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -566,7 +566,7 @@ function way_function(way)
 
 	-- Set 'housenumber'
 	if housenumber~="" then
-		way:LayerAsCentroid("housenumber", false)
+		way:LayerAsCentroid("housenumber")
 		way:Attribute("housenumber", housenumber)
 	end
 

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -172,7 +172,17 @@ function node_function(node)
 		node:MinZoom(mz)
 		if rank then node:AttributeNumeric("rank", rank) end
 		if capital then node:AttributeNumeric("capital", capital) end
-		if place=="country" then node:Attribute("iso_a2", node:Find("ISO3166-1:alpha2")) end
+		if place=="country" then
+			local iso_a2 = node:Find("ISO3166-1:alpha2")
+			while iso_a2 == "" do
+				local rel, role = node:NextRelation()
+				if not rel then break end
+				if role == 'label' then
+					iso_a2 = node:FindInRelation("ISO3166-1:alpha2")
+				end
+			end
+			node:Attribute("iso_a2", iso_a2)
+		end
 		SetNameAttributes(node)
 		return
 	end

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -577,6 +577,9 @@ Point OsmLuaProcessing::calculateCentroid(CentroidAlgorithm algorithm) {
 					index = i;
 				}
 			}
+
+			if (tmp.size() == 0)
+				throw geom::centroid_exception();
 			centroid = mapbox::polylabel(tmp[index]);
 		} else {
 			geom::centroid(tmp, centroid);

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -580,9 +580,22 @@ Point OsmLuaProcessing::calculateCentroid(CentroidAlgorithm algorithm) {
 	}
 }
 
-std::vector<double> OsmLuaProcessing::Centroid() {
-	// TODO: make this configurable by a parameter
-	Point c = calculateCentroid(CentroidAlgorithm::Polylabel);
+OsmLuaProcessing::CentroidAlgorithm OsmLuaProcessing::parseCentroidAlgorithm(const std::string& algorithm) const {
+	if (algorithm == "polylabel") return OsmLuaProcessing::CentroidAlgorithm::Polylabel;
+	if (algorithm == "centroid") return OsmLuaProcessing::CentroidAlgorithm::Centroid;
+
+	throw std::runtime_error("unknown centroid algorithm " + algorithm);
+}
+
+std::vector<double> OsmLuaProcessing::Centroid(kaguya::VariadicArgType algorithmArgs) {
+	CentroidAlgorithm algorithm = defaultCentroidAlgorithm();
+
+	for (auto needleRef : algorithmArgs) {
+		const std::string needle = needleRef.get<std::string>();
+		algorithm = parseCentroidAlgorithm(needle);
+		break;
+	}
+	Point c = calculateCentroid(algorithm);
 	return std::vector<double> { latp2lat(c.y()/10000000.0), c.x()/10000000.0 };
 }
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -582,7 +582,7 @@ template<>  struct kaguya::lua_type_traits<OsmLuaProcessing::OptionalRelation> {
 OsmLuaProcessing::OptionalRelation OsmLuaProcessing::NextRelation() {
 	relationSubscript++;
 	if (relationSubscript >= relationList.size()) return { true };
-	return { false, relationList[relationSubscript].first, relationList[relationSubscript].second };
+	return { false, static_cast<lua_Integer>(relationList[relationSubscript].first), relationList[relationSubscript].second };
 }
 
 void OsmLuaProcessing::RestartRelations() {

--- a/src/pbf_processor.cpp
+++ b/src/pbf_processor.cpp
@@ -167,11 +167,6 @@ bool PbfProcessor::ScanRelations(OsmLuaProcessing& output, PbfReader::PrimitiveG
 	int typeKey = findStringPosition(pb, "type");
 	int mpKey   = findStringPosition(pb, "multipolygon");
 
-	int innerKey= findStringPosition(pb, "inner");
-	int outerKey= findStringPosition(pb, "outer");
-	int labelKey = findStringPosition(pb, "label");
-	int adminCentreKey = findStringPosition(pb, "admin_centre");
-
 	for (PbfReader::Relation pbfRelation : pg.relations()) {
 		bool isMultiPolygon = relationIsType(pbfRelation, typeKey, mpKey);
 		bool isAccepted = false;
@@ -189,24 +184,16 @@ bool PbfProcessor::ScanRelations(OsmLuaProcessing& output, PbfReader::PrimitiveG
 
 			if (pbfRelation.types[n] == PbfReader::Relation::MemberType::NODE) {
 				if (isAccepted) {
-					std::string role;
-					if (pbfRelation.roles_sid[n] == labelKey)
-						role = "label";
-					else if (pbfRelation.roles_sid[n] == adminCentreKey)
-						role = "admin_centre";
-
+					const auto& roleView = pb.stringTable[pbfRelation.roles_sid[n]];
+					std::string role(roleView.data(), roleView.size());
 					osmStore.relation_contains_node(relid, lastID, role);
 				}
 			} else if (pbfRelation.types[n] == PbfReader::Relation::MemberType::WAY) {
 				if (lastID >= pow(2,42)) throw std::runtime_error("Way ID in relation "+std::to_string(relid)+" negative or too large: "+std::to_string(lastID));
 				osmStore.mark_way_used(static_cast<WayID>(lastID));
 				if (isAccepted) {
-					std::string role;
-					if (pbfRelation.roles_sid[n] == outerKey)
-						role = "outer";
-					else if (pbfRelation.roles_sid[n] == innerKey)
-						role = "inner";
-
+					const auto& roleView = pb.stringTable[pbfRelation.roles_sid[n]];
+					std::string role(roleView.data(), roleView.size());
 					osmStore.relation_contains_way(relid, lastID, role);
 				}
 			}

--- a/src/pbf_processor.cpp
+++ b/src/pbf_processor.cpp
@@ -186,7 +186,7 @@ bool PbfProcessor::ScanRelations(OsmLuaProcessing& output, PbfReader::PrimitiveG
 				if (isAccepted) {
 					const auto& roleView = pb.stringTable[pbfRelation.roles_sid[n]];
 					std::string role(roleView.data(), roleView.size());
-					osmStore.relation_contains_node(relid, lastID, role);
+					osmStore.scannedRelations.relation_contains_node(relid, lastID, role);
 				}
 			} else if (pbfRelation.types[n] == PbfReader::Relation::MemberType::WAY) {
 				if (lastID >= pow(2,42)) throw std::runtime_error("Way ID in relation "+std::to_string(relid)+" negative or too large: "+std::to_string(lastID));
@@ -194,7 +194,7 @@ bool PbfProcessor::ScanRelations(OsmLuaProcessing& output, PbfReader::PrimitiveG
 				if (isAccepted) {
 					const auto& roleView = pb.stringTable[pbfRelation.roles_sid[n]];
 					std::string role(roleView.data(), roleView.size());
-					osmStore.relation_contains_way(relid, lastID, role);
+					osmStore.scannedRelations.relation_contains_way(relid, lastID, role);
 				}
 			}
 		}

--- a/src/pbf_processor.cpp
+++ b/src/pbf_processor.cpp
@@ -259,7 +259,7 @@ bool PbfProcessor::ReadRelations(
 			try {
 				tag_map_t tags;
 				readTags(pbfRelation, pb, tags);
-				output.setRelation(pbfRelation.id, outerWayVec, innerWayVec, tags, isMultiPolygon, isInnerOuter);
+				output.setRelation(pb.stringTable, pbfRelation, outerWayVec, innerWayVec, tags, isMultiPolygon, isInnerOuter);
 
 			} catch (std::out_of_range &err) {
 				// Relation is missing a member?

--- a/src/relation_roles.cpp
+++ b/src/relation_roles.cpp
@@ -1,0 +1,57 @@
+#include "relation_roles.h"
+
+RelationRoles::RelationRoles() {
+	// Computed in early 2024 from popular roles: https://gist.github.com/systemed/29ea4c8d797a20dcdffee8ba907d62ea
+	// This is just an optimization to avoid taking a lock in the common case.
+	//
+	// The list should be refreshed if the set of popular roles dramatically changes,
+	// but tilemaker will still be correct, just slower.
+	popularRoleStrings = {
+		"",
+		"1700","1800","1900","2700","2800","2900","3000","3100","3200","above","accessfrom",
+		"accessto","accessvia","across","address","admin_centre","alternative","associated",
+		"attached_to","backward","basket","both","branch_circuit","building","buildingpart",
+		"builidingpart","camera","claimed","connection","contains","crossing","destination",
+		"device","de_facto","east","edge","empty role","end","endpoint","entrance","entry",
+		"ex-camera","exit","extent","facility","force","forward","from","generator","give_way",
+		"graph","guidepost","hidden","highway","Hole","hole","house","inner","intersection",
+		"in_tunnel","junction","label","lable","landuse","lateral","left","line","location_hint",
+		"lower","main","main_stream","marker","member","memorial","mirror","negative",
+		"negative:entry","negative:exit","negative:parking","object","on_bridge","outer",
+		"outline","part","pedestrian","pin","pit_lane","platform","positive","positive:entry",
+		"positive:exit","positive:parking","priority","ridge","right","road_marking","road_sign",
+		"room","section","sector","shell","side_stream","sign","signal","start","stop","street",
+		"sub-relation","subarea","subbasin","substation","switch","target","tee","through","to",
+		"tomb","track","tracksection","traffic_sign","tributary","trunk_circuit","under","upper",
+		"via","visible","walk","ways","west"
+	};
+
+	for (const auto& s : popularRoleStrings) {
+		popularRoles[s] = popularRoles.size();
+	}
+}
+
+std::string RelationRoles::getRole(uint16_t role) const {
+	if (role < popularRoleStrings.size())
+		return popularRoleStrings[role];
+
+	return rareRoleStrings[role - popularRoleStrings.size()];
+}
+
+uint16_t RelationRoles::getOrAddRole(const std::string& role) {
+	{
+		const auto& pos = popularRoles.find(role);
+		if (pos != popularRoles.end())
+			return pos->second;
+	}
+
+	std::lock_guard<std::mutex> lock(mutex);
+	const auto& pos = rareRoles.find(role);
+	if (pos != rareRoles.end())
+		return pos->second;
+
+	uint16_t rv = popularRoleStrings.size() + rareRoleStrings.size();
+	rareRoles[role] = rv;
+	rareRoleStrings.push_back(role);
+	return rv;
+}

--- a/test/relation_roles.test.cpp
+++ b/test/relation_roles.test.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include "external/minunit.h"
+#include "relation_roles.h"
+
+MU_TEST(test_relation_roles) {
+	RelationRoles rr;
+
+	mu_check(rr.getRole(0) == "");
+	mu_check(rr.getOrAddRole("inner") == rr.getOrAddRole("inner"));
+	mu_check(rr.getOrAddRole("never before seen") == rr.getOrAddRole("never before seen"));
+	mu_check(rr.getRole(rr.getOrAddRole("inner")) == "inner");
+	mu_check(rr.getRole(rr.getOrAddRole("never before seen")) == "never before seen");
+}
+
+MU_TEST_SUITE(test_suite_relation_roles) {
+	MU_RUN_TEST(test_relation_roles);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_relation_roles);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}
+


### PR DESCRIPTION
This also makes `NextRelation` return a tuple of ID, role rather than just ID.

According to https://www.lua.org/pil/5.1.html, I think that's not a breaking change.

Motivation: When I naively try to create labels from OSM entities with the `place` tag, I occasionally get duplicates due to relations.

For example, the city of Guelph has [relation 7486148](https://www.openstreetmap.org/relation/7486148), which has [node 36576733](https://www.openstreetmap.org/node/36576733) as its `label` member.

They both have `place=city`, so my Lua script faithfully spits out two labels.

This PR allows me to suppress the label from the node, which is a start.

Ideally, I'd actually prefer to use the node, as it'll likely have a nicely human-curated location. For that, I'd need the relation to be able to interrogate its members.

Would you be open to me extending this PR to add `NextMember`, `FindInMember` and `RestartMembers` functions that mirror the ones used by nodes/ways ?