### PR TITLE
Improves docker setup for basic usage to get started more easily

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,56 @@
-FROM debian:bullseye-slim AS src
+FROM debian:bookworm-slim AS src
 LABEL Description="Tilemaker" Version="1.4.0"
 
-ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    liblua5.1-0-dev \
+    libsqlite3-dev \
+    libshp-dev \
+    libboost-program-options-dev \
+    libboost-filesystem-dev \
+    libboost-system-dev \
+    libboost-iostreams-dev \
+    rapidjson-dev \
+    cmake \
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-# install dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      build-essential \
-      liblua5.1-0 \
-      liblua5.1-0-dev \
-      libsqlite3-dev \
-      shapelib \
-      libshp-dev \
-      libboost-program-options-dev \
-      libboost-filesystem-dev \
-      libboost-system-dev \
-      libboost-iostreams-dev \
-      rapidjson-dev \
-      cmake \
-      zlib1g-dev
+WORKDIR /usr/src/app
 
-COPY CMakeLists.txt /
-COPY cmake /cmake
-COPY src /src
-COPY include /include
-COPY server /server
+COPY CMakeLists.txt ./
+COPY cmake ./cmake
+COPY src ./src
+COPY include ./include
+COPY server ./server
 
-WORKDIR /build
+RUN mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    cmake --build . --parallel $(nproc) && \
+    strip tilemaker && \
+    strip tilemaker-server
 
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ ..
-RUN cmake --build .
-RUN strip tilemaker
-RUN strip tilemaker-server
+ENV PATH="/usr/src/app/build:$PATH"
 
-FROM debian:bullseye-slim
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      liblua5.1-0 \
-      libshp-dev \
-      libsqlite3-dev \
-      libboost-filesystem-dev \
-      libboost-program-options-dev \
-      libboost-iostreams-dev
-WORKDIR /
-COPY --from=src /build/tilemaker .
-COPY resources /resources
-COPY process.lua .
-COPY config.json .
+FROM debian:bookworm-slim
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    liblua5.1-0 \
+    shapelib \
+    libsqlite3-0 \
+    libboost-filesystem1.74.0 \
+    libboost-program-options1.74.0 \
+    libboost-iostreams1.74.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+COPY --from=src /usr/src/app/build/tilemaker .
+COPY --from=src /usr/src/app/build/tilemaker-server .
+COPY resources ./resources
+COPY process.lua ./
+COPY config.json ./
+
+ENV PATH="/usr/src/app/build:$PATH"
 
 # Entrypoint for docker, wrapped with /bin/sh to remove requirement for executable permissions on script
-ENTRYPOINT ["/bin/sh", "/resources/docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/sh", "/usr/src/app/resources/docker-entrypoint.sh"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ See an example of a vector tile map produced by tilemaker at [tilemaker.org](htt
 
 ![Continuous Integration](https://github.com/systemed/tilemaker/workflows/Continuous%20Integration/badge.svg)
 
+## Getting Started
+
+We provide a ready-to-use docker image that gets you started without having to compile tilemaker from source:
+
+1. Go to http://download.geofabrik.de/europe.html and download the `monaco-latest.osm.pbf` snapshot of OpenStreetMap
+
+2. Run tilemaker on the OpenStreetMap snapshot to generate [Protomaps](https://protomaps.com) vector tiles:
+
+    docker run -it --rm -v (pwd):/data ghcr.io/systemed/tilemaker:master /data/monaco-latest.osm.pbf --output /data/monaco-latest.pmtiles
+
+3. Check out what's in the vector tiles e.g. by using the debug viewer [here](https://protomaps.github.io/PMTiles/)
+
+
 ## Installing
 
 tilemaker is written in C++14. The chief dependencies are:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -62,6 +62,10 @@ Build from project root directory with:
 
 The docker container can be run like this:
 
-    docker run -v /Users/Local/Downloads/:/srv -i -t --rm tilemaker /srv/germany-latest.osm.pbf --output=/srv/germany.mbtiles
+    docker run -it --rm -v $(pwd):/data tilemaker /data/monaco-latest.osm.pbf --output /data/monaco-latest.pmtiles
+
+The tilemaker-server can be run like this:
+
+    docker run -it --rm -v $(pwd):/data --entrypoint /usr/src/app/tilemaker-server tilemaker --help
 
 Keep in mind to map the volume your .osm.pbf files are in to a path within your docker container, as seen in the example above. 

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -6,4 +6,4 @@ echo "DOCKER WARNING: The --store option can be used to partly reduce memory usa
 echo "--------------------------------------------------------------------------------" >&2
 
 # Proceed to run the command passed to the script
-exec /tilemaker "$@"
+exec /usr/src/app/tilemaker "$@"


### PR DESCRIPTION
Hi! :wave: Finally giving your project a try and because it's 2024 ain't nobody got time for building C++ from source, I checked out the docker images. In this changeset I make various improvements to the docker setup
1. Using the stable debian bookworm as a base image as bullseye is outdated
2. Not installing the development libraries with the tilemaker binary as they're only needed for building
3. Compiling in parallel so that the docker build doesn't take 10+ minutes to build
4. Adding a default command of `--help` so that if folks do `docker run` they get to see the tilemaker help
5. Updated the docker readme and added a usage section in the default readme to use docker by default

I would highly recommend defaulting to telling users to just use the docker image and not having to compile tilemaker from source. There are so many compilation problems caused by dependencies to install, compiler and linker versions, and so on.

Just from a first look
- https://github.com/systemed/tilemaker/issues/702
- https://github.com/systemed/tilemaker/issues/694
- https://github.com/systemed/tilemaker/issues/444

If we could dumb down the getting started instructions to

    docker run .. tilemaker input.pbf --output output.pbf

that would make it easier for users and hopefully less likely for us to get support tickets.