### PR TITLE
Feature/752 Add optional --quiet flag to tilemaker

### DIFF
--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -123,6 +123,9 @@ Don't forget to add `--store /path/to/your/ssd` if you don't have lots of RAM.
 Running tilemaker with the `--verbose` argument will output any issues encountered during tile
 creation.
 
+Running tilemaker with the `--quiet` argument will suppress anything written to stdout during
+tile creation. stderr is unaffected.
+
 You may see geometry errors reported by Boost::Geometry. This typically reflects an error 
 in the OSM source data (for example, a multipolygon with several inner rings but no outer ring).
 Often, if the geometry could not be written to the layer, the error will subsequently show in 

--- a/include/options_parser.h
+++ b/include/options_parser.h
@@ -42,6 +42,7 @@ namespace OptionsParser {
 
 		OsmOptions osm;
 		bool showHelp = false;
+		bool quiet = false;
 		bool verbose = false;
 		bool mergeSqlite = false;
 		OutputMode outputMode = OutputMode::File;

--- a/src/options_parser.cpp
+++ b/src/options_parser.cpp
@@ -25,6 +25,7 @@ po::options_description getParser(OptionsParser::Options& options) {
 		("merge"  ,po::bool_switch(&options.mergeSqlite),                                "merge with existing .mbtiles (overwrites otherwise)")
 		("config", po::value< string >(&options.jsonFile)->default_value("config.json"), "config JSON file")
 		("process",po::value< string >(&options.luaFile)->default_value("process.lua"),  "tag-processing Lua file")
+		("quiet",  po::bool_switch(&options.quiet),                                      "quiet, suppress standard output")
 		("verbose",po::bool_switch(&options.verbose),                                   "verbose error output")
 		("skip-integrity",po::bool_switch(&options.osm.skipIntegrity),                       "don't enforce way/node integrity")
 		("log-tile-timings", po::bool_switch(&options.logTileTimings), "log how long each tile takes");

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -95,6 +95,11 @@ int main(const int argc, const char* argv[]) {
 
 	if (options.showHelp) { OptionsParser::showHelp(); return 0; }
 
+	if (options.quiet) {
+		// Suppress anything written to std out
+		std::cout.setstate(std::ios_base::failbit);
+	}
+
 	verbose = options.verbose;
 
 	vector<string> bboxElements = parseBox(options.bbox);


### PR DESCRIPTION
See systemed/tilemaker#752

I had issues getting the VS code debugger to correctly (probably related to https://github.com/microsoft/vscode-cpptools/issues/1385. Disabling the large amount of STDOUT ouput generated when running tilemaker in debug solved the issue.

I've added an optional --quiet flag to tilemaker that defaults to false. When set to true:

```c++
if (options.quiet) {
  // Suppress anything written to std out
  std::cout.setstate(std::ios_base::failbit);
}
```

I'm not sure that this is the best/correct way to do this, but it works. I'm happy to take any advice if it should be changed.