### PR TITLE
Reduce differences between official OpenMapTiles tiles and Tilemaker implementation

### DIFF
--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -13,8 +13,6 @@
 
 		"transportation":             { "minzoom": 4,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003 },
 		"transportation_name":        { "minzoom": 8,  "maxzoom": 14 },
-		"transportation_name_mid":    { "minzoom": 12, "maxzoom": 14, "write_to": "transportation_name" },
-		"transportation_name_detail": { "minzoom": 14, "maxzoom": 14, "write_to": "transportation_name" },
 
 		"building":          { "minzoom": 13, "maxzoom": 14 },
 

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -227,10 +227,11 @@ landuseKeys     = Set { "school", "university", "kindergarten", "college", "libr
                         "retail", "stadium", "pitch", "playground", "theme_park", "bus_station", "zoo" }
 landcoverKeys   = { wood="wood", forest="wood",
                     wetland="wetland",
-                    beach="sand", sand="sand",
+                    beach="sand", sand="sand", dune="sand",
                     farmland="farmland", farm="farmland", orchard="farmland", vineyard="farmland", plant_nursery="farmland",
                     glacier="ice", ice_shelf="ice",
-                    grassland="grass", grass="grass", meadow="grass", allotments="grass", park="grass", village_green="grass", recreation_ground="grass", garden="grass", golf_course="grass" }
+                    bare_rock="rock", scree="rock",
+                    fell="grass", grassland="grass", grass="grass", heath="grass", meadow="grass", allotments="grass", park="grass", village_green="grass", recreation_ground="grass", scrub="grass", shrubbery="grass", tundra="grass", garden="grass", golf_course="grass", park="grass" }
 
 -- POI key/value pairs: based on https://github.com/openmaptiles/openmaptiles/blob/master/layers/poi/mapping.yaml
 poiTags         = { aerialway = Set { "station" },

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -311,6 +311,9 @@ function write_to_transportation_layer(minzoom, highway_class, subclass, ramp, s
 	MinZoom(minzoom)
 	SetZOrder()
 	Attribute("class", highway_class)
+	if subclass and subclass ~= "" then
+		Attribute("subclass", subclass)
+	end
 	SetBrunnelAttributes()
 	if ramp then AttributeNumeric("ramp",1) end
 

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -542,10 +542,12 @@ function way_function()
 	if route=="ferry" then
 		write_to_transportation_layer(9, "ferry", nil, false, nil, false)
 
-		Layer("transportation_name", false)
-		SetNameAttributes()
-		MinZoom(12)
-		Attribute("class", "ferry")
+		if HasNames() then
+			Layer("transportation_name", false)
+			SetNameAttributes()
+			MinZoom(12)
+			Attribute("class", "ferry")
+		end
 	end
 
 	-- 'Aeroway'

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -428,7 +428,7 @@ function way_function()
 		end
 	end
 
-	-- Roads ('transportation' and 'transportation_name', plus 'transportation_name_detail')
+	-- Roads ('transportation' and 'transportation_name')
 	if highway~="" then
 		local access = Find("access")
 		local surface = Find("surface")
@@ -475,32 +475,33 @@ function way_function()
 			write_to_transportation_layer(minzoom, h, subclass, ramp, service, false)
 
 			-- Write names
-			if minzoom < 8 then
-				minzoom = 8
-			end
-			if highway == "motorway" or highway == "trunk" then
+			if HasNames() or Holds("ref") then
+				if minzoom < 8 then
+					minzoom = 8
+				end
+				if highway == "motorway" or highway == "trunk" then
+					minzoom = math.max(8, minzoom)
+				elseif h == "minor" or h == "track" or h == "path" or h == "service" then
+					minzoom = 14
+				else
+					minzoom = math.max(12, minzoom)
+				end
 				Layer("transportation_name", false)
 				MinZoom(minzoom)
-			elseif h == "minor" or h == "track" or h == "path" or h == "service" then
-				Layer("transportation_name_detail", false)
-				MinZoom(minzoom)
-			else
-				Layer("transportation_name_mid", false)
-				MinZoom(minzoom)
-			end
-			SetNameAttributes()
-			Attribute("class",h)
-			Attribute("network","road") -- **** could also be us-interstate, us-highway, us-state
-			if h~=highway then Attribute("subclass",highway) end
-			local ref = Find("ref")
-			if ref~="" then
-				Attribute("ref",ref)
-				AttributeNumeric("ref_length",ref:len())
+				SetNameAttributes()
+				Attribute("class",h)
+				Attribute("network","road") -- **** could also be us-interstate, us-highway, us-state
+				if h~=highway then Attribute("subclass",highway) end
+				local ref = Find("ref")
+				if ref~="" then
+					Attribute("ref",ref)
+					AttributeNumeric("ref_length",ref:len())
+				end
 			end
 		end
 	end
 
-	-- Railways ('transportation' and 'transportation_name', plus 'transportation_name_detail')
+	-- Railways ('transportation' and 'transportation_name')
 	if railway~="" then
 		local class = railwayClasses[railway]
 		if class then

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -301,7 +301,7 @@ function relation_scan_function()
 	end
 end
 
-function write_to_transportation_layer(minzoom, highway_class)
+function write_to_transportation_layer(minzoom, highway_class, subclass, ramp, service)
 	Layer("transportation", false)
 	MinZoom(minzoom)
 	SetZOrder()
@@ -467,7 +467,7 @@ function way_function()
 
 		-- Write to layer
 		if minzoom <= 14 then
-			write_to_transportation_layer(minzoom, h)
+			write_to_transportation_layer(minzoom, h, subclass, ramp, service)
 
 			-- Write names
 			if minzoom < 8 then

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -540,11 +540,7 @@ function way_function()
 
 	-- 'Ferry'
 	if route=="ferry" then
-		Layer("transportation", false)
-		Attribute("class", "ferry")
-		SetZOrder()
-		MinZoom(9)
-		SetBrunnelAttributes()
+		write_to_transportation_layer(9, "ferry", nil, false, nil, false)
 
 		Layer("transportation_name", false)
 		SetNameAttributes()

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -520,10 +520,12 @@ function way_function()
 			end
 			write_to_transportation_layer(minzoom, class, railway, false, service, true)
 
-			Layer("transportation_name", false)
-			SetNameAttributes()
-			MinZoom(14)
-			Attribute("class", "rail")
+			if HasNames() then
+				Layer("transportation_name", false)
+				SetNameAttributes()
+				MinZoom(14)
+				Attribute("class", class)
+			end
 		end
 	end
 
@@ -718,6 +720,19 @@ function WritePOI(class,subclass,rank)
 	if level then
 		AttributeNumeric("level", level)
 	end
+end
+
+-- Check if there are name tags on the object
+function HasNames()
+	if Holds("name") then return true end
+	local iname
+	local main_written = name
+	if preferred_language and Holds("name:"..preferred_language) then return true end
+	-- then set any additional languages
+	for i,lang in ipairs(additional_languages) do
+		if Holds("name:"..lang) then return true end
+	end
+	return false
 end
 
 -- Set name attributes on any object

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -336,7 +336,7 @@ function write_to_transportation_layer(minzoom, highway_class, subclass, ramp, s
 		if Holds("foot") then Attribute("foot", Find("foot"), accessMinzoom) end
 		if Holds("horse") then Attribute("horse", Find("horse"), accessMinzoom) end
 		AttributeBoolean("toll", Find("toll") == "yes", accessMinzoom)
-		AttributeBoolean("expressway", Find("expressway"), 7)
+		if Find("expressway") == "yes" then AttributeBoolean("expressway", true, 7) end
 		if Holds("mtb_scale") then Attribute("mtb_scale", Find("mtb:scale"), 10) end
 	end
 	AttributeNumeric("layer", tonumber(Find("layer")) or 0, accessMinzoom)

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -339,7 +339,7 @@ function write_to_transportation_layer(minzoom, highway_class, subclass, ramp, s
 		if Holds("horse") then Attribute("horse", Find("horse"), accessMinzoom) end
 		AttributeBoolean("toll", Find("toll") == "yes", accessMinzoom)
 		AttributeBoolean("expressway", Find("expressway"), 7)
-		Attribute("mtb_scale", Find("mtb:scale"), 10)
+		if Holds("mtb_scale") then Attribute("mtb_scale", Find("mtb:scale"), 10) end
 	end
 	AttributeNumeric("layer", tonumber(Find("layer")) or 0, accessMinzoom)
 end

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -225,6 +225,7 @@ z11RoadValues   = Set { "tertiary", "tertiary_link", "busway", "bus_guideway" }
 z12MinorRoadValues = Set { "unclassified", "residential", "road", "living_street" }
 z12OtherRoadValues = Set { "raceway" }
 z13RoadValues     = Set { "track", "service" }
+manMadRoadValues = Set { "pier", "bridge" }
 pathValues      = Set { "footway", "cycleway", "bridleway", "path", "steps", "pedestrian", "platform" }
 linkValues      = Set { "motorway_link", "trunk_link", "primary_link", "secondary_link", "tertiary_link" }
 pavedValues     = Set { "paved", "asphalt", "cobblestone", "concrete", "concrete:lanes", "concrete:plates", "metal", "paving_stones", "sett", "unhewn_cobblestone", "wood" }
@@ -314,13 +315,13 @@ function write_to_transportation_layer(minzoom, highway_class, subclass, ramp, s
 		Attribute("subclass", subclass)
 	end
 	AttributeNumeric("layer", tonumber(Find("layer")) or 0, accessMinzoom)
+	SetBrunnelAttributes()
 	-- We do not write any other attributes for areas.
 	if IsClosed() then
 		SetMinZoomByAreaWithLimit(minzoom)
 		return
 	end
 	MinZoom(minzoom)
-	SetBrunnelAttributes()
 	if ramp then AttributeNumeric("ramp",1) end
 
 	-- Service
@@ -576,8 +577,8 @@ function way_function()
 	end
 
 	-- Pier
-	if man_made=="pier" then
-		write_to_transportation_layer(13, "pier", nil, false, nil, false, false)
+	if manMadRoadValues[man_made] then
+		write_to_transportation_layer(13, man_made, nil, false, nil, false, false)
 	end
 
 	-- 'Ferry'
@@ -810,7 +811,7 @@ function SetEleAttributes()
 end
 
 function SetBrunnelAttributes()
-	if     Find("bridge") == "yes" then Attribute("brunnel", "bridge")
+	if Find("bridge") == "yes" or Find("man_made") == "bridge" then Attribute("brunnel", "bridge")
 	elseif Find("tunnel") == "yes" then Attribute("brunnel", "tunnel")
 	elseif Find("ford")   == "yes" then Attribute("brunnel", "ford")
 	end

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -156,15 +156,20 @@ function node_function()
 			elseif pop>20000000 then rank=2; mz=2
 			else                     rank=3; mz=3 end
 		elseif place == "state"         then mz=4
+		elseif place == "province"         then mz=5
 		elseif place == "city"          then mz=5
 		elseif place == "town" and pop>8000 then mz=7
 		elseif place == "town"          then mz=8
 		elseif place == "village" and pop>2000 then mz=9
 		elseif place == "village"       then mz=10
+		elseif place == "borough"       then mz=10
 		elseif place == "suburb"        then mz=11
+		elseif place == "quarter"       then mz=12
 		elseif place == "hamlet"        then mz=12
 		elseif place == "neighbourhood" then mz=13
+		elseif place == "isolated_dwelling" then mz=13
 		elseif place == "locality"      then mz=13
+		elseif place == "island"      then mz=12
 		end
 
 		Layer("place", false)
@@ -353,6 +358,7 @@ function way_function()
 	local tourism  = Find("tourism")
 	local man_made = Find("man_made")
 	local boundary = Find("boundary")
+	local place = Find("place")
 	local isClosed = IsClosed()
 	local housenumber = Find("addr:housenumber")
 	local write_name = false
@@ -365,6 +371,17 @@ function way_function()
 	if aerowayBuildings[aeroway] then building="yes"; aeroway="" end
 	if landuse == "field" then landuse = "farmland" end
 	if landuse == "meadow" and Find("meadow")=="agricultural" then landuse="farmland" end
+
+	if place == "island" then
+		LayerAsCentroid("place")
+		Attribute("class", place)
+		MinZoom(10)
+		local pop = tonumber(Find("population")) or 0
+		local capital = capitalLevel(Find("capital"))
+		local rank = calcRank(place, pop, nil)
+		if rank then AttributeNumeric("rank", rank) end
+		SetNameAttributes()
+	end
 
 	-- Boundaries within relations
 	-- note that we process administrative boundaries as properties on ways, rather than as single relation geometries,


### PR DESCRIPTION
This pull request reduces the differences between official OpenMapTiles tiles as served by MapTiler (the schema documentation lacks details, therefore I inspected their tiles) and the implementation of Tilemaker.

Changes:

* Add missing features classes to layer *landcover* (`natural=dune`, `natural=bare_rock/scree/scrub/shrubbery/tundra`).
* Add missing features to layer *place* (`place=province/borough/quarter/island/isolated_dwelling`).
* Add support for `place=island` mapped as polygons.
* Add attribute `subclass` for railway features, set correct attribute `class.
* Do not write railway features to layer *transportation_name*.
* Refactor layers *transportation_name*, *transportation_name_mid*, *transportation_name_detail*.
* Do not write roads without names or reference number to layer *transportation_name*.
* Do not write unnamed ferries to layer *transportation_name*.
* Set correct minzoom values for all roads in the *transportation* and *transportation_name* layer.
* Add `highway=raceway`.
* Fix handling of roads under construction.
* Do not set attribute `mtb_scale` if the tag is not set on the OSM way.
* Add aerialways to layer *transportation*.
* Do not set attribute `expressway` if the tag is missing.
* Add areas for pedestrians and platforms to layer *transportation*.
* Add `man_made=bridge` to layer *transportation*.

Some of the bugs were found by a client using a fork of the schema.