### PR TITLE
Push Docker image on all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,17 +178,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: ${{ github.ref != 'refs/heads/master'}}
-        with:
-          context: .
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: ${{ github.ref == 'refs/heads/master'}}
         with:
           context: .
           push: true


### PR DESCRIPTION
Previously, we pushed a docker image only when building `master`.

Instead, also push it for all PRs.

My fig leaf motivation: this makes it easy for someone to test out a PR, as they can just update their docker command to reference `ghcr.io/systemed/tilemaker:pr-1234` or whatever.

My real motivation is selfish. In my fork of tilemaker, I occasionally have patches that don't exist in upstream. I'd like to just maintain a PR against my fork (eg, this one: https://github.com/cldellow/tilemaker/pull/4), and let GitHub build a docker image and push it to ghcr.io for use in my pipeline.