### PR TITLE
PR build tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Linux dependencies
-      if: ${{ matrix.os == "ubuntu-22.04" }}
+      if: ${{ matrix.os == 'ubuntu-22.04' }}
       run: |
         sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev luajit libluajit-5.1-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
         Invoke-WebRequest -Uri http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -OutFile ${{ env.AREA }}.osm.pbf
-        ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --store osm_store --verbose || true
+        ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --store osm_store --verbose
 
     - name: 'Upload compiled executable'
       uses: actions/upload-artifact@v2
@@ -90,7 +90,7 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
         curl http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -o ${{ env.AREA }}.osm.pbf
-        ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose || true
+        ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose
 
     - name: 'Upload compiled executable'
       uses: actions/upload-artifact@v2
@@ -133,7 +133,7 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
         curl http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -o ${{ env.AREA }}.osm.pbf
-        ./tilemaker ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose || true
+        ./tilemaker ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose
 
 
   Github-Action:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
     - name: Install Mac OS X dependencies
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        c++ --version
         brew install boost lua shapelib rapidjson
 
     - name: Build tilemaker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-#   - name: Build dependencies
-#     run: |
-#       vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort rapidjson
+   - name: Build dependencies
+     run: |
+      sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 
     - name: Build tilemaker
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install vcpkg (Apple Silicon)
+      if: ${{ matrix.os == 'macos-14' }}
+      run: |
+        brew install vcpkg
+
     - name: Enable vcpkg cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,11 @@ jobs:
       run: |
         sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev luajit libluajit-5.1-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 
+    - name: Install Mac OS X dependencies
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        brew install boost lua shapelib rapidjson
+
     - name: Build tilemaker
       run: |
         make -j4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             path: /usr/local/share/vcpkg/installed
             toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
 
-    name: ${{ matrix.os }} CMake build
+    name: ${{ matrix.os }} (CMake)
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -106,11 +106,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-#         - os: macos-latest
-#           triplet: x64-osx
-#           executable: tilemaker
+          - os: macos-latest
 
-    name: ${{ matrix.os }} Makefile build
+    name: ${{ matrix.os }} (Makefile)
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -122,7 +120,7 @@ jobs:
 
     - name: Build tilemaker
       run: |
-        make
+        make -j4
 
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Build dependencies
       run: |
-        if [[ $(uname -p) == 'arm' ]]; then export VCPKG_ROOT="$HOME/vcpkg" fi
+        if [[ $(uname -p) == 'arm' ]]; then export VCPKG_ROOT="$HOME/vcpkg"; fi
         vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort rapidjson
 
     - name: Build tilemaker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
 
     - name: Build dependencies
       run: |
-        sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
+        sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev luajit liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 
     - name: Build tilemaker
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
 
     - name: Build dependencies
       run: |
-        sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev luajit liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
+        sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev luajit libluajit-5.1-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 
     - name: Build tilemaker
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,22 +62,11 @@ jobs:
             executable: tilemaker
             path: /usr/local/share/vcpkg/installed
             toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-          - os: macos-14
-            triplet: arm64-osx
-            executable: tilemaker
-            path: /usr/local/share/vcpkg/installed
-            toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
     name: ${{ matrix.os }} (CMake)
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install vcpkg (Apple Silicon)
-      if: ${{ matrix.os == 'macos-14' }}
-      run: |
-        git clone https://github.com/microsoft/vcpkg "$HOME/vcpkg"
-        brew install vcpkg
 
     - name: Enable vcpkg cache
       uses: actions/cache@v2
@@ -88,12 +77,10 @@ jobs:
 
     - name: Build dependencies
       run: |
-        if [[ $(uname -p) == 'arm' ]]; then export VCPKG_ROOT="$HOME/vcpkg"; fi
         vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort rapidjson
 
     - name: Build tilemaker
       run: |
-        if [[ $(uname -p) == 'arm' ]]; then export VCPKG_ROOT="$HOME/vcpkg"; fi
         mkdir build
         cd build
         cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DCMAKE_CXX_COMPILER=g++ ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-   - name: Build dependencies
-     run: |
-      sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
+    - name: Build dependencies
+      run: |
+        sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 
     - name: Build tilemaker
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,9 @@ jobs:
 
     - name: Build tilemaker
       run: |
-        mkdir build        
-        cd build        
+        if [[ $(uname -p) == 'arm' ]]; then export VCPKG_ROOT="$HOME/vcpkg"; fi
+        mkdir build
+        cd build
         cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DCMAKE_CXX_COMPILER=g++ ..
         cmake --build . 
         strip tilemaker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
 
   Windows-Build:
-    name: Windows build
+    name: Windows (CMake)
     runs-on: windows-latest
 
     steps:
@@ -114,7 +114,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build dependencies
+    - name: Install Linux dependencies
+      if: ${{ matrix.os == "ubuntu-22.04" }}
       run: |
         sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev luajit libluajit-5.1-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
         Invoke-WebRequest -Uri http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -OutFile ${{ env.AREA }}.osm.pbf
+        ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.pmtiles --verbose
         ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --store osm_store --verbose
 
     - name: 'Upload compiled executable'
@@ -90,7 +91,8 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
         curl http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -o ${{ env.AREA }}.osm.pbf
-        ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose
+        ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.pmtiles --verbose
+        ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose --store /tmp/store
 
     - name: 'Upload compiled executable'
       uses: actions/upload-artifact@v2
@@ -133,7 +135,8 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |
         curl http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -o ${{ env.AREA }}.osm.pbf
-        ./tilemaker ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose
+        ./tilemaker ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.pmtiles --verbose
+        ./tilemaker ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose --store /tmp/store
 
 
   Github-Action:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             path: /usr/local/share/vcpkg/installed
             toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
           - os: macos-14
-            triplet: arm-osx
+            triplet: arm64-osx
             executable: tilemaker
             path: /usr/local/share/vcpkg/installed
             toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev luajit libluajit-5.1-dev liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev zlib1g-dev
 
     - name: Install Mac OS X dependencies
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-14' }}
       run: |
         c++ --version
         brew install boost lua shapelib rapidjson

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             path: /usr/local/share/vcpkg/installed
             toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
 
-    name: ${{ matrix.os }} build
+    name: ${{ matrix.os }} CMake build
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -100,6 +100,35 @@ jobs:
         path: |
           ${{ github.workspace }}/resources
           ${{ github.workspace }}/build/${{ matrix.executable }}
+
+  unix-makefile-build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+#         - os: macos-latest
+#           triplet: x64-osx
+#           executable: tilemaker
+
+    name: ${{ matrix.os }} Makefile build
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+#   - name: Build dependencies
+#     run: |
+#       vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort rapidjson
+
+    - name: Build tilemaker
+      run: |
+        make
+
+    - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
+      run: |
+        curl http://download.geofabrik.de/europe/${{ env.AREA }}-latest.osm.pbf -o ${{ env.AREA }}.osm.pbf
+        ./tilemaker ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose || true
+
 
   Github-Action:
     name: Generate mbtiles with Github Action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
     - name: Build tilemaker
       run: |
         make -j4
+        make test
 
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,11 @@ jobs:
             executable: tilemaker
             path: /usr/local/share/vcpkg/installed
             toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-
+          - os: macos-14
+            triplet: arm-osx
+            executable: tilemaker
+            path: /usr/local/share/vcpkg/installed
+            toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
     name: ${{ matrix.os }} (CMake)
     runs-on: ${{ matrix.os }}
 
@@ -107,6 +111,7 @@ jobs:
         include:
           - os: ubuntu-22.04
           - os: macos-latest
+          - os: macos-14
 
     name: ${{ matrix.os }} (Makefile)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Install vcpkg (Apple Silicon)
       if: ${{ matrix.os == 'macos-14' }}
       run: |
+        git clone https://github.com/microsoft/vcpkg "$HOME/vcpkg"
         brew install vcpkg
 
     - name: Enable vcpkg cache
@@ -87,6 +88,7 @@ jobs:
 
     - name: Build dependencies
       run: |
+        if [[ $(uname -p) == 'arm' ]]; then export VCPKG_ROOT="$HOME/vcpkg" fi
         vcpkg install --triplet=${{ matrix.triplet }} lua shapelib zlib protobuf[zlib] sqlite3 boost-program-options boost-filesystem boost-geometry boost-system boost-asio boost-interprocess boost-iostreams boost-sort rapidjson
 
     - name: Build tilemaker

--- a/README.md
+++ b/README.md
@@ -106,4 +106,3 @@ Licenses of third-party libraries:
 - [vtzero](https://github.com/mapbox/vtzero) is licensed under BSD 2-clause
 - [minunit](https://github.com/siu/minunit) is licensed under MIT
 - [Simple-Web-Server](https://gitlab.com/eidheim/Simple-Web-Server) is licensed under MIT
-

--- a/README.md
+++ b/README.md
@@ -106,3 +106,4 @@ Licenses of third-party libraries:
 - [vtzero](https://github.com/mapbox/vtzero) is licensed under BSD 2-clause
 - [minunit](https://github.com/siu/minunit) is licensed under MIT
 - [Simple-Web-Server](https://gitlab.com/eidheim/Simple-Web-Server) is licensed under MIT
+

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -15,6 +15,10 @@
 #define stat64 __stat64
 #endif
 
+#if defined(__APPLE__)
+#define stat64 stat
+#endif
+
 #define MOD_GZIP_ZLIB_WINDOWSIZE 15
 #define MOD_GZIP_ZLIB_CFACTOR 9
 #define MOD_GZIP_ZLIB_BSIZE 8096

--- a/src/pbf_processor.cpp
+++ b/src/pbf_processor.cpp
@@ -750,7 +750,7 @@ int ReadPbfBoundingBox(const std::string &inputFile, double &minLon, double &max
 }
 
 bool PbfHasOptionalFeature(const std::string& inputFile, const std::string& feature) {
-	std::ifstream infile(inputFile, std::ifstream::in);
+	std::ifstream infile(inputFile, std::ifstream::in | std::ifstream::binary);
 	auto header = reader.readHeaderFromFile(infile);
 	infile.close();
 	return header.optionalFeatures.find(feature) != header.optionalFeatures.end();


### PR DESCRIPTION
This tries to expand the PR builds to catch some of the issues that have cropped up:

- add Makefile builds, including `make test`
- add Apple Silicon runner (released Jan 30, 2024 - see [GitHub blog post](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/))
  - Added @systemed's patch that fixes #664 so the build would pass
  - There's no CMake build on Apple Silicon yet, just a Makefile build. Unlike the Intel Silicon Mac OS image, the ARM image does not have vcpkg pre-installed. I tried to figure out how to install vcpkg myself, but couldn't get it sorted, so I decided it could be a nice-to-have and dealt with in the future.
- fail build if tilemaker command has non-zero exit code
  - Added @Star-42's patch that fixes #661 so the build would pass 
- also do a pmtiles build with --store to ensure that mbtiles/pmtiles and lazy/materialized geometries are being smoketested

There's still no verification of the contents of the output files, but even just validating that the command runs with no errors is a start.