### PR TITLE
attempt to fix workflow failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --store osm_store --verbose
 
     - name: 'Upload compiled executable'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: tilemaker-windows
         path: |
@@ -90,7 +90,7 @@ jobs:
         ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose --store /tmp/store
 
     - name: 'Upload compiled executable'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: tilemaker-${{ matrix.os }}
         path: |


### PR DESCRIPTION
GitHub has deprecated the v2 version of the upload-artifact action: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Workflows automatically fail now due to using the outdated version - hence the failures on [this documentation-only PR](https://github.com/systemed/tilemaker/pull/757)

I didn't actually read the release notes, I'm just YOLOing into v4 and hoping that works. If it still fails, I'll investigate more.