### PR TITLE
feat: add standard attribution to config-openmaptiles

### DIFF
--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -41,6 +41,9 @@
 		"version": "3.0",
 		"description": "Tile config based on OpenMapTiles schema",
 		"compress": "gzip",
+		"metadata": {
+			"attribution": "<a href=\"https://www.openmaptiles.org/\" target=\"_blank\">&copy; OpenMapTiles</a> <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>"
+		},
 		"filemetadata": {
 			"tilejson": "2.0.0", 
 			"scheme": "xyz", 


### PR DESCRIPTION
As discussed here https://github.com/systemed/tilemaker/issues/781

Changing metadata.attribution is indeed sufficient. I generated a small mbtiles using this config and loaded the mbtiles file in a small tileserver, attribution was properly displayed by maplibre.