### PR TITLE
Boost 186

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         ${{ github.workspace }}\build\RelWithDebInfo\tilemaker.exe ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --store osm_store --verbose
 
     - name: 'Upload compiled executable'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: tilemaker-windows
         path: |
@@ -90,7 +90,7 @@ jobs:
         ${{ github.workspace }}/build/${{ matrix.executable }} ${{ env.AREA }}.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=${{ env.AREA }}.mbtiles --verbose --store /tmp/store
 
     - name: 'Upload compiled executable'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: tilemaker-${{ matrix.os }}
         path: |

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   config:
     description: 'A JSON file listing each layer, and the zoom levels at which to apply it'
     required: false
-    default: '/resources/config-openmaptiles.json'
+    default: 'config-openmaptiles.json'
   process:
     description: "A Lua program that looks at each node/way's tags, and places it into layers accordingly"
     required: false
-    default: '/resources/process-openmaptiles.lua'
+    default: 'process-openmaptiles.lua'
   output:
     description: 'Could be directory of tiles, or a .mbtiles files'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   config:
     description: 'A JSON file listing each layer, and the zoom levels at which to apply it'
     required: false
-    default: 'config-openmaptiles.json'
+    default: 'config.json'
   process:
     description: "A Lua program that looks at each node/way's tags, and places it into layers accordingly"
     required: false
-    default: 'process-openmaptiles.lua'
+    default: 'process.lua'
   output:
     description: 'Could be directory of tiles, or a .mbtiles files'
     required: true

--- a/include/mmap_allocator.h
+++ b/include/mmap_allocator.h
@@ -10,9 +10,6 @@ public:
 	typedef std::size_t size_type;
 
 	static void *allocate(size_type n, const void *hint = 0);
-	static void deallocate(void *p, size_type n);
-	static void destroy(void *p);
-	static void shutdown();
 	static void reportStoreSize(std::ostringstream &str);
 	static void openMmapFile(const std::string& mmapFilename);
 };
@@ -47,15 +44,15 @@ public:
 
 	void deallocate(pointer p, size_type n)
 	{
-		void_mmap_allocator::deallocate(p, n);
+		// This is a no-op. Most usage of tilemaker should never deallocate
+		// an mmap_allocator resource. On program termination, everything gets
+		// freed.
 	}
 
 	void construct(pointer p, const_reference val)
 	{
 		new((void *)p) T(val);        
 	}
-
-	void destroy(pointer p) { void_mmap_allocator::destroy(p); }
 };
 
 template<typename T1, typename T2>

--- a/src/mmap_allocator.cpp
+++ b/src/mmap_allocator.cpp
@@ -180,10 +180,6 @@ void mmap_shm::close()
 	mmap_shm_thread_region_ptr.reset();
 }
 
-bool void_mmap_allocator_shutdown = false;
-
-void void_mmap_allocator::shutdown() { void_mmap_allocator_shutdown = true; }
-
 void * void_mmap_allocator::allocate(size_type n, const void *hint)
 {
 	while(true) {
@@ -209,52 +205,6 @@ void * void_mmap_allocator::allocate(size_type n, const void *hint)
 		else
 			mmap_shm::open(n);
 	}
-}
-
-void void_mmap_allocator::deallocate(void *p, size_type n)
-{
-	destroy(p);
-}
-
-void void_mmap_allocator::destroy(void *p)
-{
-	if(void_mmap_allocator_shutdown) return;
-
-	if(mmap_shm_thread_region_ptr != nullptr) {	
-		auto &i = *mmap_shm_thread_region_ptr;
-		if(p >= (void const *)i.region.data()  && p < reinterpret_cast<void const *>(reinterpret_cast<uint8_t const *>(i.region.data()) + i.region.size())) {
-			allocator_t allocator(i.buffer.get_segment_manager());
-			return allocator.destroy(reinterpret_cast<uint8_t *>(p));
-		}
-	}
-
-	if(mmap_file_thread_ptr != nullptr) {	
-		auto &i = *mmap_file_thread_ptr;
-		if(p >= i.region.get_address()  && p < reinterpret_cast<void const *>(reinterpret_cast<uint8_t const *>(i.region.get_address()) + i.region.get_size())) {
-			allocator_t allocator(i.buffer.get_segment_manager());
-			allocator.destroy(reinterpret_cast<uint8_t *>(p));
-			return;
-		}
-	} 
-
-	std::lock_guard<std::mutex> lock(mmap_allocator_mutex);
-	for(auto &i: mmap_shm_regions) {
-		if(p >= (void const *)i->region.data()  && p < reinterpret_cast<void const *>(reinterpret_cast<uint8_t const *>(i->region.data()) + i->region.size())) {
-			std::lock_guard<std::mutex> lock(i->mutex);
-			allocator_t allocator(i->buffer.get_segment_manager());
-			allocator.destroy(reinterpret_cast<uint8_t *>(p));
-			return;
-		}
-	}
-
-	for(auto &i: mmap_dir.files) {
-		if(p >= i->region.get_address()  && p < reinterpret_cast<void const *>(reinterpret_cast<uint8_t const *>(i->region.get_address()) + i->region.get_size())) {
-			std::lock_guard<std::mutex> lock(i->mutex);
-			allocator_t allocator(i->buffer.get_segment_manager());
-			allocator.destroy(reinterpret_cast<uint8_t *>(p));
-			return;
-		}
-	} 
 }
 
 void void_mmap_allocator::reportStoreSize(std::ostringstream &str) {

--- a/src/sorted_node_store.cpp
+++ b/src/sorted_node_store.cpp
@@ -64,8 +64,6 @@ SortedNodeStore::SortedNodeStore(bool compressNodes): compressNodes(compressNode
 
 void SortedNodeStore::reopen()
 {
-	for (const auto entry: allocatedMemory)
-		void_mmap_allocator::deallocate(entry.first, entry.second);
 	allocatedMemory.clear();
 
 	totalNodes = 0;
@@ -86,9 +84,6 @@ void SortedNodeStore::reopen()
 }
 
 SortedNodeStore::~SortedNodeStore() {
-	for (const auto entry: allocatedMemory)
-		void_mmap_allocator::deallocate(entry.first, entry.second);
-
 	s(this) = ThreadStorage();
 }
 

--- a/src/sorted_way_store.cpp
+++ b/src/sorted_way_store.cpp
@@ -64,15 +64,10 @@ SortedWayStore::SortedWayStore(bool compressWays, const NodeStore& nodeStore): c
 }
 
 SortedWayStore::~SortedWayStore() {
-	for (const auto entry: allocatedMemory)
-		void_mmap_allocator::deallocate(entry.first, entry.second);
-
 	s(this) = ThreadStorage();
 }
 
 void SortedWayStore::reopen() {
-	for (const auto entry: allocatedMemory)
-		void_mmap_allocator::deallocate(entry.first, entry.second);
 	allocatedMemory.clear();
 
 	totalWays = 0;

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -596,6 +596,5 @@ int main(const int argc, const char* argv[]) {
 #endif
 
 	cout << endl << "Filled the tileset with good things at " << sharedData.outputFile << endl;
-	void_mmap_allocator::shutdown(); // this clears the mmap'ed nodes/ways/relations (quickly!)
 }
 


### PR DESCRIPTION
See issue https://github.com/systemed/tilemaker/issues/747.

The C++ powers that be have realized that something is redundant. The
Boost people have removed this redundancy, and the guidance is to use
the Other Way of Doing The Thing.

The only problem is... I don't know what the Other Way is. From
context I infer there's some static method we ought to be able to
invoke, and it's so obvious that someone who writes custom allocators
would just immediately understand what they're referring to. That's not
me, though.

But...do we even care? Can we just... not call the destroy function?

I think destroy only gets called when deallocate is called. I think we only
call deallocate in the case when a user reads multiple PBFs. I think that's
an uncommon case. I think (big grain of salt - I skimmed, and I'm out of my depth here)
that boost will free up the underlying memory if all of the objects in
a given segment are deallocated. So probably, in the multiple PBF case,
we introduce a memory leak by not calling the destroy function.

That's not great, but it's probably fine? If you're processing a bunch
of small PBFs, you'll probably still be able to do so. If you're
processing large PBFs, you'll still be saved by `--store`.

This is, obviously, an incredibly hacky fix for this issue. But I wanted
to send some PRs for other bugs, and I want to get the build to work
first. :)