### PR TITLE
Fix filter_area when used with combine_polygons_below

### DIFF
--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -329,11 +329,6 @@ void ProcessObjects(
 				continue;
 			}
 
-			if (oo.oo.geomType == POLYGON_ && filterArea > 0.0) {
-				RemovePartsBelowSize(boost::get<MultiPolygon>(g), filterArea);
-				if (geom::is_empty(g)) continue;
-			}
-
 			//This may increment the jt iterator
 			if (oo.oo.geomType == LINESTRING_ && zoom < sharedData.config.combineBelow) {
 				// Append successive linestrings, then reorder afterwards
@@ -359,6 +354,11 @@ void ProcessObjects(
 					union_many(mps); g = mps.front();
 				}
 				oo = *jt;
+			}
+
+			if (oo.oo.geomType == POLYGON_ && filterArea > 0.0) {
+				RemovePartsBelowSize(boost::get<MultiPolygon>(g), filterArea);
+				if (geom::is_empty(g)) return;
 			}
 
 			if (oo.oo.geomType == LINESTRING_ || oo.oo.geomType == MULTILINESTRING_)


### PR DESCRIPTION
Currently we run area filtering on the first polygon we have generated, but not on any successive polygons that we merge in. That's clearly an error.

This PR moves the filtering after the polygons have been generated and merged. The upshot is that you can filter out garden sheds while rows of narrow terraced houses are still retained.