### PR TITLE
Remove macos-latest CMake CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,6 @@ jobs:
             executable: tilemaker
             path: /usr/local/share/vcpkg/installed
             toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-          - os: macos-latest
-            triplet: x64-osx
-            executable: tilemaker
-            path: /usr/local/share/vcpkg/installed
-            toolchain: /usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
     name: ${{ matrix.os }} (CMake)
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This removes the failing macOS-CMake build again - cf #670, it looks like this might have been migrated onto Apple Silicon even despite specifying x64-osx.