### PR TITLE
faster Intersects queries

### DIFF
--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -66,7 +66,12 @@ private:
 	std::map<uint, std::string> indexedGeometryNames;			//  | optional names for each one
 	std::map<std::string, RTree> indices;			// Spatial indices, boost::geometry::index objects for shapefile indices
 	std::mutex indexMutex;
-	std::map<std::string, std::vector<bool>> bitIndices; // A bit it set if the z14 (or base zoom) tiles at x*width + y contains a shape. This lets us quickly reject negative Intersects queryes
+	// A bit is set if the z14 (or base zoom) tiles at 2 * (x*width + y) might contain at least one shape.
+	// This is approximated by using the bounding boxes of the shapes. For large, irregular shapes, or
+	// shapes with holes, the bounding box may result in many false positives. The first time the index
+	// is consulted for a given tile, we'll do a more expensive intersects query to refine the index.
+	// This lets us quickly reject negative Intersects queryes
+	mutable std::map<std::string, std::vector<bool>> bitIndices;
 };
 
 #endif //_OSM_MEM_TILES

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -73,12 +73,16 @@ private:
 	// bitset index, the increase in memory is not as significant.
 	unsigned int spatialIndexZoom;
 
-	// A bit is set if the z14 (or base zoom) tiles at 2 * (x*width + y) might contain at least one shape.
+	// The map is from layer name to a sparse vector of tiles that might have shapes.
+	//
+	// The outer vector has an entry for each z6 tile. The inner vector is a bitset,
+	// indexed at spatialIndexZoom, where a bit is set if the z14 (or base zoom) tiles at
+	// 2 * (x*width + y) might contain at least one shape.
 	// This is approximated by using the bounding boxes of the shapes. For large, irregular shapes, or
 	// shapes with holes, the bounding box may result in many false positives. The first time the index
 	// is consulted for a given tile, we'll do a more expensive intersects query to refine the index.
 	// This lets us quickly reject negative Intersects queryes
-	mutable std::map<std::string, std::vector<bool>> bitIndices;
+	mutable std::map<std::string, std::vector<std::vector<bool>>> bitIndices;
 };
 
 #endif //_OSM_MEM_TILES

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -76,7 +76,7 @@ private:
 	// The map is from layer name to a sparse vector of tiles that might have shapes.
 	//
 	// The outer vector has an entry for each z6 tile. The inner vector is a bitset,
-	// indexed at spatialIndexZoom, where a bit is set if the z14 (or base zoom) tiles at
+	// indexed at spatialIndexZoom, where a bit is set if the z15 tiles at
 	// 2 * (x*width + y) might contain at least one shape.
 	// This is approximated by using the bounding boxes of the shapes. For large, irregular shapes, or
 	// shapes with holes, the bounding box may result in many false positives. The first time the index

--- a/include/shp_mem_tiles.h
+++ b/include/shp_mem_tiles.h
@@ -66,6 +66,13 @@ private:
 	std::map<uint, std::string> indexedGeometryNames;			//  | optional names for each one
 	std::map<std::string, RTree> indices;			// Spatial indices, boost::geometry::index objects for shapefile indices
 	std::mutex indexMutex;
+
+
+	// This differs from indexZoom. indexZoom is clamped to z14, as there is a noticeable
+	// step function increase in memory use to go to higher zooms. For the
+	// bitset index, the increase in memory is not as significant.
+	unsigned int spatialIndexZoom;
+
 	// A bit is set if the z14 (or base zoom) tiles at 2 * (x*width + y) might contain at least one shape.
 	// This is approximated by using the bounding boxes of the shapes. For large, irregular shapes, or
 	// shapes with holes, the bounding box may result in many false positives. The first time the index

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -355,9 +355,8 @@ double OsmLuaProcessing::AreaIntersecting(const string &layerName) {
 template <typename GeometryT>
 std::vector<uint> OsmLuaProcessing::intersectsQuery(const string &layerName, bool once, GeometryT &geom) const {
 	Box box; geom::envelope(geom, box);
-	if (!shpMemTiles.mayIntersect(layerName, box)) {
+	if (!shpMemTiles.mayIntersect(layerName, box))
 		return std::vector<uint>();
-	}
 
 	std::vector<uint> ids = shpMemTiles.QueryMatchingGeometries(layerName, once, box,
 		[&](const RTree &rtree) { // indexQuery

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -19,9 +19,6 @@ thread_local OsmLuaProcessing* osmLuaProcessing = nullptr;
 
 std::mutex vectorLayerMetadataMutex;
 
-std::atomic<uint64_t> bitmapLookups;
-std::atomic<uint64_t> bitmapHits;
-
 void handleOsmLuaProcessingUserSignal(int signum) {
 	osmLuaProcessing->handleUserSignal(signum);
 }
@@ -358,13 +355,7 @@ double OsmLuaProcessing::AreaIntersecting(const string &layerName) {
 template <typename GeometryT>
 std::vector<uint> OsmLuaProcessing::intersectsQuery(const string &layerName, bool once, GeometryT &geom) const {
 	Box box; geom::envelope(geom, box);
-	bitmapLookups++;
-
-	if (bitmapLookups.load() % 10000 == 0) {
-		std::cout << "lookup: " << std::to_string(bitmapHits) << " saved calls of " << std::to_string(bitmapLookups) << " lookups" << std::endl;
-	}
 	if (!shpMemTiles.mayIntersect(layerName, box)) {
-		bitmapHits++;
 		return std::vector<uint>();
 	}
 

--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -209,7 +209,6 @@ void ShpMemTiles::StoreGeometry(
 	uint32_t y1 = latp2tiley(latp1, spatialIndexZoom);
 	uint32_t y2 = latp2tiley(latp2, spatialIndexZoom);
 
-	uint32_t hits = 0;
 	for (int x = std::min(x1, x2); x <= std::min((1u << spatialIndexZoom) - 1u, std::max(x1, x2)); x++) {
 		for (int y = std::min(y1, y2); y <= std::min((1u << spatialIndexZoom) - 1u, std::max(y1, y2)); y++) {
 			uint32_t z6x = x / (1u << (spatialIndexZoom - CLUSTER_ZOOM));
@@ -223,9 +222,6 @@ void ShpMemTiles::StoreGeometry(
 
 			uint32_t divisor = 1u << (spatialIndexZoom - CLUSTER_ZOOM);
 			uint64_t index = 2u * ((x - z6x * divisor) * divisor + (y - z6y * divisor));
-			if (!bitvec[index]) {
-				hits++;
-			}
 			bitvec[index] = true;
 		}
 	}


### PR DESCRIPTION
This improves on previous work to short-circuit `Intersects` queries in the negative case, so as to avoid the expensive call into Boost's R-Tree. (Introduced in wildly-fast-and-wildly-broken form in PR #635, then fixed in #641.)

For one of my use cases, this decreases the build time from 7m47s to 1m30s, while also decreasing memory use.

There are 3 main changes:

1. The old code was very naive. When loading shapes from a shapefile or GeoJSON file, it used a bounding box on the shape, and marked every z14 tile contained therein as possibly containing an intersecting shape.

The bounding box approach is a good approximation for many shapes but breaks down for large, irregular shapes that span many z14 tiles, like https://www.openstreetmap.org/relation/9848163#map=12/39.9616/-105.2197

Instead, we now use 2 bits for each z14 tile. The first bit indicates whether the tile might contain an intersecting shape. The second bit indicates whether it definitely contains an intersecting shape. The second bit is lazily initialized with the more expensive intersects query only when that tile is queried.

This provides a big speedup, but at the cost of 2x the memory usage.

2. Previously, the old code indexed at `indexZoom`, which is clamped to 14. The code now uses `spatialIndexZoom`, which is set to 15. `indexZoom` controls other indexes as well, where the marginal decrease in runtime doesn't scale 1:1 with increased memory usage. For this index, though, it seems like the extra 2x memory cost is repaid with a 50% decrease in runtime, which seems worth it.

3. To mitigate the 4x memory increase (from 32MB to 128MB per indexed layer), the index is now sparse. We previously tracked a bitset for the entire globe. Now, we track the index as a set of bitsets, one for each z6 tile. If no z15 tiles in a given z6 tile need to be indexed, we don't allocate a bitset. If you're doing a small geographical extract, you'll benefit from this. Even if you're doing the globe, you'll probably benefit, since your shapefiles probably don't cover the oceans and Antarctica.

This gives up a bit of the runtime benefit, but decreases the memory usage.

Some future improvements (not urgent, just capturing them before I forget):

1. Reduce memory: instead of allocating 2 bits per z15 tile, we could do 1 bit per z15 tile to track intersections, and, say, 1 bit per z13 tile to track whether we've done the lazy initialization. Then lazily init all the z15 tiles in the containing z13 tile on first access.

2. With some bookkeeping, I think we could speed up the special case where there's a positive match of exactly 1 shape, if that 1 shape spans the entire z15 tile. This definitely occurs often for my use case of national parks - probably it occurs for other use cases like political boundaries.

3. AreaIntersecting and CoveredBy could re-use these indexes to speed up their negative cases. And if (2) is done, they could re-use that work to speed up the positive case in the special case. I don't use these yet, but I might start soon.