### PR TITLE
Default encoding UTF-8

### DIFF
--- a/src/mbtiles.cpp
+++ b/src/mbtiles.cpp
@@ -34,6 +34,11 @@ void MBTiles::openForWriting(string &filename) {
 		cout << "Couldn't write SQLite application_id (not fatal): " << e.what() << endl;
 	}
 	try {
+		db << "PRAGMA encoding = 'UTF-8';";
+	} catch(runtime_error &e) {
+		cout << "Couldn't set SQLite default encoding (not fatal): " << e.what() << endl;
+	}
+	try {
 		db << "PRAGMA journal_mode=OFF;";
 	} catch(runtime_error &e) {
 		cout << "Couldn't turn journaling off (not fatal): " << e.what() << endl;


### PR DESCRIPTION
Currently we do not specify an encoding when creating an .mbtiles file. We open the file using `sqlite3_open16` (in sqlite_modern_cpp.h) which defaults to "UTF-16 in the native byte order". The [mbtiles spec](https://github.com/mapbox/mbtiles-spec) does not specify a preferred encoding in 1.0-1.2; in 1.3 it specifies UTF-8.

This PR explicitly sets newly created mbtiles to UTF-8.