### PR TITLE
Centroid(...) should return nil on error

### DIFF
--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -144,7 +144,7 @@ public:
 	double Length();
 	
 	// Return centroid lat/lon
-	std::vector<double> Centroid(kaguya::VariadicArgType algorithm);
+	kaguya::optional<std::vector<double>> Centroid(kaguya::VariadicArgType algorithm);
 
 	enum class CentroidAlgorithm: char { Centroid = 0, Polylabel = 1 };
 	CentroidAlgorithm defaultCentroidAlgorithm() const { return CentroidAlgorithm::Polylabel; }


### PR DESCRIPTION
Previously, calling Centroid(...) on an invalid geometry (such as https://www.openstreetmap.org/relation/9769005, which I think gets simplified to having 0 rings) would throw, killing the lua process.

Instead, return nil.

I think this is reasonable? I guess it might be preferable if invalid geometries never made it to the lua code, but then we'd have to proactively fix every geometry, even those not ultimately emitted, which would be expensive.