### PR TITLE
Faster polygon combining

### DIFF
--- a/include/geom.h
+++ b/include/geom.h
@@ -77,6 +77,8 @@ void make_valid(GeometryT &geom) { }
 
 void make_valid(MultiPolygon &mp);
 
+void union_many(std::vector<MultiPolygon> &mps);
+
 Point intersect_edge(Point const &a, Point const &b, char edge, Box const &bbox);
 char bit_code(Point const &p, Box const &bbox);
 void fast_clip(Ring &points, Box const &bbox);

--- a/include/output_object.h
+++ b/include/output_object.h
@@ -76,6 +76,9 @@ public:
 		vtzero::feature_builder& fbuilder,
 		char zoom
 	) const;
+		
+	bool compatible(const OutputObject &other);
+
 };
 #pragma pack(pop)
 

--- a/src/geom.cpp
+++ b/src/geom.cpp
@@ -145,6 +145,30 @@ void make_valid(MultiPolygon &mp)
 }
 
 // ---------------
+// Union multipolygons
+// from https://github.com/boostorg/geometry/discussions/947
+void union_many(std::vector<MultiPolygon> &to_unify) {
+	if (to_unify.size()<2) return;
+	size_t step = 1;
+	size_t half_step;
+
+	// the outer loop doubles the distance between two polygons to be merged at every iteration
+	do {
+		half_step = step;
+		step *= 2;
+		size_t i = 0;
+
+		// the inner loop merges polygons at i and i+half_step storing the result at i
+		do {
+			MultiPolygon unified;
+			boost::geometry::union_(to_unify.at(i), to_unify.at(i + half_step), unified);
+			to_unify.at(i) = std::move(unified);
+			i += step;
+		} while (i + half_step < to_unify.size());
+	} while (step < to_unify.size());
+}
+
+// ---------------
 // Sutherland-Hodgeman clipper
 // ported from Volodymyr Agafonkin's https://github.com/mapbox/lineclip
 

--- a/src/output_object.cpp
+++ b/src/output_object.cpp
@@ -55,6 +55,11 @@ void OutputObject::writeAttributes(
 	}
 }
 
+bool OutputObject::compatible(const OutputObject &other) {
+	return geomType == other.geomType &&
+	       z_order == other.z_order &&
+	       attributes == other.attributes;
+}
 
 // Comparision functions
 bool operator==(const OutputObject& x, const OutputObject& y) {

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -301,7 +301,7 @@ void ProcessObjects(
 			//This may increment the jt iterator
 			if (oo.oo.geomType == LINESTRING_ && zoom < sharedData.config.combineBelow) {
 				// Append successive linestrings, then reorder afterwards
-				while (jt<ooSameLayerEnd && oo.oo.compatible((jt+1)->oo)) {
+				while (jt<(ooSameLayerEnd-1) && oo.oo.compatible((jt+1)->oo)) {
 					jt++;
 					MultiLinestring to_merge = boost::get<MultiLinestring>(source->buildWayGeometry(jt->oo.geomType, jt->oo.objectID, bbox));
 					for (auto &ls : to_merge) boost::get<MultiLinestring>(g).emplace_back(ls);
@@ -314,7 +314,7 @@ void ProcessObjects(
 			} else if (oo.oo.geomType == POLYGON_ && combinePolygons) {
 				// Append successive multipolygons, then union afterwards
 				std::vector<MultiPolygon> mps;
-				while (jt<ooSameLayerEnd && oo.oo.compatible((jt+1)->oo)) {
+				while (jt<(ooSameLayerEnd-1) && oo.oo.compatible((jt+1)->oo)) {
 					jt++;
 					mps.emplace_back( boost::get<MultiPolygon>(source->buildWayGeometry(jt->oo.geomType, jt->oo.objectID, bbox)) );
 				}


### PR DESCRIPTION
The `combine_polygons_below` option significantly slows tile generation (#270). In #383 we moved to faster code but it's still not especially fast.

This PR further improves it by using a neat bit of code from https://github.com/boostorg/geometry/discussions/947#discussioncomment-5820218. It also successfully merges more adjoining polygons. Newer Boost has [`merge_elements`](https://github.com/boostorg/geometry/blob/develop/include/boost/geometry/algorithms/merge_elements.hpp) but we can't rely on users having that yet.

It also removes a bit of template-y indirection by replacing CheckNextObjectAndMerge and MergeIntersecting with a simple while loop.

For Reims using my 2016 Mac mini:

No combine_polygons_below: 12s

![Screenshot 2024-02-16 at 10 40 20](https://github.com/systemed/tilemaker/assets/694425/3919b7b4-dd03-4d91-ad4a-37634f1cfee4)

Using combine_polygons_below, current master: 122s

![Screenshot 2024-02-16 at 10 40 11](https://github.com/systemed/tilemaker/assets/694425/c563e151-7db4-4e3e-ab64-35a0cc3a40e9)

Using combine_polygons_below, this PR: 80s

![Screenshot 2024-02-16 at 13 38 48](https://github.com/systemed/tilemaker/assets/694425/ba7e82f1-a3af-43a2-9386-e9a8024c216d)

There's clearly still room for improvement (maybe using an rtree to quickly identify polygons that intersect, and only unioning those?) but this is a worthwhile step forward.