### PR TITLE
GeoJSON lines: skip leading whitespace in a chunk

### DIFF
--- a/src/geojson_processor.cpp
+++ b/src/geojson_processor.cpp
@@ -58,13 +58,16 @@ void GeoJSONProcessor::readFeatureLines(class LayerDef &layer, uint layerNum) {
 			char readBuffer[65536];
 			rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
 
+			// Skip leading whitespace.
+			while(is.Tell() < chunk.length && isspace(is.Peek())) is.Take();
+
 			while(is.Tell() < chunk.length) {
 				auto doc = rapidjson::Document();
 				doc.ParseStream<rapidjson::kParseStopWhenDoneFlag>(is);
 				if (doc.HasParseError()) { throw std::runtime_error("Invalid JSON file."); }
 				processFeature(std::move(doc.GetObject()), layer, layerNum);
 
-				// Skip whitespace.
+				// Skip trailing whitespace.
 				while(is.Tell() < chunk.length && isspace(is.Peek())) is.Take();
 			}
 			fclose(fp);


### PR DESCRIPTION
D'oh, after running more GeoJSON lines content through my pipelines, I ran into a bug.

If the chunking algorithm returns a chunk that consists only of whitespace, the current code will try to parse at least one JSON object out of it, and fail.

This fixes that bug by consuming all the whitespace before trying to parse an item -- the `while(is.Tell() < chunk.length)` loop will no longer be entered, as there will be no non-whitespace content to consume.