### PR TITLE
Feature/748 Add AllKeys and AllTags Lua functions

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -142,6 +142,8 @@ To do that, you use these methods:
 
 * `Find(key)`: get the value for a tag, or the empty string if not present. For example, `Find("railway")` might return "rail" for a railway, "siding" for a siding, or "" if it isn't a railway at all.
 * `Holds(key)`: returns true if that key exists, false otherwise.
+* `AllKeys()`: returns a table (array) containing all the OSM tag keys.
+* `AllTags()`: returns a table containing all the OSM tags.
 * `Layer(layer_name, is_area)`: write this node/way to the named layer. This is how you put objects in your vector tile. is_area (true/false) specifies whether a way should be treated as an area, or just as a linestring.
 * `LayerAsCentroid(layer_name, algorithm, role, role...)`: write a single centroid point for this way to the named layer (useful for labels and POIs). Only the first argument is required. `algorithm` can be "polylabel" (default) or "centroid". The third arguments onwards specify relation roles: if you're processing a multipolygon-type relation (e.g. a boundary) and it has a "label" node member, then by adding "label" as an argument here, this will be used in preference to the calculated point.
 * `Attribute(key,value,minzoom)`: add an attribute to the most recently written layer. Argument `minzoom` is optional, use it if you do not want to write the attribute on lower zoom levels.

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -111,6 +111,12 @@ public:
 	// Get the ID of the current object
 	std::string Id() const;
 
+	// Gets a table of all the keys of the OSM tags
+	kaguya::LuaTable AllKeys(kaguya::State& luaState);
+
+	// Gets a table of all the OSM tags
+	kaguya::LuaTable AllTags(kaguya::State& luaState);
+
 	// Check if there's a value for a given key
 	bool Holds(const std::string& key) const;
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -117,7 +117,43 @@ template<>  struct kaguya::lua_type_traits<protozero::data_view> {
 	}
 };
 
+// Gets a table of all the keys of the OSM tags
+kaguya::LuaTable getAllKeys(kaguya::State& luaState, const boost::container::flat_map<std::string, std::string>* tags) {
+	kaguya::LuaTable tagsTable = luaState.newTable();
+	int index = 1; // Lua is 1-based
+	for (const auto& kv: *tags) {
+		tagsTable[index++] = kv.first;
+	}
+	return tagsTable;
+}
+
+// Gets a table of all the OSM tags
+kaguya::LuaTable getAllTags(kaguya::State& luaState, const boost::container::flat_map<std::string, std::string>* tags) {
+	kaguya::LuaTable tagsTable = luaState.newTable();
+	for (const auto& kv: *tags) {
+		tagsTable[kv.first] = kv.second;
+	}
+	return tagsTable;
+}
+
 std::string rawId() { return osmLuaProcessing->Id(); }
+kaguya::LuaTable rawAllKeys() {
+	if (osmLuaProcessing->isPostScanRelation) {
+		return osmLuaProcessing->AllKeys(*g_luaState);
+	}
+
+	auto tags = osmLuaProcessing->currentTags->exportToBoostMap();
+
+	return getAllKeys(*g_luaState, &tags);
+}kaguya::LuaTable rawAllTags() {
+	if (osmLuaProcessing->isPostScanRelation) {
+		return osmLuaProcessing->AllTags(*g_luaState);
+	}
+
+	auto tags = osmLuaProcessing->currentTags->exportToBoostMap();
+
+	return getAllTags(*g_luaState, &tags);
+}
 bool rawHolds(const KnownTagKey& key) {
 	if (osmLuaProcessing->isPostScanRelation) {
 		return osmLuaProcessing->Holds(key.stringValue);
@@ -196,6 +232,8 @@ OsmLuaProcessing::OsmLuaProcessing(
 
 	osmLuaProcessing = this;
 	luaState["Id"] = &rawId;
+	luaState["AllKeys"] = &rawAllKeys;
+	luaState["AllTags"] = &rawAllTags;
 	luaState["Holds"] = &rawHolds;
 	luaState["Find"] = &rawFind;
 	luaState["HasTags"] = &rawHasTags;
@@ -288,6 +326,18 @@ kaguya::LuaTable OsmLuaProcessing::remapAttributes(kaguya::LuaTable& in_table, c
 // Get the ID of the current object
 string OsmLuaProcessing::Id() const {
 	return to_string(originalOsmID);
+}
+
+// Gets a table of all the keys of the OSM tags
+kaguya::LuaTable OsmLuaProcessing::AllKeys(kaguya::State& luaState) {
+	// NOTE: this is only called in the PostScanRelation phase -- other phases are handled in rawAllKeys
+	return getAllKeys(luaState, currentPostScanTags);
+}
+
+// Gets a table of all the OSM tags
+kaguya::LuaTable OsmLuaProcessing::AllTags(kaguya::State& luaState) {
+	// NOTE: this is only called in the PostScanRelation phase -- other phases are handled in rawAllTags
+	return getAllTags(luaState, currentPostScanTags);
 }
 
 // Check if there's a value for a given key


### PR DESCRIPTION
See systemed/tilemaker#748

This adds two exported functions for Lua:
* AllKeys - returns an array of all the keys for the OSM tags
* AllTags - returns a table of all the OSM tags

This allows us to add all the OSM nodes that match a pattern, have a desired prefix, etc without need to know in advance the actual tags.

I have this working on my tilemake fork and it's working quite nicely. I'm not a C++ guy, but I've tried duplicating the code style.