### PR TITLE
Stable tags for container images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: "Continuous Integration"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ stable-containers ]
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,12 +179,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@5
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-          type=raw,value={{date 'YYYY-MM-DDTHH-mm'}}
-          type=raw,value=latest
+          tags: |
+            type=raw,value={{date 'YYYY-MM-DDTHH-mm'}}
+            type=raw,value=latest
 
       - name: Build Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Build tilemaker
       run: |
-        mkdir ${{ github.workspace }}\build        
+        mkdir ${{ github.workspace }}\build
         cd ${{ github.workspace }}\build && cmake -DTILEMAKER_BUILD_STATIC=ON -DVCPKG_TARGET_TRIPLET="x64-windows-static-md" -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake"  ..
         cd ${{ github.workspace }}\build && cmake --build . --config RelWithDebInfo
 
@@ -49,9 +49,9 @@ jobs:
           ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe
           ${{ github.workspace }}\build\RelWithDebInfo\*.pdb
 
-  unix-build:  
-    strategy:  
-      matrix: 
+  unix-build:
+    strategy:
+      matrix:
         include:
           - os: ubuntu-22.04
             triplet: x64-linux
@@ -85,7 +85,7 @@ jobs:
         mkdir build
         cd build
         cmake -DTILEMAKER_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} -DCMAKE_CXX_COMPILER=g++ ..
-        cmake --build . 
+        cmake --build .
         strip tilemaker
 
     - name: Build openmaptiles-compatible mbtiles files of Liechtenstein
@@ -153,7 +153,7 @@ jobs:
     - name: Build openmaptiles-compatible mbtiles files of given area
       uses: ./
       with:
-        input: ${{ env.AREA }}.osm.pbf 
+        input: ${{ env.AREA }}.osm.pbf
         output: ${{ env.AREA }}.mbtiles
 
   docker-build:
@@ -179,9 +179,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=raw,value={{date 'YYYY-MM-DDTHH-mm'}}
+          type=raw,value=latest
 
       - name: Build Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Build Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: ${{ github.ref != 'refs/heads/master'}}
+        if: ${{ github.ref != 'refs/heads/stable-containers'}}
         with:
           context: .
           push: false
@@ -196,7 +196,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: ${{ github.ref == 'refs/heads/master'}}
+        if: ${{ github.ref == 'refs/heads/stable-containers'}}
         with:
           context: .
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: "Continuous Integration"
 
 on:
   push:
-    branches: [ stable-containers ]
+    branches: [ master ]
   pull_request:
 
 env:
@@ -188,7 +188,7 @@ jobs:
 
       - name: Build Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: ${{ github.ref != 'refs/heads/stable-containers'}}
+        if: ${{ github.ref != 'refs/heads/master'}}
         with:
           context: .
           push: false
@@ -196,7 +196,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: ${{ github.ref == 'refs/heads/stable-containers'}}
+        if: ${{ github.ref == 'refs/heads/master'}}
         with:
           context: .
           push: true


### PR DESCRIPTION
For a while tilemaker has been building container images. This is great but so far only the very latest version is uploaded.

For my deployments I would not want to rely on a moving target but only reference a stable version.

This PR changes the container CI job so that it adds date-based tags to the container which will remain stable over time. They will have tags like `2024-02-23T12-42` and they will remain in the repo even if newer ones are added.

You can check what it looks like in this repo: https://github.com/leonardehrenfried/tilemaker/pkgs/container/tilemaker