### PR TITLE
Add per-layer ability to disable multipoints

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -82,6 +82,7 @@ You can add optional parameters to layers:
 * `feature_limit` - restrict the number of features written to each tile
 * `feature_limit_below` - restrict only below this zoom level
 * `combine_polygons_below` - merge adjacent polygons with the same attributes below this zoom level
+* `combine_points` - merge points with the same attributes (defaults to `true`: specify `false` to disable)
 * `z_order_ascending` - sort features in ascending order by a numeric value set in the Lua processing script (defaults to `true`: specify `false` for descending order)
 
 `write_to` enables you to combine different layer specs within one outputted layer. For example:

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -29,6 +29,7 @@ struct LayerDef {
 	bool sortZOrderAscending;
 	uint featureLimit;
 	uint featureLimitBelow;
+	bool combinePoints;
 	std::string source;
 	std::vector<std::string> sourceColumns;
 	bool allSourceColumns;
@@ -54,7 +55,7 @@ public:
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,
 			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
 			uint filterBelow, double filterArea, uint combinePolygonsBelow, bool sortZOrderAscending,
-			uint featureLimit, uint featureLimitBelow,
+			uint featureLimit, uint featureLimitBelow, bool combinePoints,
 			const std::string &source,
 			const std::vector<std::string> &sourceColumns,
 			bool allSourceColumns,

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -137,7 +137,7 @@ void SharedData::writePMTilesBounds() {
 uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, 
 		uint filterBelow, double filterArea, uint combinePolygonsBelow, bool sortZOrderAscending,
-		uint featureLimit, uint featureLimitBelow,
+		uint featureLimit, uint featureLimitBelow, bool combinePoints,
 		const std::string &source,
 		const std::vector<std::string> &sourceColumns,
 		bool allSourceColumns,
@@ -147,7 +147,7 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 
 	bool isWriteTo = !writeTo.empty();
 	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
-		filterBelow, filterArea, combinePolygonsBelow, sortZOrderAscending, featureLimit, featureLimitBelow,
+		filterBelow, filterArea, combinePolygonsBelow, sortZOrderAscending, featureLimit, featureLimitBelow, combinePoints,
 		source, sourceColumns, allSourceColumns, indexed, indexName,
 		std::map<std::string,uint>(), isWriteTo };
 	layers.push_back(layer);
@@ -317,6 +317,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		int    combinePolyBelow=it->value.HasMember("combine_polygons_below") ? it->value["combine_polygons_below"].GetInt() : 0;
 		int    featureLimit   = it->value.HasMember("feature_limit"  ) ? it->value["feature_limit"  ].GetInt()    : 0;
 		int  featureLimitBelow= it->value.HasMember("feature_limit_below") ? it->value["feature_limit_below"].GetInt() : (maxZoom+1);
+		bool combinePoints    = it->value.HasMember("combine_points" ) ? it->value["combine_points" ].GetBool()   : true;
 		bool sortZOrderAscending = it->value.HasMember("z_order_ascending") ? it->value["z_order_ascending"].GetBool() : (featureLimit==0);
 		string source = it->value.HasMember("source") ? it->value["source"].GetString() : "";
 		vector<string> sourceColumns;
@@ -337,7 +338,7 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 
 		layers.addLayer(layerName, minZoom, maxZoom,
 				simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, 
-				filterBelow, filterArea, combinePolyBelow, sortZOrderAscending, featureLimit, featureLimitBelow,
+				filterBelow, filterArea, combinePolyBelow, sortZOrderAscending, featureLimit, featureLimitBelow, combinePoints,
 				source, sourceColumns, allSourceColumns, indexed, indexName,
 				writeTo);
 

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -266,6 +266,7 @@ void ProcessObjects(
 	double simplifyLevel,
 	double filterArea,
 	bool combinePolygons,
+	bool combinePoints,
 	unsigned zoom,
 	const TileBbox &bbox,
 	vtzero::layer_builder& vtLayer
@@ -285,7 +286,7 @@ void ProcessObjects(
 			pair<int,int> xy = bbox.scaleLatpLon(pos.latp/10000000.0, pos.lon/10000000.0);
 			multipoint.push_back(xy);
 
-			while (jt<(ooSameLayerEnd-1) && oo.oo.compatible((jt+1)->oo)) {
+			while (jt<(ooSameLayerEnd-1) && oo.oo.compatible((jt+1)->oo) && combinePoints) {
 				jt++;
 				LatpLon pos = source->buildNodeGeometry(jt->oo.objectID, bbox);
 				pair<int,int> xy = bbox.scaleLatpLon(pos.latp/10000000.0, pos.lon/10000000.0);
@@ -300,7 +301,7 @@ void ProcessObjects(
 			if (verbose && multipoint.size() > 1)
 				std::cout << "Merging " << multipoint.size() << " points into a multipoint" << std::endl;
 
-			for (const auto point : multipoint)
+			for (const auto &point : multipoint)
 				fbuilder.set_point(point.first, point.second);
 
 			oo.oo.writeAttributes(attributeStore, fbuilder, zoom);
@@ -435,7 +436,7 @@ void ProcessLayer(
 			if (ld.featureLimit>0 && end-ooListSameLayer.first>ld.featureLimit && zoom<ld.featureLimitBelow) end = ooListSameLayer.first+ld.featureLimit;
 			ProcessObjects(sources[i], attributeStore, 
 				ooListSameLayer.first, end, sharedData, 
-				simplifyLevel, filterArea, zoom < ld.combinePolygonsBelow, zoom, bbox, vtLayer);
+				simplifyLevel, filterArea, zoom < ld.combinePolygonsBelow, ld.combinePoints, zoom, bbox, vtLayer);
 		}
 	}
 	if (verbose && std::time(0)-start>3) {


### PR DESCRIPTION
In #725 we added automatic combining of point geometries to create multipoints. 99% of the time this is what you want and it makes tiles smaller.

But the 1% of cases is where you're doing something interactive and you actually want a point geometry back - e.g. when you're using `queryRenderedFeatures` (or the Native equivalent) to find the exact point that the user has clicked.

This PR adds the ability to disable multipoint combining per-layer by setting `"combine_points": false`. Default behaviour is unchanged.