### PR TITLE
Nested relations via post-scan phase

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -19,6 +19,7 @@
 typedef uint32_t ShardedNodeID;
 typedef uint64_t NodeID;
 typedef uint64_t WayID;
+typedef uint64_t RelationID;
 
 typedef std::vector<WayID> WayVec;
 

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -64,6 +64,7 @@ public:
 	
 	// Do we have Lua routines for non-MP relations?
 	bool canReadRelations();
+	bool canPostScanRelations();
 	bool canWriteRelations();
 
 	// Shapefile tag remapping
@@ -77,7 +78,10 @@ public:
 
 	// Scan non-MP relation
 	bool scanRelation(WayID id, const tag_map_t &tags);
-
+	
+	// Post-scan non-MP relations
+	void postScanRelations();
+	
 	/// \brief We are now processing a significant node
 	void setNode(NodeID id, LatpLon node, const tag_map_t &tags);
 
@@ -108,6 +112,9 @@ public:
 
 	// Get an OSM tag for a given key (or return empty string if none)
 	const std::string Find(const std::string& key) const;
+
+	// Check if an object has any tags
+	bool HasTags() const;
 
 	// ----	Spatial queries called from Lua
 
@@ -194,6 +201,7 @@ public:
 	void RestartRelations();
 	std::string FindInRelation(const std::string &key);
 	void Accept();
+	void SetTag(const std::string &key, const std::string &value);
 
 	// Write error if in verbose mode
 	void ProcessingError(const std::string &errStr) {
@@ -237,6 +245,9 @@ private:
 		relationList.clear();
 		relationSubscript = -1;
 		lastStoredGeometryId = 0;
+		isWay = false;
+		isRelation = false;
+		isPostScanRelation = false;
 	}
 
 	const inline Point getPoint() {
@@ -248,6 +259,7 @@ private:
 	kaguya::State luaState;
 	bool supportsRemappingShapefiles;
 	bool supportsReadingRelations;
+	bool supportsPostScanRelations;
 	bool supportsWritingRelations;
 	const class ShpMemTiles &shpMemTiles;
 	class OsmMemTiles &osmMemTiles;
@@ -259,6 +271,7 @@ private:
 	bool relationAccepted;					// in scanRelation, whether we're using a non-MP relation
 	std::vector<std::pair<WayID, uint16_t>> relationList;		// in processNode/processWay, list of relations this entity is in, and its role
 	int relationSubscript = -1;				// in processWay, position in the relation list
+	bool isPostScanRelation;				// processing a relation in postScanRelation
 
 	int32_t lon,latp;						///< Node coordinates
 	LatpLonVec const *llVecPtr;
@@ -283,6 +296,7 @@ private:
 	std::vector<std::pair<OutputObject, AttributeSet>> outputs;		// All output objects that have been created
 	const boost::container::flat_map<protozero::data_view, protozero::data_view, DataViewLessThan>* currentTags;
 	const PbfReader::Relation* currentRelation;
+	const boost::container::flat_map<std::string, std::string>* currentPostScanTags; // for postScan only
 	const std::vector<protozero::data_view>* stringTable;
 
 	std::vector<OutputObject> finalizeOutputs();

--- a/src/pbf_processor.cpp
+++ b/src/pbf_processor.cpp
@@ -188,6 +188,12 @@ bool PbfProcessor::ScanRelations(OsmLuaProcessing& output, PbfReader::PrimitiveG
 					std::string role(roleView.data(), roleView.size());
 					osmStore.scannedRelations.relation_contains_node(relid, lastID, role);
 				}
+			} else if (pbfRelation.types[n] == PbfReader::Relation::MemberType::RELATION) {
+				if (isAccepted) {
+					const auto& roleView = pb.stringTable[pbfRelation.roles_sid[n]];
+					std::string role(roleView.data(), roleView.size());
+					osmStore.scannedRelations.relation_contains_relation(relid, lastID, role);
+				}
 			} else if (pbfRelation.types[n] == PbfReader::Relation::MemberType::WAY) {
 				if (lastID >= pow(2,42)) throw std::runtime_error("Way ID in relation "+std::to_string(relid)+" negative or too large: "+std::to_string(lastID));
 				osmStore.mark_way_used(static_cast<WayID>(lastID));
@@ -622,6 +628,10 @@ int PbfProcessor::ReadPbfFile(
 #endif
 		}
 
+		if(phase == ReadPhase::RelationScan) {
+			auto output = generate_output();
+			output->postScanRelations();
+		}
 		if(phase == ReadPhase::Nodes) {
 			osmStore.nodes.finalize(threadNum);
 		}


### PR DESCRIPTION
With #632 we have support for nodes in relations and for relation roles. This completes the missing functionality by supporting nested relations.

Nested relations are quite niche but important for a few use cases, particularly cycling and walking routes. Because each relation type is sui generis, it's difficult to provide an interface which caters for all use cases while remaining performant. This PR provides two (related) mechanisms:

- `relation_function` can now iterate through its parents using `NextRelation` as usual
- a new `relation_postscan_function` is supported, which is called immediately after the `relation_scan_function` phase

### Relation post-scan

The purpose of `relation_postscan_function` is to enable tags from parent relations to "bounce down" to their children. Consider this common case:

- a route relation 12345 (`type=route, route=bicycle, network=ncn, ref=5`) contains ways
- a route relation 23456 (`type=route, route=bicycle, network=icn, ref=EV3`) contains route relation 12345 and some others

Previously, tilemaker's `way_function` could only see the relation that the ways were a direct member of, i.e. 12345. We could potentially expand it so that `NextRelation` within `way_function` iterated over parent relations too, but this would mean repeating the same processing for potentially thousands of member ways.

Instead, we provide a way to modify the child relation via a new `SetTag` method:

````lua
function relation_postscan_function(child)
	print("In relation_postscan_function for "..child:Id())
	print("child network is "..child:Find("network"))
	while true do
		local parent,role = child:NextRelation()
		if not parent then break end
		local parent_ref = child:FindInRelation("ref")
		print(" - in "..parent.." "..parent_ref.."/"..role)
		child:SetTag("child_of", parent_ref)
	end
end
````

Then, when `way_function` comes to examine the relations that the way is a member of, it'll be able to do things based on the tags we've set (in this case, `child_of`).

### Deeply nested relations

The OSM data model allows multiple levels of nesting, e.g. way->relation->relation->relation.

For `relation_postscan_function` we flatten out all these levels. The `relations_for_relation_with_parents` method returns a `relationList`-style list of all the parent/grandparent/great-grandparent/etc. relations. The original hierarchy is not recorded. We do trap circular references (these exist!).

(We could potentially use `relations_for_relation_with_parents` in `way_function` and `relation_function`, but it means more copying and would be a performance hit. If people want it then we could perhaps offer it as a config option, or provide a method callable from Lua to invoke it.)

### Implementation issues

Scanned relation tags are currently stored in a map of `std::string`s. Other entity tags are stored in a map of protozero views. This means `OsmLuaProcessing::Holds` and `::Find` have to check a boolean before working out which one to interrogate, which is a bit ugly. Perhaps we could move scanned relation tags to use protozero views, at which point we can just set `currentTags` to that and be done with it.

The post-scan code is currently single-threaded - the number of nested relations is probably so low that multi-threading would only save seconds on a full planet - but that could of course be changed.

I've added a `HasTags` Lua-accessible method as a quick way of testing whether a relation has tags (this is useful in Geofabrik extracts which ship empty relations outside the area).

@cldellow This will of course interact with #626 - I don't mind tidying it up to work with that (assuming `SetTag` is still doable...) but thought I'd get a proof-of-concept working with the current codebase first.