### PR TITLE
support multiple input files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ test: \
 	test_attribute_store \
 	test_deque_map \
 	test_helpers \
+	test_options_parser \
 	test_pbf_reader \
 	test_pooled_string \
 	test_relation_roles \

--- a/src/options_parser.cpp
+++ b/src/options_parser.cpp
@@ -105,5 +105,10 @@ OptionsParser::Options OptionsParser::parse(const int argc, const char* argv[]) 
 		throw OptionException{"Couldn't open .lua script: " + options.luaFile };
 	}
 
+	// The lazy geometry code has assumptions that break when more than one
+	// input file is used.
+	if (options.inputFiles.size() > 1)
+		options.osm.materializeGeometries = true;
+
 	return options;
 }

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -122,7 +122,10 @@ int main(const int argc, const char* argv[]) {
 
 	bool hasClippingBox = false;
 	Box clippingBox;
-	double minLon=0.0, maxLon=0.0, minLat=0.0, maxLat=0.0;
+	double minLon=std::numeric_limits<double>::max(),
+				 maxLon=std::numeric_limits<double>::min(),
+				 minLat=std::numeric_limits<double>::max(),
+				 maxLat=std::numeric_limits<double>::min();
 	if (!bboxElements.empty()) {
 		hasClippingBox = true;
 		minLon = bboxElementFromStr(bboxElements.at(0));
@@ -131,8 +134,20 @@ int main(const int argc, const char* argv[]) {
 		maxLat = bboxElementFromStr(bboxElements.at(3));
 
 	} else if (options.inputFiles.size()>0) {
-		int ret = ReadPbfBoundingBox(options.inputFiles[0], minLon, maxLon, minLat, maxLat, hasClippingBox);
-		if(ret != 0) return ret;
+		for (const auto inputFile : options.inputFiles) {
+			bool localHasClippingBox;
+			double localMinLon, localMaxLon, localMinLat, localMaxLat;
+			int ret = ReadPbfBoundingBox(inputFile, localMinLon, localMaxLon, localMinLat, localMaxLat, localHasClippingBox);
+			if(ret != 0) return ret;
+			hasClippingBox = hasClippingBox || localHasClippingBox;
+
+			if (localHasClippingBox) {
+				minLon = std::min(minLon, localMinLon);
+				maxLon = std::max(maxLon, localMaxLon);
+				minLat = std::min(minLat, localMinLat);
+				maxLat = std::max(maxLat, localMaxLat);
+			}
+		}
 	}
 
 	if (hasClippingBox) {
@@ -179,7 +194,7 @@ int main(const int argc, const char* argv[]) {
 			return rv;
 		}
 
-		if (allPbfsHaveSortTypeThenID) {
+		if (options.inputFiles.size() == 1 && allPbfsHaveSortTypeThenID) {
 			std::shared_ptr<NodeStore> rv = make_shared<SortedNodeStore>(!options.osm.uncompressedNodes);
 			return rv;
 		}
@@ -198,7 +213,7 @@ int main(const int argc, const char* argv[]) {
 	}
 
 	auto createWayStore = [anyPbfHasLocationsOnWays, allPbfsHaveSortTypeThenID, options, &nodeStore]() {
-		if (!anyPbfHasLocationsOnWays && allPbfsHaveSortTypeThenID) {
+		if (options.inputFiles.size() == 1 && !anyPbfHasLocationsOnWays && allPbfsHaveSortTypeThenID) {
 			std::shared_ptr<WayStore> rv = make_shared<SortedWayStore>(!options.osm.uncompressedWays, *nodeStore.get());
 			return rv;
 		}
@@ -280,12 +295,18 @@ int main(const int argc, const char* argv[]) {
 			significantWayTags,
 			options.threadNum,
 			[&]() {
-				thread_local std::shared_ptr<ifstream> pbfStream(new ifstream(inputFile, ios::in | ios::binary));
-				return pbfStream;
+				thread_local std::pair<std::string, std::shared_ptr<ifstream>> pbfStream;
+				if (pbfStream.first != inputFile) {
+					pbfStream = std::make_pair(inputFile, std::make_shared<ifstream>(inputFile, ios::in | ios::binary));
+				}
+				return pbfStream.second;
 			},
 			[&]() {
-				thread_local std::shared_ptr<OsmLuaProcessing> osmLuaProcessing(new OsmLuaProcessing(osmStore, config, layers, options.luaFile, shpMemTiles, osmMemTiles, attributeStore, options.osm.materializeGeometries));
-				return osmLuaProcessing;
+				thread_local std::pair<std::string, std::shared_ptr<OsmLuaProcessing>> osmLuaProcessing;
+				if (osmLuaProcessing.first != inputFile) {
+					osmLuaProcessing = std::make_pair(inputFile, std::make_shared<OsmLuaProcessing>(osmStore, config, layers, options.luaFile, shpMemTiles, osmMemTiles, attributeStore, options.osm.materializeGeometries));
+				}
+				return osmLuaProcessing.second;
 			},
 			*nodeStore,
 			*wayStore


### PR DESCRIPTION
Fixes #696, a regression introduced in the v3.0 work:

- fix bug in thread locals for `generate_stream` and `generate_output`
  - if the thread local was read on the main thread, we would previously fail to reset it for the subsequent PBF file
- use the old NodeStore/WayStore when multiple input files are present
  - the optimization for `Sort.Type_then_ID` assumes IDs are monotonically increasing. This is not true when there are multiple PBFs, as the subsequent PBF restarts its numbering.
- don't use lazy geometries when multiple input files present
  - `LeasedStore` assumed that there would be at most 1 PBF being read. This might be fixable by multiplying `threadNum` by the number of PBFs to be read in the initializers here: https://github.com/systemed/tilemaker/blob/07e878fc5c382a9e1fd9ad255c13f6df533b86f5/src/tile_data.cpp#L54-L57 
- compute the bbox from the union of all the pbfs
  - I think this may have been a pre-existing bug, made more noticeable by changes in v3 that relied more heavily on the bbox being correct

For testing, I built a pmtiles with monaco + liechtenstein and verified they both showed up.

I think we could probably support lazy geometries, but have left it alone for now.