### PR TITLE
When serving tiles, add the CORS Access-Control-Allow-Origin: * header

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -89,6 +89,7 @@ int main(int argc, char* argv[]) {
         std::string outStr(pbfBlob.begin(), pbfBlob.end());
         SimpleWeb::CaseInsensitiveMultimap header;
         header.emplace("Content-Encoding", "gzip");
+        header.emplace("Access-Control-Allow-Origin", "*");
         response->write(outStr,header);
     };
 


### PR DESCRIPTION
This allows tiles served with `tileserver-server` to be easily used in simple web apps.