### PR TITLE
Adds convenience scripts to download coastline and landuse data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,23 @@ tilemaker keeps everything in RAM by default. To process large areas without run
 
     tilemaker /path/to/your/input.osm.pbf /path/to/your/output.mbtiles --store /path/to/your/ssd
 
-To include sea tiles, create a directory called `coastline` in the same place you're running tilemaker from, and then save the files from https://osmdata.openstreetmap.de/download/water-polygons-split-4326.zip in it, such that tilemaker can find a file at `coastline/water_polygons.shp`.
-
-_(If you want to include optional small-scale landcover, create a `landcover` directory, and download the appropriate 10m files from 'Features' at https://www.naturalearthdata.com so that you have `landcover/ne_10m_antarctic_ice_shelves_polys/ne_10m_antarctic_ice_shelves_polys.shp`, `landcover/ne_10m_urban_areas/ne_10m_urban_areas.shp`, `landcover/ne_10m_glaciated_areas/ne_10m_glaciated_areas.shp`.)_
-
 Then, to serve your tiles using the demonstration server:
 
     cd server
 	tilemaker-server /path/to/your/output.mbtiles
 
 You can now navigate to http://localhost:8080/ and see your map!
+
+## Coastline and Landcover
+
+To include sea tiles and small-scale landcover, run
+
+    ./get-coastline.sh
+    ./get-landcover.sh
+
+This will download coastline and landcover data; you will need around 2GB disk space.
+
+Have a look at the coastline and landcover example in the [`resources/`](./resources) directory.
 
 ## Your own configuration
 

--- a/get-coastline.sh
+++ b/get-coastline.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+mkdir -p coastline
+pushd coastline
+
+if ! [ -f "water-polygons-split-4326.zip" ]; then
+  curl --proto '=https' --tlsv1.3 -sSfO https://osmdata.openstreetmap.de/download/water-polygons-split-4326.zip
+fi
+
+unzip -o -j water-polygons-split-4326.zip
+
+popd

--- a/get-landcover.sh
+++ b/get-landcover.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+mkdir -p landcover
+pushd landcover
+
+if ! [ -f "ne_10m_antarctic_ice_shelves_polys.zip" ]; then
+  curl --proto '=https' --tlsv1.3 -sSfO https://naciscdn.org/naturalearth/10m/physical/ne_10m_antarctic_ice_shelves_polys.zip
+fi
+
+if ! [ -f "ne_10m_urban_areas.zip" ]; then
+  curl --proto '=https' --tlsv1.3 -sSfO https://naciscdn.org/naturalearth/10m/cultural/ne_10m_urban_areas.zip
+fi
+
+if ! [ -f "ne_10m_glaciated_areas.zip" ]; then
+  curl --proto '=https' --tlsv1.3 -sSfO https://naciscdn.org/naturalearth/10m/physical/ne_10m_glaciated_areas.zip
+fi
+
+mkdir -p ne_10m_antarctic_ice_shelves_polys
+unzip -o ne_10m_antarctic_ice_shelves_polys.zip -d ne_10m_antarctic_ice_shelves_polys
+
+mkdir -p ne_10m_urban_areas
+unzip -o ne_10m_urban_areas.zip -d ne_10m_urban_areas
+
+mkdir -p ne_10m_glaciated_areas
+unzip -o ne_10m_glaciated_areas.zip -d ne_10m_glaciated_areas
+
+popd

--- a/get-monaco.sh
+++ b/get-monaco.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+if ! [ -f "monaco-latest.osm.pbf" ]; then
+  curl --proto '=https' --tlsv1.3 -sSfO https://download.geofabrik.de/europe/monaco-latest.osm.pbf
+fi


### PR DESCRIPTION
Splitting off from #720 - this changeset adds my convenience scripts to download coastline and landcover data. It's inconvenient to go to these websites, manually find the dataset needed, download and unpack it, and so on.

Let me know what a good file structure is, where we should put them, if I should consolidate them into a single script, and so on.


Adding a section to the readme; preview:

https://github.com/daniel-j-h/tilemaker/tree/add-coastline-landcover-download?tab=readme-ov-file#coastline-and-landcover