### PR TITLE
feat: optionally find population from relations

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -147,8 +147,17 @@ function node_function()
 	--   we could potentially approximate it for cities based on the population tag
 	local place = Find("place")
 	if place ~= "" then
+		local population = Find("population")
+		while population == "" do
+			local rel, role = NextRelation()
+			if not rel then break end
+			if role == 'label' then
+				population = FindInRelation("population")
+			end
+		end
+
 		local mz = 13
-		local pop = tonumber(Find("population")) or 0
+		local pop = tonumber(population) or 0
 		local capital = capitalLevel(Find("capital"))
 		local rank = calcRank(place, pop, capital)
 


### PR DESCRIPTION
This PR aims to improve the way the `population` attribute is fetched for places. If it can't find a population on the place itself, it will attempt to read the relations until it finds a label that does contain a population.

I noticed that some city centers in my area of Germany did not contain the population on the city center node, but on the administrative boundary. While I added the population to the labels on the ones I saw missing, I figure it might be a common issue, so the processing script should optionally handle it as well.

Example:
Boundary: https://www.openstreetmap.org/relation/454863#map=13/50.56452/9.64956
Node (prior to me adding the population): https://www.openstreetmap.org/node/240088844/history/59