### PR TITLE
remove FAT_TILE_INDEX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ file(GLOB tilemaker_src_files
 	src/sorted_node_store.cpp
 	src/sorted_way_store.cpp
 	src/tag_map.cpp
+	src/tile_coordinates_set.cpp
 	src/tile_data.cpp
 	src/tilemaker.cpp
 	src/tile_worker.cpp

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ tilemaker: \
 	src/sorted_node_store.o \
 	src/sorted_way_store.o \
 	src/tag_map.o \
+	src/tile_coordinates_set.o \
 	src/tile_data.o \
 	src/tilemaker.o \
 	src/tile_worker.o \
@@ -130,7 +131,8 @@ test: \
 	test_relation_roles \
 	test_significant_tags \
 	test_sorted_node_store \
-	test_sorted_way_store
+	test_sorted_way_store \
+	test_tile_coordinates_set
 
 test_append_vector: \
 	src/mmap_allocator.o \
@@ -192,6 +194,11 @@ test_sorted_way_store: \
 	src/sorted_way_store.o \
 	test/sorted_way_store.test.o
 	$(CXX) $(CXXFLAGS) -o test.sorted_way_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.sorted_way_store
+
+test_tile_coordinates_set: \
+	src/tile_coordinates_set.o \
+	test/tile_coordinates_set.test.o
+	$(CXX) $(CXXFLAGS) -o test.tile_coordinates_set $^ $(INC) $(LIB) $(LDFLAGS) && ./test.tile_coordinates_set
 
 test_pbf_reader: \
 	src/helpers.o \

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -65,11 +65,3 @@ The docker container can be run like this:
     docker run -v /Users/Local/Downloads/:/srv -i -t --rm tilemaker /srv/germany-latest.osm.pbf --output=/srv/germany.mbtiles
 
 Keep in mind to map the volume your .osm.pbf files are in to a path within your docker container, as seen in the example above. 
-
-### Compile-time options
-
-tilemaker has a compile-time option that increases memory usage but may be useful in certain circumstances. You can include it when building like this:
-
-    make "CONFIG=-DFAT_TILE_INDEX"
-
-FAT_TILE_INDEX allows you to generate vector tiles at zoom level 17 or greater. You almost certainly don't need to do this. Vector tiles are usually generated up to zoom 14 (sometimes 15), and then the browser/app client uses the vector data to scale up at subsequent zoom levels.

--- a/include/clip_cache.h
+++ b/include/clip_cache.h
@@ -11,10 +11,6 @@ class TileBbox;
 template <class T>
 class ClipCache {
 public:
-	// Consider: `baseZoom` is a poor name; it's actually the zoom at which we'll
-	// stop caching clips (and prefer clips from lower zooms). The caller of this
-	// code caps it to z14, even if the map's real basezoom is lower.
-	// Maybe this should be renamed `maxZoomForCaching`?
 	ClipCache(size_t threadNum, unsigned int baseZoom):
 		baseZoom(baseZoom),
 		clipCache(threadNum * 16),

--- a/include/clip_cache.h
+++ b/include/clip_cache.h
@@ -11,6 +11,10 @@ class TileBbox;
 template <class T>
 class ClipCache {
 public:
+	// Consider: `baseZoom` is a poor name; it's actually the zoom at which we'll
+	// stop caching clips (and prefer clips from lower zooms). The caller of this
+	// code caps it to z14, even if the map's real basezoom is lower.
+	// Maybe this should be renamed `maxZoomForCaching`?
 	ClipCache(size_t threadNum, unsigned int baseZoom):
 		baseZoom(baseZoom),
 		clipCache(threadNum * 16),

--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -24,17 +24,8 @@ typedef uint64_t RelationID;
 typedef std::vector<WayID> WayVec;
 
 
-#ifdef FAT_TILE_INDEX
 // Supports up to z22
 typedef uint32_t TileCoordinate;
-typedef uint16_t Z6Offset;
-#define TILE_COORDINATE_MAX UINT32_MAX
-#else
-// Supports up to z14
-typedef uint16_t TileCoordinate;
-typedef uint8_t Z6Offset;
-#define TILE_COORDINATE_MAX UINT16_MAX
-#endif
 
 class TileCoordinates_ {
 

--- a/include/osm_mem_tiles.h
+++ b/include/osm_mem_tiles.h
@@ -31,7 +31,7 @@ class OsmMemTiles : public TileDataSource {
 public:
 	OsmMemTiles(
 		size_t threadNum,
-		uint baseZoom,
+		uint indexZoom,
 		bool includeID,
 		const NodeStore& nodeStore,
 		const WayStore& wayStore

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -9,7 +9,7 @@ extern bool verbose;
 class ShpMemTiles : public TileDataSource
 {
 public:
-	ShpMemTiles(size_t threadNum, uint baseZoom);
+	ShpMemTiles(size_t threadNum, uint indexZoom);
 
 	std::string name() const override { return "shp"; }
 

--- a/include/tile_coordinates_set.h
+++ b/include/tile_coordinates_set.h
@@ -17,14 +17,14 @@ public:
 // generally expected to be z14.
 class PreciseTileCoordinatesSet : public TileCoordinatesSet {
 public:
-	PreciseTileCoordinatesSet(uint zoom);
+	PreciseTileCoordinatesSet(unsigned int zoom);
 	bool test(TileCoordinate x, TileCoordinate y) const override;
 	size_t size() const override;
 	size_t zoom() const override;
 	void set(TileCoordinate x, TileCoordinate y) override;
 
 private:
-	uint zoom_;
+	unsigned int zoom_;
 	std::vector<bool> tiles;
 };
 
@@ -32,16 +32,16 @@ private:
 // z15 or higher, extrapolates a result based on a set for a lower zoom.
 class LossyTileCoordinatesSet : public TileCoordinatesSet {
 public:
-	LossyTileCoordinatesSet(uint zoom, const TileCoordinatesSet& precise);
+	LossyTileCoordinatesSet(unsigned int zoom, const TileCoordinatesSet& precise);
 	bool test(TileCoordinate x, TileCoordinate y) const override;
 	size_t size() const override;
 	size_t zoom() const override;
 	void set(TileCoordinate x, TileCoordinate y) override;
 
 private:
-	uint zoom_;
+	unsigned int zoom_;
 	const TileCoordinatesSet& tiles;
-	uint scale;
+	unsigned int scale;
 };
 
 #endif

--- a/include/tile_coordinates_set.h
+++ b/include/tile_coordinates_set.h
@@ -1,6 +1,7 @@
 #ifndef TILE_COORDINATES_SET_H
 #define TILE_COORDINATES_SET_H
 
+#include <cstddef>
 #include "coordinates.h"
 
 // Interface representing a bitmap of tiles of interest at a given zoom.

--- a/include/tile_coordinates_set.h
+++ b/include/tile_coordinates_set.h
@@ -1,0 +1,46 @@
+#ifndef TILE_COORDINATES_SET_H
+#define TILE_COORDINATES_SET_H
+
+#include "coordinates.h"
+
+// Interface representing a bitmap of tiles of interest at a given zoom.
+class TileCoordinatesSet {
+public:
+	virtual bool test(TileCoordinate x, TileCoordinate y) const = 0;
+	virtual void set(TileCoordinate x, TileCoordinate y) = 0;
+	virtual size_t size() const = 0;
+	virtual size_t zoom() const = 0;
+};
+
+// Read-write implementation for precise sets; maximum zoom is
+// generally expected to be z14.
+class PreciseTileCoordinatesSet : public TileCoordinatesSet {
+public:
+	PreciseTileCoordinatesSet(uint zoom);
+	bool test(TileCoordinate x, TileCoordinate y) const override;
+	size_t size() const override;
+	size_t zoom() const override;
+	void set(TileCoordinate x, TileCoordinate y) override;
+
+private:
+	uint zoom_;
+	std::vector<bool> tiles;
+};
+
+// Read-only implementation for a lossy set. Used when zoom is
+// z15 or higher, extrapolates a result based on a set for a lower zoom.
+class LossyTileCoordinatesSet : public TileCoordinatesSet {
+public:
+	LossyTileCoordinatesSet(uint zoom, const TileCoordinatesSet& precise);
+	bool test(TileCoordinate x, TileCoordinate y) const override;
+	size_t size() const override;
+	size_t zoom() const override;
+	void set(TileCoordinate x, TileCoordinate y) override;
+
+private:
+	uint zoom_;
+	const TileCoordinatesSet& tiles;
+	uint scale;
+};
+
+#endif

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -23,11 +23,17 @@ class TileBbox;
 #define CLUSTER_ZOOM_WIDTH (1 << CLUSTER_ZOOM)
 #define CLUSTER_ZOOM_AREA (CLUSTER_ZOOM_WIDTH * CLUSTER_ZOOM_WIDTH)
 
-// When basezoom <= 14, we track which base zoom tile contains the output object
-// by reconstituting the base zoom tile offset relative to the z6 tile.
-// When basezoom is >= 15, we truncate to z14 when indexing. This means we'll
-// get false positives when looking up in the index (since, e.g., a single z14 tile
-// covers 4 z15 tiles).
+// TileDataSource indexes which tiles have objects in them. The indexed zoom
+// is at most z14; we'll clamp to z14 if the base zoom is higher than z14.
+//
+// As a result, we need at most 15 bits to store an X/Y coordinate. For efficiency,
+// we bucket the world into 4,096 z6 tiles, which each contain some number of 
+// z14 objects. This lets us use only 8 bits to store an X/Y coordinate.
+//
+// Because index zoom is higher than base zoom in the case where base zoom is
+// z15+, we'll get false positives when looking up objects in the index,
+// since, e.g., a single z14 tile covers 4 z15 tiles.
+//
 // This is OK: when writing the z15 tile, there's a clipping step that will filter
 // out the false positives.
 typedef uint8_t Z6Offset;
@@ -60,12 +66,12 @@ struct OutputObjectXYID {
 template<typename OO> void finalizeObjects(
 	const std::string& name,
 	const size_t& threadNum,
-	const unsigned int& baseZoom,
+	const unsigned int& indexZoom,
 	typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator begin,
 	typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator end,
 	typename std::vector<std::vector<OO>>& lowZoom
 	) {
-	size_t z6OffsetDivisor = baseZoom >= CLUSTER_ZOOM ? (1 << (baseZoom - CLUSTER_ZOOM)) : 1;
+	size_t z6OffsetDivisor = indexZoom >= CLUSTER_ZOOM ? (1 << (indexZoom - CLUSTER_ZOOM)) : 1;
 #ifdef CLOCK_MONOTONIC
 	timespec startTs, endTs;
 	clock_gettime(CLOCK_MONOTONIC, &startTs);
@@ -114,7 +120,7 @@ template<typename OO> void finalizeObjects(
 		boost::sort::block_indirect_sort(
 			it->begin(),
 			it->end(), 
-			[baseZoom](const OO& a, const OO& b) {
+			[indexZoom](const OO& a, const OO& b) {
 				// Cluster by parent zoom, so that a subsequent search
 				// can find a contiguous range of entries for any tile
 				// at zoom 6 or higher.
@@ -122,14 +128,14 @@ template<typename OO> void finalizeObjects(
 				const size_t aY = a.y;
 				const size_t bX = b.x;
 				const size_t bY = b.y;
-				for (size_t z = CLUSTER_ZOOM; z <= baseZoom; z++) {
-					const auto aXz = aX / (1 << (baseZoom - z));
-					const auto bXz = bX / (1 << (baseZoom - z));
+				for (size_t z = CLUSTER_ZOOM; z <= indexZoom; z++) {
+					const auto aXz = aX / (1 << (indexZoom - z));
+					const auto bXz = bX / (1 << (indexZoom - z));
 					if (aXz != bXz)
 						return aXz < bXz;
 
-					const auto aYz = aY / (1 << (baseZoom - z));
-					const auto bYz = bY / (1 << (baseZoom - z));
+					const auto aYz = aY / (1 << (indexZoom - z));
+					const auto bYz = bY / (1 << (indexZoom - z));
 
 					if (aYz != bYz)
 						return aYz < bYz;
@@ -145,13 +151,13 @@ template<typename OO> void finalizeObjects(
 }
 
 template<typename OO> void collectTilesWithObjectsAtZoomTemplate(
-	const unsigned int& baseZoom,
+	const unsigned int& indexZoom,
 	const typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator objects,
 	const size_t size,
 	std::vector<TileCoordinatesSet>& zooms
 ) {
 	size_t maxZoom = zooms.size() - 1;
-	uint16_t z6OffsetDivisor = baseZoom >= CLUSTER_ZOOM ? (1 << (baseZoom - CLUSTER_ZOOM)) : 1;
+	uint16_t z6OffsetDivisor = indexZoom >= CLUSTER_ZOOM ? (1 << (indexZoom - CLUSTER_ZOOM)) : 1;
 	int64_t lastX = -1;
 	int64_t lastY = -1;
 	for (size_t i = 0; i < size; i++) {
@@ -164,8 +170,8 @@ template<typename OO> void collectTilesWithObjectsAtZoomTemplate(
 			TileCoordinate baseY = z6y * z6OffsetDivisor + objects[i][j].y;
 
 			// Translate the x, y at the requested zoom level
-			TileCoordinate x = baseX / (1 << (baseZoom - maxZoom));
-			TileCoordinate y = baseY / (1 << (baseZoom - maxZoom));
+			TileCoordinate x = baseX / (1 << (indexZoom - maxZoom));
+			TileCoordinate y = baseY / (1 << (indexZoom - maxZoom));
 
 			if (lastX != x || lastY != y) {
 				lastX = x;
@@ -192,7 +198,7 @@ inline OutputObjectID outputObjectWithId<OutputObjectXYID>(const OutputObjectXYI
 }
 
 template<typename OO> void collectLowZoomObjectsForTile(
-	const unsigned int& baseZoom,
+	const unsigned int& indexZoom,
 	typename std::vector<std::vector<OO>> objects,
 	unsigned int zoom,
 	const TileCoordinates& dstIndex,
@@ -201,7 +207,7 @@ template<typename OO> void collectLowZoomObjectsForTile(
 	if (zoom >= CLUSTER_ZOOM)
 		throw std::runtime_error("collectLowZoomObjectsForTile should not be called for high zooms");
 
-	uint16_t z6OffsetDivisor = baseZoom >= CLUSTER_ZOOM ? (1 << (baseZoom - CLUSTER_ZOOM)) : 1;
+	uint16_t z6OffsetDivisor = indexZoom >= CLUSTER_ZOOM ? (1 << (indexZoom - CLUSTER_ZOOM)) : 1;
 
 	for (size_t i = 0; i < objects.size(); i++) {
 		const size_t z6x = i / CLUSTER_ZOOM_WIDTH;
@@ -213,8 +219,8 @@ template<typename OO> void collectLowZoomObjectsForTile(
 			TileCoordinate baseY = z6y * z6OffsetDivisor + objects[i][j].y;
 
 			// Translate the x, y at the requested zoom level
-			TileCoordinate x = baseX / (1 << (baseZoom - zoom));
-			TileCoordinate y = baseY / (1 << (baseZoom - zoom));
+			TileCoordinate x = baseX / (1 << (indexZoom - zoom));
+			TileCoordinate y = baseY / (1 << (indexZoom - zoom));
 
 			if (dstIndex.x == x && dstIndex.y == y) {
 				if (objects[i][j].oo.minZoom <= zoom) {
@@ -226,7 +232,7 @@ template<typename OO> void collectLowZoomObjectsForTile(
 }
 
 template<typename OO> void collectObjectsForTileTemplate(
-	const unsigned int& baseZoom,
+	const unsigned int& indexZoom,
 	typename std::vector<AppendVectorNS::AppendVector<OO>>::iterator objects,
 	size_t iStart,
 	size_t iEnd,
@@ -237,7 +243,7 @@ template<typename OO> void collectObjectsForTileTemplate(
 	if (zoom < CLUSTER_ZOOM)
 		throw std::runtime_error("collectObjectsForTileTemplate should not be called for low zooms");
 
-	uint16_t z6OffsetDivisor = baseZoom >= CLUSTER_ZOOM ? (1 << (baseZoom - CLUSTER_ZOOM)) : 1;
+	uint16_t z6OffsetDivisor = indexZoom >= CLUSTER_ZOOM ? (1 << (indexZoom - CLUSTER_ZOOM)) : 1;
 
 	for (size_t i = iStart; i < iEnd; i++) {
 		// If z >= 6, we can compute the exact bounds within the objects array.
@@ -246,8 +252,8 @@ template<typename OO> void collectObjectsForTileTemplate(
 		TileCoordinate z6x = dstIndex.x / (1 << (zoom - CLUSTER_ZOOM));
 		TileCoordinate z6y = dstIndex.y / (1 << (zoom - CLUSTER_ZOOM));
 
-		TileCoordinate baseX = dstIndex.x * (1 << (baseZoom - zoom));
-		TileCoordinate baseY = dstIndex.y * (1 << (baseZoom - zoom));
+		TileCoordinate baseX = dstIndex.x * (1 << (indexZoom - zoom));
+		TileCoordinate baseY = dstIndex.y * (1 << (indexZoom - zoom));
 
 		Z6Offset needleX = baseX - z6x * z6OffsetDivisor;
 		Z6Offset needleY = baseY - z6y * z6OffsetDivisor;
@@ -256,7 +262,7 @@ template<typename OO> void collectObjectsForTileTemplate(
 		// into two arrays, one of x/y and one of OOs. Would have better locality for
 		// searching, too.
 		OutputObject dummyOo(POINT_, 0, 0, 0, 0);
-		const size_t bz = baseZoom;
+		const size_t bz = indexZoom;
 
 		const OO targetXY = {dummyOo, needleX, needleY };
 		auto iter = std::lower_bound(
@@ -293,8 +299,8 @@ template<typename OO> void collectObjectsForTileTemplate(
 			TileCoordinate baseY = z6y * z6OffsetDivisor + iter->y;
 
 			// Translate the x, y at the requested zoom level
-			TileCoordinate x = baseX / (1 << (baseZoom - zoom));
-			TileCoordinate y = baseY / (1 << (baseZoom - zoom));
+			TileCoordinate x = baseX / (1 << (indexZoom - zoom));
+			TileCoordinate y = baseY / (1 << (indexZoom - zoom));
 
 			if (dstIndex.x == x && dstIndex.y == y) {
 				if (iter->oo.minZoom <= zoom) {
@@ -363,7 +369,7 @@ protected:
 	boost::geometry::index::rtree< std::pair<Box,OutputObject>, oo_rtree_param_type> boxRtree;
 	boost::geometry::index::rtree< std::pair<Box,OutputObjectID>, oo_rtree_param_type> boxRtreeWithIds;
 
-	unsigned int baseZoom;
+	unsigned int indexZoom;
 
 	std::vector<point_store_t> pointStores;
 	std::vector<linestring_store_t> linestringStores;
@@ -376,7 +382,7 @@ protected:
 	std::deque<std::vector<std::tuple<TileCoordinates, OutputObject, uint64_t>>> pendingSmallIndexObjects;
 
 public:
-	TileDataSource(size_t threadNum, unsigned int baseZoom, bool includeID);
+	TileDataSource(size_t threadNum, unsigned int indexZoom, bool includeID);
 
 	void collectTilesWithObjectsAtZoom(std::vector<TileCoordinatesSet>& zooms);
 

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -31,7 +31,7 @@ class TileBbox;
 // we bucket the world into 4,096 z6 tiles, which each contain some number of 
 // z14 objects. This lets us use only 8 bits to store an X/Y coordinate.
 //
-// Because index zoom is higher than base zoom in the case where base zoom is
+// Because index zoom is lower than base zoom in the case where base zoom is
 // z15+, we'll get false positives when looking up objects in the index,
 // since, e.g., a single z14 tile covers 4 z15 tiles.
 //

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -23,6 +23,15 @@ class TileBbox;
 #define CLUSTER_ZOOM_WIDTH (1 << CLUSTER_ZOOM)
 #define CLUSTER_ZOOM_AREA (CLUSTER_ZOOM_WIDTH * CLUSTER_ZOOM_WIDTH)
 
+// When basezoom <= 14, we track which base zoom tile contains the output object
+// by reconstituting the base zoom tile offset relative to the z6 tile.
+// When basezoom is >= 15, we truncate to z14 when indexing. This means we'll
+// get false positives when looking up in the index (since, e.g., a single z14 tile
+// covers 4 z15 tiles).
+// This is OK: when writing the z15 tile, there's a clipping step that will filter
+// out the false positives.
+typedef uint8_t Z6Offset;
+
 struct OutputObjectXY {
 	OutputObject oo;
 	Z6Offset x;

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -7,12 +7,12 @@ thread_local GeometryCache<Linestring> linestringCache;
 
 OsmMemTiles::OsmMemTiles(
 	size_t threadNum,
-	uint baseZoom,
+	uint indexZoom,
 	bool includeID,
 	const NodeStore& nodeStore,
 	const WayStore& wayStore
 )
-	: TileDataSource(threadNum, baseZoom, includeID),
+	: TileDataSource(threadNum, indexZoom, includeID),
 	nodeStore(nodeStore),
 	wayStore(wayStore)
 {

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -259,12 +259,6 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		cout << "tilemaker may have excessive memory, time, and space requirements at higher zooms. You can find more information in the docs/ folder." << endl;
 		cout << "**** WARNING ****" << endl;
 	}
-#ifndef FAT_TILE_INDEX
-	if (endZoom>16) {
-		cerr << "Compile tilemaker with -DFAT_TILE_INDEX to enable tile output at zoom level 17 or greater" << endl;
-		exit (EXIT_FAILURE);
-	}
-#endif
 
 	compressOpt    = jsonConfig["settings"]["compress"].GetString();
 	combineBelow   = jsonConfig["settings"].HasMember("combine_below") ? jsonConfig["settings"]["combine_below"].GetUint() : 0;

--- a/src/tile_coordinates_set.cpp
+++ b/src/tile_coordinates_set.cpp
@@ -1,0 +1,55 @@
+#include "tile_coordinates_set.h"
+
+PreciseTileCoordinatesSet::PreciseTileCoordinatesSet(uint zoom):
+	zoom_(zoom),
+	tiles((1 << zoom) * (1 << zoom)) {}
+
+bool PreciseTileCoordinatesSet::test(TileCoordinate x, TileCoordinate y) const {
+	uint64_t loc = x * (1 << zoom_) + y;
+	if (loc >= tiles.size())
+		return false;
+
+	return tiles[loc];
+}
+
+size_t PreciseTileCoordinatesSet::zoom() const {
+	return zoom_;
+}
+
+size_t PreciseTileCoordinatesSet::size() const {
+	size_t rv = 0;
+	for (int i = 0; i < tiles.size(); i++)
+		if (tiles[i])
+			rv++;
+
+	return rv;
+}
+
+void PreciseTileCoordinatesSet::set(TileCoordinate x, TileCoordinate y) {
+	uint64_t loc = x * (1 << zoom_) + y;
+	if (loc >= tiles.size())
+		return;
+	tiles[loc] = true;
+}
+
+LossyTileCoordinatesSet::LossyTileCoordinatesSet(uint zoom, const TileCoordinatesSet& underlying) : zoom_(zoom), tiles(underlying), scale(1 << (zoom - underlying.zoom())) {
+	if (zoom <= underlying.zoom())
+		throw std::out_of_range("LossyTileCoordinatesSet: zoom (" + std::to_string(zoom_) + ") must be greater than underlying set's zoom (" + std::to_string(underlying.zoom()) + ")");
+}
+
+bool LossyTileCoordinatesSet::test(TileCoordinate x, TileCoordinate y) const {
+	return tiles.test(x / scale, y / scale);
+}
+
+size_t LossyTileCoordinatesSet::size() const {
+	return tiles.size() * scale * scale;
+}
+
+size_t LossyTileCoordinatesSet::zoom() const {
+	return zoom_;
+}
+
+void LossyTileCoordinatesSet::set(TileCoordinate x, TileCoordinate y) {
+	throw std::logic_error("LossyTileCoordinatesSet::set() is not implemented; LossyTileCoordinatesSet is read-only");
+}
+

--- a/src/tile_coordinates_set.cpp
+++ b/src/tile_coordinates_set.cpp
@@ -1,7 +1,7 @@
 #include "tile_coordinates_set.h"
 #include <string>
 
-PreciseTileCoordinatesSet::PreciseTileCoordinatesSet(uint zoom):
+PreciseTileCoordinatesSet::PreciseTileCoordinatesSet(unsigned int zoom):
 	zoom_(zoom),
 	tiles((1 << zoom) * (1 << zoom)) {}
 
@@ -33,7 +33,7 @@ void PreciseTileCoordinatesSet::set(TileCoordinate x, TileCoordinate y) {
 	tiles[loc] = true;
 }
 
-LossyTileCoordinatesSet::LossyTileCoordinatesSet(uint zoom, const TileCoordinatesSet& underlying) : zoom_(zoom), tiles(underlying), scale(1 << (zoom - underlying.zoom())) {
+LossyTileCoordinatesSet::LossyTileCoordinatesSet(unsigned int zoom, const TileCoordinatesSet& underlying) : zoom_(zoom), tiles(underlying), scale(1 << (zoom - underlying.zoom())) {
 	if (zoom <= underlying.zoom())
 		throw std::out_of_range("LossyTileCoordinatesSet: zoom (" + std::to_string(zoom_) + ") must be greater than underlying set's zoom (" + std::to_string(underlying.zoom()) + ")");
 }

--- a/src/tile_coordinates_set.cpp
+++ b/src/tile_coordinates_set.cpp
@@ -1,5 +1,6 @@
 #include "tile_coordinates_set.h"
 #include <string>
+#include <stdexcept>
 
 PreciseTileCoordinatesSet::PreciseTileCoordinatesSet(unsigned int zoom):
 	zoom_(zoom),
@@ -51,6 +52,6 @@ size_t LossyTileCoordinatesSet::zoom() const {
 }
 
 void LossyTileCoordinatesSet::set(TileCoordinate x, TileCoordinate y) {
-	throw std::runtime_error("LossyTileCoordinatesSet::set() is not implemented; LossyTileCoordinatesSet is read-only");
+	throw std::logic_error("LossyTileCoordinatesSet::set() is not implemented; LossyTileCoordinatesSet is read-only");
 }
 

--- a/src/tile_coordinates_set.cpp
+++ b/src/tile_coordinates_set.cpp
@@ -50,6 +50,6 @@ size_t LossyTileCoordinatesSet::zoom() const {
 }
 
 void LossyTileCoordinatesSet::set(TileCoordinate x, TileCoordinate y) {
-	throw std::logic_error("LossyTileCoordinatesSet::set() is not implemented; LossyTileCoordinatesSet is read-only");
+	throw std::runtime_error("LossyTileCoordinatesSet::set() is not implemented; LossyTileCoordinatesSet is read-only");
 }
 

--- a/src/tile_coordinates_set.cpp
+++ b/src/tile_coordinates_set.cpp
@@ -1,4 +1,5 @@
 #include "tile_coordinates_set.h"
+#include <string>
 
 PreciseTileCoordinatesSet::PreciseTileCoordinatesSet(uint zoom):
 	zoom_(zoom),

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -41,27 +41,28 @@ thread_local LeasedStore<TileDataSource::linestring_store_t> linestringStore;
 thread_local LeasedStore<TileDataSource::multi_linestring_store_t> multilinestringStore;
 thread_local LeasedStore<TileDataSource::multi_polygon_store_t> multipolygonStore;
 
-TileDataSource::TileDataSource(size_t threadNum, unsigned int baseZoom, bool includeID)
+TileDataSource::TileDataSource(size_t threadNum, unsigned int indexZoom, bool includeID)
 	:
 	includeID(includeID),
-	z6OffsetDivisor(baseZoom >= CLUSTER_ZOOM ? (1 << (baseZoom - CLUSTER_ZOOM)) : 1),
+	z6OffsetDivisor(indexZoom >= CLUSTER_ZOOM ? (1 << (indexZoom - CLUSTER_ZOOM)) : 1),
 	objectsMutex(threadNum * 4),
 	objects(CLUSTER_ZOOM_AREA),
 	lowZoomObjects(CLUSTER_ZOOM_AREA),
 	objectsWithIds(CLUSTER_ZOOM_AREA),
 	lowZoomObjectsWithIds(CLUSTER_ZOOM_AREA),
-	baseZoom(baseZoom),
+	indexZoom(indexZoom),
 	pointStores(threadNum),
 	linestringStores(threadNum),
 	multilinestringStores(threadNum),
 	multipolygonStores(threadNum),
-	multiPolygonClipCache(ClipCache<MultiPolygon>(threadNum, baseZoom)),
-	multiLinestringClipCache(ClipCache<MultiLinestring>(threadNum, baseZoom))
+	// TODO 682: Confirm this is OK
+	multiPolygonClipCache(ClipCache<MultiPolygon>(threadNum, indexZoom)),
+	multiLinestringClipCache(ClipCache<MultiLinestring>(threadNum, indexZoom))
 {
 	// TileDataSource can only index up to zoom 14. The caller is responsible for
 	// ensuring it does not use a higher zoom.
-	if (baseZoom > 14)
-		throw std::out_of_range("TileDataSource: baseZoom cannot be higher than 14, but was " + std::to_string(baseZoom));
+	if (indexZoom > 14)
+		throw std::out_of_range("TileDataSource: indexZoom cannot be higher than 14, but was " + std::to_string(indexZoom));
 
 
 	shardBits = 0;
@@ -92,8 +93,8 @@ void TileDataSource::finalize(size_t threadNum) {
 
 	std::cout << "indexed " << finalized << " contended objects" << std::endl;
 
-	finalizeObjects<OutputObjectXY>(name(), threadNum, baseZoom, objects.begin(), objects.end(), lowZoomObjects);
-	finalizeObjects<OutputObjectXYID>(name(), threadNum, baseZoom, objectsWithIds.begin(), objectsWithIds.end(), lowZoomObjectsWithIds);
+	finalizeObjects<OutputObjectXY>(name(), threadNum, indexZoom, objects.begin(), objects.end(), lowZoomObjects);
+	finalizeObjects<OutputObjectXYID>(name(), threadNum, indexZoom, objectsWithIds.begin(), objectsWithIds.end(), lowZoomObjectsWithIds);
 }
 
 void TileDataSource::addObjectToSmallIndex(const TileCoordinates& index, const OutputObject& oo, uint64_t id) {
@@ -102,7 +103,7 @@ void TileDataSource::addObjectToSmallIndex(const TileCoordinates& index, const O
 	const size_t z6y = index.y / z6OffsetDivisor;
 
 	if (z6x >= 64 || z6y >= 64) {
-		if (verbose) std::cerr << "ignoring OutputObject with invalid z" << baseZoom << " coordinates " << index.x << ", " << index.y << " (id: " << id << ")" << std::endl;
+		if (verbose) std::cerr << "ignoring OutputObject with invalid z" << indexZoom << " coordinates " << index.x << ", " << index.y << " (id: " << id << ")" << std::endl;
 		return;
 	}
 
@@ -147,13 +148,13 @@ void TileDataSource::addObjectToSmallIndexUnsafe(const TileCoordinates& index, c
 
 void TileDataSource::collectTilesWithObjectsAtZoom(std::vector<TileCoordinatesSet>& zooms) {
 	// Scan through all shards. Convert to base zoom, then convert to the requested zoom.
-	collectTilesWithObjectsAtZoomTemplate<OutputObjectXY>(baseZoom, objects.begin(), objects.size(), zooms);
-	collectTilesWithObjectsAtZoomTemplate<OutputObjectXYID>(baseZoom, objectsWithIds.begin(), objectsWithIds.size(), zooms);
+	collectTilesWithObjectsAtZoomTemplate<OutputObjectXY>(indexZoom, objects.begin(), objects.size(), zooms);
+	collectTilesWithObjectsAtZoomTemplate<OutputObjectXYID>(indexZoom, objectsWithIds.begin(), objectsWithIds.size(), zooms);
 }
 
-void addCoveredTilesToOutput(const uint baseZoom, std::vector<TileCoordinatesSet>& zooms, const Box& box) {
+void addCoveredTilesToOutput(const uint indexZoom, std::vector<TileCoordinatesSet>& zooms, const Box& box) {
 	size_t maxZoom = zooms.size() - 1;
-	int scale = pow(2, baseZoom - maxZoom);
+	int scale = pow(2, indexZoom - maxZoom);
 	TileCoordinate minx = box.min_corner().x() / scale;
 	TileCoordinate maxx = box.max_corner().x() / scale;
 	TileCoordinate miny = box.min_corner().y() / scale;
@@ -174,10 +175,10 @@ void addCoveredTilesToOutput(const uint baseZoom, std::vector<TileCoordinatesSet
 // Find the tiles used by the "large objects" from the rtree index
 void TileDataSource::collectTilesWithLargeObjectsAtZoom(std::vector<TileCoordinatesSet>& zooms) {
 	for(auto const &result: boxRtree)
-		addCoveredTilesToOutput(baseZoom, zooms, result.first);
+		addCoveredTilesToOutput(indexZoom, zooms, result.first);
 
 	for(auto const &result: boxRtreeWithIds)
-		addCoveredTilesToOutput(baseZoom, zooms, result.first);
+		addCoveredTilesToOutput(indexZoom, zooms, result.first);
 }
 
 // Copy objects from the tile at dstIndex (in the dataset srcTiles) into output
@@ -187,8 +188,8 @@ void TileDataSource::collectObjectsForTile(
 	std::vector<OutputObjectID>& output
 ) {
 	if (zoom < CLUSTER_ZOOM) {
-		collectLowZoomObjectsForTile<OutputObjectXY>(baseZoom, lowZoomObjects, zoom, dstIndex, output);
-		collectLowZoomObjectsForTile<OutputObjectXYID>(baseZoom, lowZoomObjectsWithIds, zoom, dstIndex, output);
+		collectLowZoomObjectsForTile<OutputObjectXY>(indexZoom, lowZoomObjects, zoom, dstIndex, output);
+		collectLowZoomObjectsForTile<OutputObjectXYID>(indexZoom, lowZoomObjectsWithIds, zoom, dstIndex, output);
 		return;
 	}
 
@@ -208,8 +209,8 @@ void TileDataSource::collectObjectsForTile(
 		iEnd = iStart + 1;
 	}
 
-	collectObjectsForTileTemplate<OutputObjectXY>(baseZoom, objects.begin(), iStart, iEnd, zoom, dstIndex, output);
-	collectObjectsForTileTemplate<OutputObjectXYID>(baseZoom, objectsWithIds.begin(), iStart, iEnd, zoom, dstIndex, output);
+	collectObjectsForTileTemplate<OutputObjectXY>(indexZoom, objects.begin(), iStart, iEnd, zoom, dstIndex, output);
+	collectObjectsForTileTemplate<OutputObjectXYID>(indexZoom, objectsWithIds.begin(), iStart, iEnd, zoom, dstIndex, output);
 }
 
 // Copy objects from the large index into output
@@ -218,7 +219,7 @@ void TileDataSource::collectLargeObjectsForTile(
 	TileCoordinates dstIndex,
 	std::vector<OutputObjectID>& output
 ) {
-	int scale = pow(2, baseZoom - zoom);
+	int scale = pow(2, indexZoom - zoom);
 	TileCoordinates srcIndex1( dstIndex.x   *scale  ,  dstIndex.y   *scale  );
 	TileCoordinates srcIndex2((dstIndex.x+1)*scale-1, (dstIndex.y+1)*scale-1);
 	Box box = Box(geom::make<Point>(srcIndex1.x, srcIndex1.y),
@@ -407,6 +408,7 @@ void populateTilesAtZoom(
 	const std::vector<class TileDataSource *>& sources,
 	std::vector<TileCoordinatesSet>& zooms
 ) {
+	// TODO 682
 	for(size_t i=0; i<sources.size(); i++) {
 		sources[i]->collectTilesWithObjectsAtZoom(zooms);
 		sources[i]->collectTilesWithLargeObjectsAtZoom(zooms);
@@ -452,7 +454,7 @@ void TileDataSource::addGeometryToIndex(
 ) {
 	unordered_set<TileCoordinates> tileSet;
 	try {
-		insertIntermediateTiles(geom, baseZoom, tileSet);
+		insertIntermediateTiles(geom, indexZoom, tileSet);
 
 		bool polygonExists = false;
 		TileCoordinate minTileX = std::numeric_limits<TileCoordinate>::max(), maxTileX = 0, minTileY = std::numeric_limits<TileCoordinate>::max(), maxTileY = 0;
@@ -504,7 +506,7 @@ void TileDataSource::addGeometryToIndex(
 ) {
 	for (Linestring ls : geom) {
 		unordered_set<TileCoordinates> tileSet;
-		insertIntermediateTiles(ls, baseZoom, tileSet);
+		insertIntermediateTiles(ls, indexZoom, tileSet);
 		for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 			TileCoordinates index = *it;
 			for (const auto& output : outputs) {
@@ -523,7 +525,7 @@ void TileDataSource::addGeometryToIndex(
 	bool singleOuter = geom.size()==1;
 	for (Polygon poly : geom) {
 		unordered_set<TileCoordinates> tileSetTmp;
-		insertIntermediateTiles(poly.outer(), baseZoom, tileSetTmp);
+		insertIntermediateTiles(poly.outer(), indexZoom, tileSetTmp);
 		fillCoveredTiles(tileSetTmp);
 		if (singleOuter) {
 			tileSet = std::move(tileSetTmp);

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -27,7 +27,6 @@ TileDataSource::TileDataSource(size_t threadNum, unsigned int indexZoom, bool in
 	linestringStores(threadNum),
 	multilinestringStores(threadNum),
 	multipolygonStores(threadNum),
-	// TODO 682: Confirm this is OK
 	multiPolygonClipCache(ClipCache<MultiPolygon>(threadNum, indexZoom)),
 	multiLinestringClipCache(ClipCache<MultiLinestring>(threadNum, indexZoom))
 {
@@ -389,7 +388,6 @@ void populateTilesAtZoom(
 	if (zooms.size() > 15)
 		throw std::out_of_range("populateTilesAtZoom: expected at most z14 zooms (15), but found " + std::to_string(zooms.size()) + " vectors");
 
-	// TODO 682
 	for(size_t i=0; i<sources.size(); i++) {
 		sources[i]->collectTilesWithObjectsAtZoom(zooms);
 		sources[i]->collectTilesWithLargeObjectsAtZoom(zooms);

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -191,8 +191,13 @@ void TileDataSource::collectLargeObjectsForTile(
 	TileCoordinates dstIndex,
 	std::vector<OutputObjectID>& output
 ) {
-	// TODO 682 - we must need to do... something here. But what?
-	int scale = pow(2, indexZoom - zoom);
+	unsigned int clampedZoom = zoom;
+	while (clampedZoom > indexZoom) {
+		clampedZoom--;
+		dstIndex.x /= 2;
+		dstIndex.y /= 2;
+	}
+	int scale = pow(2, indexZoom - clampedZoom);
 	TileCoordinates srcIndex1( dstIndex.x   *scale  ,  dstIndex.y   *scale  );
 	TileCoordinates srcIndex2((dstIndex.x+1)*scale-1, (dstIndex.y+1)*scale-1);
 	Box box = Box(geom::make<Point>(srcIndex1.x, srcIndex1.y),

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -58,6 +58,12 @@ TileDataSource::TileDataSource(size_t threadNum, unsigned int baseZoom, bool inc
 	multiPolygonClipCache(ClipCache<MultiPolygon>(threadNum, baseZoom)),
 	multiLinestringClipCache(ClipCache<MultiLinestring>(threadNum, baseZoom))
 {
+	// TileDataSource can only index up to zoom 14. The caller is responsible for
+	// ensuring it does not use a higher zoom.
+	if (baseZoom > 14)
+		throw std::out_of_range("TileDataSource: baseZoom cannot be higher than 14, but was " + std::to_string(baseZoom));
+
+
 	shardBits = 0;
 	numShards = 1;
 	while(numShards < threadNum) {
@@ -449,7 +455,7 @@ void TileDataSource::addGeometryToIndex(
 		insertIntermediateTiles(geom, baseZoom, tileSet);
 
 		bool polygonExists = false;
-		TileCoordinate minTileX = TILE_COORDINATE_MAX, maxTileX = 0, minTileY = TILE_COORDINATE_MAX, maxTileY = 0;
+		TileCoordinate minTileX = std::numeric_limits<TileCoordinate>::max(), maxTileX = 0, minTileY = std::numeric_limits<TileCoordinate>::max(), maxTileY = 0;
 		for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 			TileCoordinates index = *it;
 			minTileX = std::min(index.x, minTileX);
@@ -526,7 +532,7 @@ void TileDataSource::addGeometryToIndex(
 		}
 	}
 	
-	TileCoordinate minTileX = TILE_COORDINATE_MAX, maxTileX = 0, minTileY = TILE_COORDINATE_MAX, maxTileY = 0;
+	TileCoordinate minTileX = std::numeric_limits<TileCoordinate>::max(), maxTileX = 0, minTileY = std::numeric_limits<TileCoordinate>::max(), maxTileY = 0;
 	for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
 		TileCoordinates index = *it;
 		minTileX = std::min(index.x, minTileX);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -516,7 +516,6 @@ int main(const int argc, const char* argv[]) {
 					data.emplace_back(source->getObjectsForTile(sortOrders, zoom, coords));
 					n += data[data.size() - 1].size();
 				}
-				std::cout << "for tile z" << std::to_string(zoom) << "/" << std::to_string(coords.x) << "/" << std::to_string(coords.y) << ": " << std::to_string(n) << " objects" << std::endl;
 				outputProc(sharedData, sources, attributeStore, data, coords, zoom);
 
 #ifdef CLOCK_MONOTONIC

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -511,10 +511,8 @@ int main(const int argc, const char* argv[]) {
 #endif
 
 				std::vector<std::vector<OutputObjectID>> data;
-				size_t n = 0;
 				for (auto source : sources) {
 					data.emplace_back(source->getObjectsForTile(sortOrders, zoom, coords));
-					n += data[data.size() - 1].size();
 				}
 				outputProc(sharedData, sources, attributeStore, data, coords, zoom);
 

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -363,6 +363,7 @@ int main(const int argc, const char* argv[]) {
 		clock_gettime(CLOCK_MONOTONIC, &start);
 #endif
 		std::cout << "collecting tiles" << std::flush;
+		// TODO 682
 		populateTilesAtZoom(sources, zoomResults);
 #ifdef CLOCK_MONOTONIC
 		clock_gettime(CLOCK_MONOTONIC, &end);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -225,8 +225,10 @@ int main(const int argc, const char* argv[]) {
 	AttributeStore attributeStore;
 
 	class LayerDefinition layers(config.layers);
-	class OsmMemTiles osmMemTiles(options.threadNum, config.baseZoom, config.includeID, *nodeStore, *wayStore);
-	class ShpMemTiles shpMemTiles(options.threadNum, config.baseZoom);
+
+	const unsigned int indexZoom = std::min(config.baseZoom, 14u);
+	class OsmMemTiles osmMemTiles(options.threadNum, indexZoom, config.includeID, *nodeStore, *wayStore);
+	class ShpMemTiles shpMemTiles(options.threadNum, indexZoom);
 	osmMemTiles.open();
 	shpMemTiles.open();
 

--- a/test/tile_coordinates_set.test.cpp
+++ b/test/tile_coordinates_set.test.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include "external/minunit.h"
+#include "tile_coordinates_set.h"
+
+MU_TEST(test_tile_coordinates_set) {
+	{
+		PreciseTileCoordinatesSet z0(0);
+		mu_check(z0.test(0, 0) == false);
+		mu_check(z0.size() == 0);
+		mu_check(z0.zoom() == 0);
+
+		z0.set(0, 0);
+		mu_check(z0.test(0, 0) == true);
+		mu_check(z0.size() == 1);
+	}
+
+	{
+		PreciseTileCoordinatesSet z6(6);
+		mu_check(z6.test(0, 0) == false);
+
+		z6.set(0, 0);
+		mu_check(z6.test(0, 0) == true);
+		mu_check(z6.test(1, 0) == false);
+		mu_check(z6.test(0, 1) == false);
+		mu_check(z6.size() == 1);
+		mu_check(z6.zoom() == 6);
+	}
+
+	// Wrapped sets should extrapolate from lower zooms
+	{
+		PreciseTileCoordinatesSet z1(1);
+		LossyTileCoordinatesSet z2(2, z1);
+
+		mu_check(z2.size() == 0);
+		for (int x = 0; x < 4; x++) {
+			for (int y = 0; y < 4; y++) {
+				mu_check(z2.test(x, y) == false);
+			}
+		}
+		z1.set(0, 0);
+		mu_check(z2.size() == 4);
+		mu_check(z2.test(0, 0) == true);
+		mu_check(z2.test(0, 1) == true);
+		mu_check(z2.test(1, 0) == true);
+		mu_check(z2.test(1, 1) == true);
+		mu_check(z2.test(2, 2) == false);
+	}
+}
+
+MU_TEST_SUITE(test_suite_tile_coordinates_set) {
+	MU_RUN_TEST(test_tile_coordinates_set);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_tile_coordinates_set);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}


### PR DESCRIPTION
This fixes https://github.com/systemed/tilemaker/discussions/682. Opening as a draft, as I've only done minimal testing so far.

The gist is: TileDataSource now operates in terms of `indexZoom`, not `baseZoom`. It's the lesser of `14` or your configured base zoom.

`TileCoordinatesSet` has been turned into an interface, with two implementations:

- `PreciseTileCoordinatesSet`, which is the old implementation, and used for z0-z14
- `LossyTileCoordinatesSet`, which is used for z15+. It wraps a `PreciseTileCoordinatesSet` to answer whether a tile might have objects at z15+. It gives false positives, but never false negatives. False positives are OK, as they get clipped out when writing anyway.

Some smoke testing makes me think this is working. I'll ask the reporter to give it a whirl, too.