### PR TITLE
Fix _minzoom handling in attribute_function

### DIFF
--- a/include/shp_processor.h
+++ b/include/shp_processor.h
@@ -45,7 +45,7 @@ private:
 
 	// Process an individual shapefile record
 	void processShapeGeometry(SHPObject* shape, AttributeIndex attrIdx, 
-	                          const LayerDef &layer, uint layerNum, bool hasName, const std::string &name);
+	                          const LayerDef &layer, uint layerNum, bool hasName, const std::string &name, const uint minzoom);
 };
 
 #endif //_SHP_PROCESSOR_H

--- a/src/shp_processor.cpp
+++ b/src/shp_processor.cpp
@@ -166,9 +166,10 @@ void ShpProcessor::read(class LayerDef &layer, uint layerNum)
 				std::lock_guard<std::mutex> lock(attributeMutex);
 				name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;
 			}
-			AttributeIndex attrIdx = readShapefileAttributes(dbf, i, columnMap, columnTypeMap, layer, layer.minzoom);
+			uint minzoom = layer.minzoom;
+			AttributeIndex attrIdx = readShapefileAttributes(dbf, i, columnMap, columnTypeMap, layer, minzoom);
 			// process geometry
-			processShapeGeometry(shape, attrIdx, layer, layerNum, hasName, name);
+			processShapeGeometry(shape, attrIdx, layer, layerNum, hasName, name, minzoom);
 			SHPDestroyObject(shape);
 		});
 	}
@@ -178,9 +179,8 @@ void ShpProcessor::read(class LayerDef &layer, uint layerNum)
 }
 
 void ShpProcessor::processShapeGeometry(SHPObject* shape, AttributeIndex attrIdx,
-                                        const LayerDef &layer, uint layerNum, bool hasName, const string &name) {
+                                        const LayerDef &layer, uint layerNum, bool hasName, const string &name, const uint minzoom) {
 	int shapeType = shape->nSHPType;	// 1=point, 3=polyline, 5=(multi)polygon [8=multipoint, 11+=3D]
-	int minzoom = layer.minzoom;
 
 	if (shapeType==1 || shapeType==11 || shapeType==21) {
 		// Points


### PR DESCRIPTION
Setting _minzoom was being overwritten while processing each feature. It needs to be persisted per feature and per layer. This way it's possible to easily add filtering logic based on zoom in the attribute_function.

Fixes https://github.com/systemed/tilemaker/issues/774