### PR TITLE
feat: write attribution in pmtiles metadata

### DIFF
--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -111,7 +111,7 @@ public:
 	void writeMBTilesProjectData();
 	void writeMBTilesMetadata(rapidjson::Document const &jsonConfig);
 	void writeFileMetadata(rapidjson::Document const &jsonConfig);	
-	std::string pmTilesMetadata();
+	std::string pmTilesMetadata(rapidjson::Document const &jsonConfig);
 	void writePMTilesBounds();
 };
 

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -104,13 +104,16 @@ void SharedData::writeFileMetadata(rapidjson::Document const &jsonConfig) {
 }
 
 // Create JSON string with .pmtiles-format metadata
-std::string SharedData::pmTilesMetadata() {
+std::string SharedData::pmTilesMetadata(rapidjson::Document const &jsonConfig) {
 	rapidjson::Document document;
 	document.SetObject();
 	document.AddMember("name",          rapidjson::Value().SetString(config.projectName.c_str(), document.GetAllocator()), document.GetAllocator());
 	document.AddMember("description",   rapidjson::Value().SetString(config.projectDesc.c_str(), document.GetAllocator()), document.GetAllocator());
 	document.AddMember("vector_layers", layers.serialiseToJSONValue(document.GetAllocator()), document.GetAllocator());
-	// we don't currently write "attribution" or "type" fields, see .pmtiles spec
+	if (jsonConfig["settings"].HasMember("metadata") && jsonConfig["settings"]["metadata"].HasMember("attribution")) {
+		document.AddMember("attribution", rapidjson::Value().SetString(jsonConfig["settings"]["metadata"]["attribution"].GetString(), document.GetAllocator()), document.GetAllocator());
+	}
+	// we don't currently write "type" field, see .pmtiles spec
 	rapidjson::StringBuffer buffer;
 	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 	document.Accept(writer);

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -591,7 +591,7 @@ int main(const int argc, const char* argv[]) {
 		sharedData.mbtiles.closeForWriting();
 	} else if (options.outputMode == OptionsParser::OutputMode::PMTiles) {
 		sharedData.writePMTilesBounds();
-		std::string metadata = sharedData.pmTilesMetadata();
+		std::string metadata = sharedData.pmTilesMetadata(jsonConfig);
 		sharedData.pmtiles.close(metadata);
 	} else {
 		sharedData.writeFileMetadata(jsonConfig);


### PR DESCRIPTION
This patch includes the attribution in the PMTiles metadata if it exists in config.json.
This should allow #782 to function with PMTiles, too, not just MBTiles.