### PR TITLE
Standalone coastline config and docs

### DIFF
--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -91,10 +91,32 @@ Then rerun with another .pbf, using the `--merge` flag:
 The second run will proceed a little more slowly due to reading in existing tiles in areas which 
 overlap. Any OSM objects which appear in both files will be written twice.
 
-If you're very pushed for memory, you could potentially use `osmium tags-filter` to split a 
-.pbf into several "thematic" extracts: for example, one containing buildings, another roads, 
-and another landuse. Renumber each one, then run tilemaker several times with `--merge` to add 
-one theme at a time.
+### Creating a map with varying detail
+
+A map with global coastline, but detailed mapping only for a specific region, is a common use case.
+You can use tilemaker's `--merge` switch to achieve this.
+
+First, create a global coastline .mbtiles. There's a special stripped down config for this:
+
+    tilemaker --output coastline.mbtiles \
+              --bbox -180,-85,180,85 \
+              --process resources/process-coastline.lua \
+              --config resources/config-coastline.json
+
+Save this .mbtiles somewhere; then make a copy, and call it output.mbtiles.
+
+Edit `resources/config-openmaptiles.json` to remove the `ocean`, `urban_areas`, `ice_shelf` and 
+`glacier` layers (because we've already generated these).
+
+Now simply merge the region you want into the coastline .mbtiles you generated:
+
+    tilemaker --input new-zealand.osm.pbf \
+              --output output.mbtiles \
+              --merge \
+              --process resources/process-openmaptiles.lua \
+              --config resources/config-openmaptiles.json
+
+Don't forget to add `--store /path/to/your/ssd` if you don't have lots of RAM.
 
 ## Output messages
 

--- a/resources/config-coastline.json
+++ b/resources/config-coastline.json
@@ -1,7 +1,13 @@
 {
 	"layers": {
-		"water": { "minzoom": 6,  "maxzoom": 14, "simplify_below": 12, "simplify_length": 1, "simplify_ratio": 2},
-		"ocean": { "minzoom": 0,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "simplify_below": 13, "simplify_level": 0.0001, "simplify_ratio": 2, "filter_below": 12, "filter_area": 0.5, "write_to": "water", "index": true, "source_columns": true }
+		"water":       { "minzoom": 6,  "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003, "simplify_ratio": 2 },
+		"ocean":       { "minzoom": 0,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "filter_below": 12, "filter_area": 0.5, 
+		                 "simplify_below": 13, "simplify_level": 0.0001, "simplify_ratio": 2, "write_to": "water" },
+		"landuse":     { "minzoom":  4, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "simplify_ratio": 2 },
+		"urban_areas": { "minzoom":  4, "maxzoom":  8, "source": "landcover/ne_10m_urban_areas/ne_10m_urban_areas.shp", "source_columns": ["featurecla"], "simplify_below": 7, "simplify_level": 0.0003, "simplify_ratio": 2, "write_to": "landuse" },
+		"landcover":   { "minzoom":  0, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "simplify_ratio": 2 },
+		"ice_shelf":   { "minzoom":  0, "maxzoom":  9, "source": "landcover/ne_10m_antarctic_ice_shelves_polys/ne_10m_antarctic_ice_shelves_polys.shp", "source_columns": ["featurecla"], "simplify_below": 13, "simplify_level": 0.0005, "write_to": "landcover" },
+		"glacier":     { "minzoom":  2, "maxzoom":  9, "source": "landcover/ne_10m_glaciated_areas/ne_10m_glaciated_areas.shp", "source_columns": ["featurecla"], "simplify_below": 13, "simplify_level": 0.0005, "write_to": "landcover" }
 	},
 	"settings": {
 		"minzoom": 0,

--- a/resources/process-coastline.lua
+++ b/resources/process-coastline.lua
@@ -1,8 +1,3 @@
--- Data processing based on openmaptiles.org schema
--- https://openmaptiles.org/schema/
--- Copyright (c) 2016, KlokanTech.com & OpenMapTiles contributors.
--- Used under CC-BY 4.0
-
 -- Enter/exit Tilemaker
 function init_function()
 end
@@ -16,7 +11,17 @@ end
 function way_function()
 end
 
--- Remap coastlines
-function attribute_function(attr)
-	return { class="ocean" }
+-- Remap coastlines and landcover
+function attribute_function(attr,layer)
+	if attr["featurecla"]=="Glaciated areas" then
+		return { subclass="glacier" }
+	elseif attr["featurecla"]=="Antarctic Ice Shelf" then
+		return { subclass="ice_shelf" }
+	elseif attr["featurecla"]=="Urban area" then
+		return { class="residential" }
+	elseif layer=="ocean" then
+		return { class="ocean" }
+	else
+		return attr
+	end
 end

--- a/src/options_parser.cpp
+++ b/src/options_parser.cpp
@@ -87,10 +87,6 @@ OptionsParser::Options OptionsParser::parse(const int argc, const char* argv[]) 
 		throw OptionException{ "You must specify an output file or directory. Run with --help to find out more." };
 	}
 
-	if (vm.count("input") == 0) {
-		throw OptionException{ "No source .osm.pbf file supplied" };
-	}
-
 	if (ends_with(options.outputFile, ".mbtiles") || ends_with(options.outputFile, ".sqlite")) {
 		options.outputMode = OutputMode::MBTiles;
 	} else if (ends_with(options.outputFile, ".pmtiles")) {


### PR DESCRIPTION
This is mostly documentation/config for the common use-case of generating a map with worldwide coastlines but detail for one region only.

It also fixes a slight regression in 3.0, in that we were erroring if no input .osm.pbf was supplied, but in fact that's completely legit if you're just using shapefiles/GeoJSON.