### PR TITLE
ignore --shard-stores if --compact is present

### DIFF
--- a/include/node_stores.h
+++ b/include/node_stores.h
@@ -59,8 +59,8 @@ public:
 	void batchStart() override {}
 
 	// CompactNodeStore has no metadata to know whether or not it contains
-	// a node, so it's not suitable for used in sharded scenarios.
-	bool contains(size_t shard, NodeID id) const override { return true; }
+	// a node, so it's not suitable for use in sharded scenarios
+	bool contains(size_t shard, NodeID id) const override { throw std::runtime_error("CompactNodeStore does not support contains"); }
 	NodeStore& shard(size_t shard) override { return *this; }
 	const NodeStore& shard(size_t shard) const override { return *this; }
 	size_t shards() const override { return 1; }

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -292,6 +292,7 @@ public:
 	void open(std::string const &osm_store_filename);
 
 	void use_compact_store(bool use) { use_compact_nodes = use; }
+	bool isCompactStore() { return use_compact_nodes; }
 	void enforce_integrity(bool ei) { require_integrity = ei; }
 	bool integrity_enforced() { return require_integrity; }
 

--- a/include/pbf_processor.h
+++ b/include/pbf_processor.h
@@ -2,6 +2,7 @@
 #ifndef _READ_PBF_H
 #define _READ_PBF_H
 
+#include <atomic>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -122,6 +123,7 @@ private:
 	
 	OSMStore &osmStore;
 	std::mutex ioMutex;
+	std::atomic<bool> compactWarningIssued;
 };
 
 int ReadPbfBoundingBox(const std::string &inputFile, double &minLon, double &maxLon, 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -189,7 +189,9 @@ int main(const int argc, const char* argv[]) {
 
 	shared_ptr<NodeStore> nodeStore;
 
-	if (options.osm.shardStores) {
+	// CompactNodeStore is a dense datatype; it doesn't make sense to allocate
+	// more than one of them.
+	if (options.osm.shardStores && !options.osm.compact) {
 		nodeStore = std::make_shared<ShardedNodeStore>(createNodeStore);
 	} else {
 		nodeStore = createNodeStore();


### PR DESCRIPTION
Fixes #657 

These two settings are incompatible, because CompactNodeStore does not implement `.contains(...)`

Instead, if `--compact` is present, don't shard stores. Further, throw if code calls `.contains(...)`, so that we'll fail noisily and more clearly.

I debated teaching CompactNodeStore how to do `.contains(...)`, e.g. by maintaning a bitmap of which entries were present. Ultimately, though, I think sharding CompactNodeStores does not make sense -- each CompactNodeStore instance will use about the same amount of memory (vs the other stores, which will each use 1/N memory)

Also a small tweak: detect if `--compact` is used on a non-renumbered PBF, and warn the user.