### PR TITLE
Fix reading bools from shapefiles

### DIFF
--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -42,7 +42,7 @@ private:
 	std::map<const std::string*, uint16_t, string_ptr_less_than> keys2index;
 };
 
-enum class AttributePairType: uint8_t { Bool = 0, Float = 1, String = 2 };
+enum class AttributePairType: uint8_t { String = 0, Float = 1, Bool = 2 };
 // AttributePair is a key/value pair (with minzoom)
 #pragma pack(push, 1)
 struct AttributePair {

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -34,7 +34,7 @@ struct LayerDef {
 	bool allSourceColumns;
 	bool indexed;
 	std::string indexName;
-	std::map<std::string, uint> attributeMap;
+	std::map<std::string, uint> attributeMap; // string 0, number 1, bool 2
 	bool writeTo;
 	
 	const bool useColumn(std::string &col) {

--- a/src/shp_processor.cpp
+++ b/src/shp_processor.cpp
@@ -35,6 +35,7 @@ void ShpProcessor::fillPointArrayFromShapefile(vector<Point> *points, SHPObject 
 }
 
 // Read requested attributes from a shapefile, and encode into an OutputObject
+// columnTypeMap: 0 string, 1 int, 2 double, 3 boolean
 AttributeIndex ShpProcessor::readShapefileAttributes(
 		DBFHandle &dbf,
 		int recordNum, unordered_map<int,string> &columnMap, unordered_map<int,int> &columnTypeMap,
@@ -53,6 +54,7 @@ AttributeIndex ShpProcessor::readShapefileAttributes(
 			switch (columnTypeMap[pos]) {
 				case 1:  in_table[key] = DBFReadIntegerAttribute(dbf, recordNum, pos); break;
 				case 2:  in_table[key] =  DBFReadDoubleAttribute(dbf, recordNum, pos); break;
+				case 3:  in_table[key] = strcmp(DBFReadStringAttribute(dbf, recordNum, pos), "T")==0; break;
 				default: in_table[key] =  DBFReadStringAttribute(dbf, recordNum, pos); break;
 			}
 		}
@@ -92,7 +94,10 @@ AttributeIndex ShpProcessor::readShapefileAttributes(
 				case 2:  attributeStore.addAttribute(attributes, key, static_cast<float>(DBFReadDoubleAttribute(dbf, recordNum, pos)), 0);
 				         layer.attributeMap[key] = 1;
 				         break;
-				default: attributeStore.addAttribute(attributes, key, DBFReadStringAttribute(dbf, recordNum, pos), 0);
+				case 3:  attributeStore.addAttribute(attributes, key, strcmp(DBFReadStringAttribute(dbf, recordNum, pos), "T")==0, 0);
+				         layer.attributeMap[key] = 2;
+				         break;
+				default: attributeStore.addAttribute(attributes, key, static_cast<const std::string&>(DBFReadStringAttribute(dbf, recordNum, pos)), 0);
 				         layer.attributeMap[key] = 0;
 				         break;
 			}


### PR DESCRIPTION
I don't think we've ever handled shapefile bools correctly, and even what we did do slipped a little in 3.0. This should fix it such that bools are carried through correctly to the vector tile attributes.

DBF file format calls bools "logical values". [Shapelib returns them as value 3](http://shapelib.maptools.org/dbf_api.html) (==FTLogical). According to https://www.dbase.com/help/Design_Tables/IDH_TABLEDES_FIELD_TYPES.htm, truthy values can be T/t/Y/y, while falsey is F/f/N/n (sheesh). I have never seen anything other than "T" in the wild so that's all I'm handling here, but if that proves not to be the case, this PR is an aide-memoire for why!