### PR TITLE
IsMultiPolygon Lua method

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -151,6 +151,8 @@ To do that, you use these methods:
 * `Attribute(key,value,minzoom)`: add an attribute to the most recently written layer. Argument `minzoom` is optional, use it if you do not want to write the attribute on lower zoom levels.
 * `AttributeNumeric(key,value,minzoom)`, `AttributeBoolean(key,value,minzoom)`: for numeric/boolean columns.
 * `Id()`: get the OSM ID of the current object.
+* `IsClosed()`: returns true if the current object is a closed area.
+* `IsMultiPolygon()`: returns true if the current object is a multipolygon.
 * `ZOrder(number)`: Set a numeric value (default 0) used to sort features within a layer. Use this feature to ensure a proper rendering order if the rendering engine itself does not support sorting. Sorting is not supported across layers merged with `write_to`. Features with different z-order are not merged if `combine_below` or `combine_polygons_below` is used. Use this in conjunction with `feature_limit` to only write the most important (highest z-order) features within a tile. (Values can be -50,000,000 to 50,000,000 and are lossy, particularly beyond -1000 to 1000.)
 * `MinZoom(zoom)`: set the minimum zoom level (0-15) at which this object will be written. Note that the JSON layer configuration minimum still applies (so `:MinZoom(5)` will have no effect if your layer only starts at z6).
 * `Length()` and `Area()`: return the length (metres)/area (square metres) of the current object. Requires Boost 1.67+.

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -143,6 +143,7 @@ public:
 		
 	// Returns whether it is closed polygon
 	bool IsClosed() const;
+	bool IsMultiPolygon() const;
 
 	// Returns area
 	double Area();

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -181,6 +181,7 @@ bool rawIntersects(const std::string& layerName) { return osmLuaProcessing->Inte
 std::vector<std::string> rawFindCovering(const std::string& layerName) { return osmLuaProcessing->FindCovering(layerName); }
 bool rawCoveredBy(const std::string& layerName) { return osmLuaProcessing->CoveredBy(layerName); }
 bool rawIsClosed() { return osmLuaProcessing->IsClosed(); }
+bool rawIsMultiPolygon() { return osmLuaProcessing->IsMultiPolygon(); }
 double rawArea() { return osmLuaProcessing->Area(); }
 double rawLength() { return osmLuaProcessing->Length(); }
 kaguya::optional<std::vector<double>> rawCentroid(kaguya::VariadicArgType algorithm) { return osmLuaProcessing->Centroid(algorithm); }
@@ -246,6 +247,7 @@ OsmLuaProcessing::OsmLuaProcessing(
 	luaState["FindCovering"] = &rawFindCovering;
 	luaState["CoveredBy"] = &rawCoveredBy;
 	luaState["IsClosed"] = &rawIsClosed;
+	luaState["IsMultiPolygon"] = &rawIsMultiPolygon;
 	luaState["Area"] = &rawArea;
 	luaState["AreaIntersecting"] = &rawAreaIntersecting;
 	luaState["Length"] = &rawLength;
@@ -473,6 +475,11 @@ std::vector<uint> OsmLuaProcessing::coveredQuery(const string &layerName, bool o
 bool OsmLuaProcessing::IsClosed() const {
 	if (!isWay) return false; // nonsense: it isn't a way
 	return isClosed;
+}
+
+// Return whether it's a multipolygon
+bool OsmLuaProcessing::IsMultiPolygon() const {
+	return isWay && isRelation;
 }
 
 void reverse_project(DegPoint& p) {


### PR DESCRIPTION
A simple Lua call to return whether the current OSM object is a multipolygon or not. Handy when processing pedestrian highway areas which might be missing the traditional `area=yes`.