### PR TITLE
be less chatty when run non-interactively

### DIFF
--- a/include/helpers.h
+++ b/include/helpers.h
@@ -6,6 +6,12 @@
 #include <sstream>
 #include <vector>
 
+#ifdef _MSVC_LANG
+#define ISATTY true
+#else
+#define ISATTY isatty(1)
+#endif
+
 // General helper routines
 
 inline void endian_swap(unsigned int& x) {

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -69,7 +69,7 @@ template<typename OO> void finalizeObjects(
 	int i = -1;
 	for (auto it = begin; it != end; it++) {
 		i++;
-		if (it->size() > 0 || i % 10 == 0 || i == 4095) {
+		if (it->size() > 0 || i % 50 == 0 || i == 4095) {
 			std::cout << "\r" << name << ": finalizing z6 tile " << (i + 1) << "/" << CLUSTER_ZOOM_AREA;
 
 #ifdef CLOCK_MONOTONIC

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -345,7 +345,7 @@ int main(const int argc, const char* argv[]) {
 	std::mutex io_mutex;
 
 	// Loop through tiles
-	std::atomic<uint64_t> tilesWritten(0);
+	std::atomic<uint64_t> tilesWritten(0), lastTilesWritten(0);
 
 	for (auto source : sources) {
 		source->finalize(options.threadNum);
@@ -518,7 +518,7 @@ int main(const int argc, const char* argv[]) {
 			batchSize++;
 		}
 
-		boost::asio::post(pool, [=, &tileCoordinates, &pool, &sharedData, &sources, &attributeStore, &io_mutex, &tilesWritten]() {
+		boost::asio::post(pool, [=, &tileCoordinates, &pool, &sharedData, &sources, &attributeStore, &io_mutex, &tilesWritten, &lastTilesWritten]() {
 			std::vector<std::string> tileTimings;
 			std::size_t endIndex = std::min(tileCoordinates.size(), startIndex + batchSize);
 			for(std::size_t i = startIndex; i < endIndex; ++i) {
@@ -557,16 +557,21 @@ int main(const int argc, const char* argv[]) {
 			tilesWritten += (endIndex - startIndex); 
 
 			if (io_mutex.try_lock()) {
-				// Show progress grouped by z6 (or lower)
-				size_t z = tileCoordinates[startIndex].first;
-				size_t x = tileCoordinates[startIndex].second.x;
-				size_t y = tileCoordinates[startIndex].second.y;
-				if (z > CLUSTER_ZOOM) {
-					x = x / (1 << (z - CLUSTER_ZOOM));
-					y = y / (1 << (z - CLUSTER_ZOOM));
-					z = CLUSTER_ZOOM;
+				uint64_t written = tilesWritten.load();
+
+				if (written >= lastTilesWritten + tileCoordinates.size() / 100 || ISATTY) {
+					lastTilesWritten = written;
+					// Show progress grouped by z6 (or lower)
+					size_t z = tileCoordinates[startIndex].first;
+					size_t x = tileCoordinates[startIndex].second.x;
+					size_t y = tileCoordinates[startIndex].second.y;
+					if (z > CLUSTER_ZOOM) {
+						x = x / (1 << (z - CLUSTER_ZOOM));
+						y = y / (1 << (z - CLUSTER_ZOOM));
+						z = CLUSTER_ZOOM;
+					}
+					cout << "z" << z << "/" << x << "/" << y << ", writing tile " << written << " of " << tileCoordinates.size() << "               \r" << std::flush;
 				}
-				cout << "z" << z << "/" << x << "/" << y << ", writing tile " << tilesWritten.load() << " of " << tileCoordinates.size() << "               \r" << std::flush;
 				io_mutex.unlock();
 			}
 		});


### PR DESCRIPTION
This introduces a minimum threshold for writing the progress updates like:

- Scanning for nodes in ways
- Block M/N
- Writing tile M of N

The threshold only applies when run non-interactively, for example, when in a GitHub action. It shoots for one line of output for every 1% of progress. I was motivated to do this because processing North America in an action generated > 500 MB of logs and seemed to cause GitHub to kill the action.

Interactive use should be unaffected. Windows is always treated as interactive, as I'm not sure how to test for that.