### PR TITLE
Fix thread safety issue with shapefile index

### DIFF
--- a/src/shp_processor.cpp
+++ b/src/shp_processor.cpp
@@ -157,7 +157,10 @@ void ShpProcessor::read(class LayerDef &layer, uint layerNum)
 			// process attributes
 			string name;
 			bool hasName = false;
-			if (indexField>-1) { name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;}
+			if (indexField>-1) { 
+				std::lock_guard<std::mutex> lock(attributeMutex);
+				name=DBFReadStringAttribute(dbf, i, indexField); hasName = true
+			}
 			AttributeIndex attrIdx = readShapefileAttributes(dbf, i, columnMap, columnTypeMap, layer, layer.minzoom);
 			// process geometry
 			processShapeGeometry(shape, attrIdx, layer, layerNum, hasName, name);

--- a/src/shp_processor.cpp
+++ b/src/shp_processor.cpp
@@ -159,7 +159,7 @@ void ShpProcessor::read(class LayerDef &layer, uint layerNum)
 			bool hasName = false;
 			if (indexField>-1) { 
 				std::lock_guard<std::mutex> lock(attributeMutex);
-				name=DBFReadStringAttribute(dbf, i, indexField); hasName = true
+				name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;
 			}
 			AttributeIndex attrIdx = readShapefileAttributes(dbf, i, columnMap, columnTypeMap, layer, layer.minzoom);
 			// process geometry


### PR DESCRIPTION
shapelib is not thread-safe when reading from the same .dbf file. This avoids a crash when reading shapefile index columns by sharing the mutex we already have for the attributes.