### PR TITLE
AttributePair: use uint, not char

### DIFF
--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -42,13 +42,13 @@ private:
 	std::map<const std::string*, uint16_t, string_ptr_less_than> keys2index;
 };
 
-enum class AttributePairType: uint { Bool = 0, Float = 1, String = 2 };
+enum class AttributePairType: uint8_t { Bool = 0, Float = 1, String = 2 };
 // AttributePair is a key/value pair (with minzoom)
 #pragma pack(push, 1)
 struct AttributePair {
 	short keyIndex : 9;
 	AttributePairType valueType : 2;
-	uint minzoom : 5; // Support zooms from 0..31. In practice, we expect z16 to be the biggest minzoom.
+	uint8_t minzoom : 5; // Support zooms from 0..31. In practice, we expect z16 to be the biggest minzoom.
 	union {
 		float floatValue_;
 		PooledString stringValue_;

--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -42,13 +42,13 @@ private:
 	std::map<const std::string*, uint16_t, string_ptr_less_than> keys2index;
 };
 
-enum class AttributePairType: char { Bool = 0, Float = 1, String = 2 };
+enum class AttributePairType: uint { Bool = 0, Float = 1, String = 2 };
 // AttributePair is a key/value pair (with minzoom)
 #pragma pack(push, 1)
 struct AttributePair {
 	short keyIndex : 9;
-	AttributePairType valueType : 3;
-	char minzoom : 4;
+	AttributePairType valueType : 2;
+	uint minzoom : 5; // Support zooms from 0..31. In practice, we expect z16 to be the biggest minzoom.
 	union {
 		float floatValue_;
 		PooledString stringValue_;

--- a/test/attribute_store.test.cpp
+++ b/test/attribute_store.test.cpp
@@ -11,10 +11,10 @@ MU_TEST(test_attribute_store) {
 
 	AttributeSet s1;
 	store.addAttribute(s1, "str1", std::string("someval"), 0);
-	store.addAttribute(s1, "str2", std::string("a very long string"), 0);
+	store.addAttribute(s1, "str2", std::string("a very long string"), 14);
 	store.addAttribute(s1, "bool1", false, 0);
 	store.addAttribute(s1, "bool2", true, 0);
-	store.addAttribute(s1, "float1", (float)42.0, 0);
+	store.addAttribute(s1, "float1", (float)42.0, 4);
 
 	const auto s1Index = store.add(s1);
 
@@ -35,6 +35,7 @@ MU_TEST(test_attribute_store) {
 	mu_check(str2 != s1Pairs.end());
 	mu_check((*str2)->hasStringValue());
 	mu_check((*str2)->stringValue() == "a very long string");
+	mu_check((*str2)->minzoom == 14);
 
 	const auto bool1 = std::find_if(s1Pairs.begin(), s1Pairs.end(), [&store](auto ap) {
 			return ap->keyIndex == store.keyStore.key2index("bool1");
@@ -56,6 +57,7 @@ MU_TEST(test_attribute_store) {
 	mu_check(float1 != s1Pairs.end());
 	mu_check((*float1)->hasFloatValue());
 	mu_check((*float1)->floatValue() == 42);
+	mu_check((*float1)->minzoom == 4);
 }
 
 MU_TEST(test_attribute_store_reuses) {


### PR DESCRIPTION
Fixes #671 

Since we only allocate 4 bits and `char` is signed, the usable space
was -8..7. Larger values (like, say, 12) overflow, and get interpreted
as a negative value, which means they don't act as a filter, since all
zoom values are natural numbers.

The tests didn't actually test that a zoom value could be roundtripped.
I updated them, and verified they failed before the code change, and
passed after the code change.

I've also allocated an extra bit so that we support minzooms up to z31,
vs just up to z15, since I think (?) some people generate up to z16