### PR TITLE
pmtiles: always set leafStart when closing file [#794]

### DIFF
--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -28,6 +28,7 @@ void PMTiles::close(std::string &metadata) {
 	// add all tiles to directories, writing leaf directories as we go
 	std::vector<pmtiles::entryv3> rootEntries;
 	std::vector<pmtiles::entryv3> entries;
+	leafStart = outputStream.tellp();
 	if (isSparse) {
 		for (auto it : sparseIndex) {
 			appendTileEntry(it.first, it.second, rootEntries, entries);
@@ -120,7 +121,6 @@ void PMTiles::flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vect
 	// write the leaf directory to disk
 	std::lock_guard<std::mutex> lock(fileMutex);
 	uint64_t location = outputStream.tellp();
-	if (leafStart==0) leafStart=location;
 	uint64_t length = compressed.size();
 	outputStream << compressed;
 


### PR DESCRIPTION
* the `leafStart` was only assigned in flushEntries, which never happens if there is only a root directory.
* resulted in erroneous leafDirectoryOffset and tileDataLength in the pmtiles header.

Detect with `pmtiles verify`:

```
pmtiles verify main.pmtiles
2025/01/30 15:11:57 main.go:223: Failed to verify archive, Leaf directories offset=0 must not be 0
exit status 1
```

Fixes #794 