### PR TITLE
Only use Mac-specific LuaJIT linking for 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,10 @@ ifeq ($(LUA_CMD),luajit)
   LUA_CFLAGS := ${LUA_CFLAGS} -DLUAJIT
   ifneq ($(OS),Windows_NT)
     ifeq ($(shell uname -s), Darwin)
-      LDFLAGS := -pagezero_size 10000 -image_base 100000000
-      $(info - with MacOS LuaJIT linking)
+      ifeq ($(LUA_JITV),2.0)
+        LDFLAGS := -pagezero_size 10000 -image_base 100000000
+        $(info - with MacOS LuaJIT linking)
+      endif
     endif
   endif
 endif


### PR DESCRIPTION
The Mac-specific build flags for LuaJIT are no longer required with LuaJIT 2.1 (see https://github.com/LuaJIT/LuaJIT/issues/993#issuecomment-1566011965).

Fixes #699 hopefully.