### PR TITLE
docker: luarocks, luaflock, lua-sql-sqlite3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libboost-program-options-dev \
     libboost-filesystem-dev \
     libboost-system-dev \
+    luarocks \
     rapidjson-dev \
     cmake && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    luarocks install luaflock
 
 WORKDIR /usr/src/app
 
@@ -35,6 +37,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     liblua5.1-0 \
     shapelib \
     libsqlite3-0 \
+    lua-sql-sqlite3 \
     libboost-filesystem1.74.0 \
     libboost-program-options1.74.0 && \
     rm -rf /var/lib/apt/lists/*
@@ -42,6 +45,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 WORKDIR /usr/src/app
 COPY --from=src /usr/src/app/build/tilemaker .
 COPY --from=src /usr/src/app/build/tilemaker-server .
+COPY --from=src /usr/local/lib/lua/5.1/flock.so /usr/local/lib/lua/5.1/flock.so
 COPY resources ./resources
 COPY process.lua ./
 COPY config.json ./

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -199,7 +199,8 @@ bool supportsRemappingShapefiles = false;
 
 int lua_error_handler(int errCode, const char *errMessage)
 {
-	std::cerr << "lua runtime error: " << std::endl;
+	std::cerr << "lua runtime error " << std::to_string(errCode) << ":" << std::endl;
+	std::cerr << errMessage << std::endl;
 	kaguya::util::traceBack(g_luaState->state(), errMessage); // full traceback on 5.2+
 	kaguya::util::stackDump(g_luaState->state());
 	throw OsmLuaProcessing::luaProcessingException();


### PR DESCRIPTION
This updates the Docker container to have some useful packages that a user might want available to their Lua scripts:

- `luaflock`: BSD-style flock
- `lua-sql-sqlite3`: SQLite bindings for Lua

It also updates tilemaker's Lua error handler to print the lua error code and error message string.

It seems like not all Lua errors have stack traces/tracebacks -- for example, requiring a non-existent module:

before this change:

```
lua runtime error:
terminate called after throwing an instance of 'OsmLuaProcessing::luaProcessingException'
  what():  std::exception
```

after this change:

```
lua runtime error 2:
./file_append.lua:7: module 'flock' not found:
	no field package.preload['flock']
	no file './flock.lua'
	no file '/usr/local/share/lua/5.1/flock.lua'
	no file '/usr/local/share/lua/5.1/flock/init.lua'
	no file '/usr/local/lib/lua/5.1/flock.lua'
	no file '/usr/local/lib/lua/5.1/flock/init.lua'
	no file '/usr/share/lua/5.1/flock.lua'
	no file '/usr/share/lua/5.1/flock/init.lua'
	no file './flock.so'
	no file '/usr/local/lib/lua/5.1/flock.so'
	no file '/usr/lib/x86_64-linux-gnu/lua/5.1/flock.so'
	no file '/usr/lib/lua/5.1/flock.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
terminate called after throwing an instance of 'OsmLuaProcessing::luaProcessingException'
  what():  std::exception
```

A drawback of this is that the case where there _was_ already a useful error message is now quite spammy, e.g.:

```
lua runtime error 2:
/home/cldellow/src/basemap/export/city-parks.lua:27: attempt to perform arithmetic on global 'w' (a nil value)
table  `/home/cldellow/src/basemap/export/city-parks.lua:27: attempt to perform arithmetic on global 'w' (a nil value)'  `/home/cldellow/src/basemap/export/city-parks.lua:27: attempt to perform arithmetic on global 'w' (a nil value)'  
Lua error on node 21760675
```

...that's kind of unfortunate, but for me, is still a good tradeoff vs having nothing in some cases.