### PR TITLE
remove PossiblyKnownTagValue; fixup LayerAsCentroid; fixup way_keys interaction with LayerAsCentroid; fixup Intersects

### DIFF
--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -10,6 +10,7 @@
 #include <boost/functional/hash.hpp>
 #include <boost/container/flat_map.hpp>
 #include <vector>
+#include <protozero/data_view.hpp>
 #include "pooled_string.h"
 #include "deque_map.h"
 
@@ -126,7 +127,7 @@ struct AttributePair {
 
 	void ensureStringIsOwned();
 
-	static bool isHot(const std::string& keyName, const std::string& value) {
+	static bool isHot(const std::string& keyName, const protozero::data_view value) {
 		// Is this pair a candidate for the hot pool?
 
 		// Hot pairs are pairs that we think are likely to be re-used, like
@@ -139,7 +140,8 @@ struct AttributePair {
 
 		// Only strings that are IDish are eligible: only lowercase letters.
 		bool ok = true;
-		for (const auto& c: value) {
+		for (size_t i = 0; i < value.size(); i++) {
+			const auto c = value.data()[i];
 			if (c != '-' && c != '_' && (c < 'a' || c > 'z'))
 				return false;
 		}
@@ -404,7 +406,7 @@ struct AttributeStore {
 	void reportSize() const;
 	void finalize();
 
-	void addAttribute(AttributeSet& attributeSet, std::string const &key, const std::string& v, char minzoom);
+	void addAttribute(AttributeSet& attributeSet, std::string const &key, const protozero::data_view v, char minzoom);
 	void addAttribute(AttributeSet& attributeSet, std::string const &key, float v, char minzoom);
 	void addAttribute(AttributeSet& attributeSet, std::string const &key, bool v, char minzoom);
 	

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -36,19 +36,6 @@ extern bool verbose;
 class AttributeStore;
 class AttributeSet;
 
-// A string, which might be in `currentTags` as a value. If Lua
-// code refers to an absent value, it'll fallback to passing
-// it as a std::string.
-//
-// The intent is that Attribute("name", Find("name")) is a common
-// pattern, and we ought to avoid marshalling a string back and
-// forth from C++ to Lua when possible.
-struct PossiblyKnownTagValue {
-	bool found;
-	uint32_t index;
-	std::string fallback;
-};
-
 /**
 	\brief OsmLuaProcessing - converts OSM objects into OutputObjects.
 	
@@ -183,12 +170,9 @@ public:
 	void LayerAsCentroid(const std::string &layerName, kaguya::VariadicArgType nodeSources);
 	
 	// Set attributes in a vector tile's Attributes table
-	void Attribute(const std::string &key, const std::string &val);
-	void AttributeWithMinZoom(const std::string &key, const std::string &val, const char minzoom);
-	void AttributeNumeric(const std::string &key, const float val);
-	void AttributeNumericWithMinZoom(const std::string &key, const float val, const char minzoom);
-	void AttributeBoolean(const std::string &key, const bool val);
-	void AttributeBooleanWithMinZoom(const std::string &key, const bool val, const char minzoom);
+	void Attribute(const std::string &key, const protozero::data_view val, const char minzoom);
+	void AttributeNumeric(const std::string &key, const float val, const char minzoom);
+	void AttributeBoolean(const std::string &key, const bool val, const char minzoom);
 	void MinZoom(const double z);
 	void ZOrder(const double z);
 	

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -26,6 +26,7 @@ public:
 	bool test(NodeID id);
 	void set(NodeID id);
 	void enable();
+	bool enabled() const;
 	void clear();
 
 private:

--- a/include/pooled_string.h
+++ b/include/pooled_string.h
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
+#include <protozero/data_view.hpp>
 
 namespace PooledStringNS {
   class PooledString {
@@ -40,9 +41,10 @@ namespace PooledStringNS {
       PooledString(const std::string& str);
 
 
-      // Create a std string - only valid so long as the string that is
-      // pointed to is valid.
-      PooledString(const std::string* str);
+      // Wrap a protozero::data_view - only valid so long as the
+      // data_view that is pointed to is valid; call ensureStringIsOwned
+      // if you need to persist the string.
+      PooledString(const protozero::data_view* str);
       size_t size() const;
       bool operator<(const PooledString& other) const;
       bool operator==(const PooledString& other) const;

--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -240,7 +240,7 @@ void AttributeSet::removePairWithKey(const AttributePairStore& pairStore, uint32
 	}
 }
 
-void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, const std::string& v, char minzoom) {
+void AttributeStore::addAttribute(AttributeSet& attributeSet, std::string const &key, const protozero::data_view v, char minzoom) {
 	PooledString ps(&v);
 	AttributePair kv(keyStore.key2index(key), ps, minzoom);
 	bool isHot = AttributePair::isHot(key, v);

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -606,11 +606,11 @@ void OsmLuaProcessing::LayerAsCentroid(const string &layerName, kaguya::Variadic
 		// If we're a relation, see if the user would prefer we use one of its members
 		// to label the point.
 		if (isRelation) {
-			size_t i = 0;
+			int i = -1;
 			for (auto needleRef : varargs) {
+				i++;
 				// Skip the first vararg, it's the algorithm.
 				if (i == 0) continue;
-				i++;
 				const std::string needle = needleRef.get<std::string>();
 
 				// We do a linear search of the relation's members. This is not very efficient

--- a/src/osm_store.cpp
+++ b/src/osm_store.cpp
@@ -35,6 +35,10 @@ void UsedObjects::enable() {
 	status = Status::Enabled;
 }
 
+bool UsedObjects::enabled() const {
+	return status == Status::Enabled;
+}
+
 void UsedObjects::set(NodeID id) {
 	const size_t chunk = id / 65536;
 

--- a/src/pbf_processor.cpp
+++ b/src/pbf_processor.cpp
@@ -220,6 +220,9 @@ bool PbfProcessor::ScanRelations(OsmLuaProcessing& output, PbfReader::PrimitiveG
 					const auto& roleView = pb.stringTable[pbfRelation.roles_sid[n]];
 					std::string role(roleView.data(), roleView.size());
 					osmStore.scannedRelations.relation_contains_node(relid, lastID, role);
+
+					if (osmStore.usedNodes.enabled())
+						osmStore.usedNodes.set(lastID);
 				}
 			} else if (pbfRelation.types[n] == PbfReader::Relation::MemberType::WAY) {
 				if (lastID >= pow(2,42)) throw std::runtime_error("Way ID in relation "+std::to_string(relid)+" negative or too large: "+std::to_string(lastID));

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -77,8 +77,8 @@ bool ShpMemTiles::mayIntersect(const std::string& layerName, const Box& box) con
 	uint32_t y1 = lat2tiley(lat1, indexZoom);
 	uint32_t y2 = lat2tiley(lat2, indexZoom);
 
-	for (int x = std::min(x1, x2); x < std::max(x1, x2); x++) {
-		for (int y = std::min(y1, y2); y < std::max(y1, y2); y++) {
+	for (int x = std::min(x1, x2); x <= std::max(x1, x2); x++) {
+		for (int y = std::min(y1, y2); y <= std::max(y1, y2); y++) {
 			if (bitvec[x * (1 << indexZoom) + y])
 				return true;
 		}

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -77,8 +77,8 @@ bool ShpMemTiles::mayIntersect(const std::string& layerName, const Box& box) con
 	uint32_t y1 = lat2tiley(lat1, indexZoom);
 	uint32_t y2 = lat2tiley(lat2, indexZoom);
 
-	for (int x = std::min(x1, x2); x <= std::max(x1, x2); x++) {
-		for (int y = std::min(y1, y2); y <= std::max(y1, y2); y++) {
+	for (int x = std::min(x1, x2); x <= std::min((1u << indexZoom) - 1u, std::max(x1, x2)); x++) {
+		for (int y = std::min(y1, y2); y <= std::min((1u << indexZoom) - 1u, std::max(y1, y2)); y++) {
 			if (bitvec[x * (1 << indexZoom) + y])
 				return true;
 		}
@@ -171,8 +171,8 @@ void ShpMemTiles::StoreGeometry(
 	uint32_t y1 = lat2tiley(lat1, indexZoom);
 	uint32_t y2 = lat2tiley(lat2, indexZoom);
 
-	for (int x = std::min(x1, x2); x < std::max(x1, x2); x++) {
-		for (int y = std::min(y1, y2); y < std::max(y1, y2); y++) {
+	for (int x = std::min(x1, x2); x <= std::min((1u << indexZoom) - 1u, std::max(x1, x2)); x++) {
+		for (int y = std::min(y1, y2); y <= std::min((1u << indexZoom) - 1u, std::max(y1, y2)); y++) {
 			bitvec[x * (1 << indexZoom) + y] = true;
 		}
 	}

--- a/test/pooled_string.test.cpp
+++ b/test/pooled_string.test.cpp
@@ -23,13 +23,15 @@ MU_TEST(test_pooled_string) {
 	mu_check(big.toString() != big2.toString());
 
 	std::string shortString("short");
+	protozero::data_view shortStringView = { shortString.data(), shortString.size() };
 	std::string longString("this is a very long string");
+	protozero::data_view longStringView = { longString.data(), longString.size() };
 
-	PooledString stdShortString(&shortString);
+	PooledString stdShortString(&shortStringView);
 	mu_check(stdShortString.size() == 5);
 	mu_check(stdShortString.toString() == "short");
 
-	PooledString stdLongString(&longString);
+	PooledString stdLongString(&longStringView);
 	mu_check(stdLongString.size() == 26);
 	mu_check(stdLongString.toString() == "this is a very long string");
 

--- a/test/sorted_way_store.test.cpp
+++ b/test/sorted_way_store.test.cpp
@@ -15,7 +15,9 @@ class TestNodeStore : public NodeStore {
 	void insert(const std::vector<std::pair<NodeID, LatpLon>>& elements) override {}
 
 	bool contains(size_t shard, NodeID id) const override { return true; }
-	size_t shard() const override { return 0; }
+	NodeStore& shard(size_t shard) override { return *this; }
+	const NodeStore& shard(size_t shard) const override { return *this; }
+
 	size_t shards() const override { return 1; }
 };
 


### PR DESCRIPTION
When I replaced #604 with #626, I botched extracting this part of the code. I had the trait, which taught kaguya how to serialize `PossiblyKnownTagValue`, but I missed updating the parameter type of `Attribute` to actually use it, so it was a no-op.

This PR restores the behaviour of avoiding string copies, but now that we have protozero's data_view class, we can use that rather than our own weirdo struct.

It also fixes an unrelated test build error in the way store test.

...and two issues to do with LayerAsCentroid's support for relation members.

...and an issue with the Intersects PR.