### PR TITLE
docs: fix docker command syntax and add code formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ We provide a ready-to-use docker image that gets you started without having to c
 
 2. Run tilemaker on the OpenStreetMap snapshot to generate [Protomaps](https://protomaps.com) vector tiles:
 
-    docker run -it --rm -v (pwd):/data ghcr.io/systemed/tilemaker:master /data/monaco-latest.osm.pbf --output /data/monaco-latest.pmtiles
+```
+    docker run -it --rm -v $(pwd):/data ghcr.io/systemed/tilemaker:master /data/monaco-latest.osm.pbf --output /data/monaco-latest.pmtiles
+```
 
 3. Check out what's in the vector tiles e.g. by using the debug viewer [here](https://protomaps.github.io/PMTiles/)
 


### PR DESCRIPTION
### Description

This PR updates the README to correct the syntax for the Docker command and improves readability by formatting the command as code.

### Changes Made

- Corrected the Docker command syntax from (pwd) to $(pwd).
- Added code formatting to the Docker command for better readability.

### Motivation

Had an error running the original command due to incorrect syntax.