### PR TITLE
Update process-debug.lua

### DIFF
--- a/resources/process-debug.lua
+++ b/resources/process-debug.lua
@@ -354,7 +354,7 @@ function way_function()
 
 	-- Set 'housenumber'
 	if housenumber~="" then
-		LayerAsCentroid("housenumber", false)
+		LayerAsCentroid("housenumber")
 		Attribute("housenumber", housenumber)
 	end
 


### PR DESCRIPTION
Adjust to v3.0.0 syntax: `LayerAsCentroid(layer_name, algorithm, role, role...)`

Running debug config threw error:
```
stack traceback:                                                                    
        [C]: in function 'LayerAsCentroid' 
        process.lua:357: in function 'way_function''  `maybe...Argument mismatch:string,boolean  candidate is:
                std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,kaguya::VariadicArgType,
```