### PR TITLE
Empty strings are ok really

### DIFF
--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -830,7 +830,6 @@ void OsmLuaProcessing::removeAttributeIfNeeded(const string& key) {
 
 // Set attributes in a vector tile's Attributes table
 void OsmLuaProcessing::Attribute(const string &key, const protozero::data_view val, const char minzoom) {
-	if (val.size()==0) { return; }		// don't set empty strings
 	if (outputs.size()==0) { ProcessingError("Can't add Attribute if no Layer set"); return; }
 	removeAttributeIfNeeded(key);
 	attributeStore.addAttribute(outputs.back().second, key, val, minzoom);


### PR DESCRIPTION
Possibly the least consequential pull request in history...

Currently we trap empty strings in `OsmLuaProcessing::Attribute`. It is legitimate though to write an empty string value, and some styles may behave differently depending whether an attribute =="" or ==undefined - for example, the MBGL `has` operator will return true for the former, false for the latter.