### PR TITLE
not using visvalingam breaks earcut in maplibre.

### DIFF
--- a/resources/config-openmaptiles.json
+++ b/resources/config-openmaptiles.json
@@ -1,14 +1,14 @@
 {
 	"layers": {
 		"place":            { "minzoom":  0, "maxzoom": 14 },
-		"boundary":         { "minzoom":  0, "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003, "simplify_ratio": 2, "simplify_algorithm": "visvalingam" },
+		"boundary":         { "minzoom":  0, "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003, "simplify_algorithm": "visvalingam" },
 
 		"poi":              { "minzoom": 12, "maxzoom": 14 },
 		"poi_detail":       { "minzoom": 14, "maxzoom": 14, "write_to": "poi" },
 
 		"housenumber":      { "minzoom": 14, "maxzoom": 14 },
 
-		"waterway":         { "minzoom":  8,  "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003, "simplify_ratio": 2 },
+		"waterway":         { "minzoom":  8,  "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003 },
 		"waterway_detail":  { "minzoom": 12,  "maxzoom": 14, "write_to": "waterway" },
 
 		"transportation":             { "minzoom": 4,  "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003 },
@@ -16,17 +16,17 @@
 
 		"building":          { "minzoom": 13, "maxzoom": 14 },
 
-		"water":             { "minzoom": 6,  "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003, "simplify_ratio": 2, "simplify_algorithm": "visvalingam" },
-		"ocean":             { "minzoom": 0,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "filter_below": 12, "filter_area": 0.5, "simplify_below": 13, "simplify_level": 0.0001, "simplify_ratio": 2, "simplify_algorithm": "visvalingam", "write_to": "water" },
+		"water":             { "minzoom": 6,  "maxzoom": 14, "simplify_below": 12, "simplify_level": 0.0003, "simplify_algorithm": "visvalingam" },
+		"ocean":             { "minzoom": 0,  "maxzoom": 14, "source": "coastline/water_polygons.shp", "filter_below": 12, "filter_area": 0.5, "simplify_below": 13, "simplify_level": 0.0001, "simplify_algorithm": "visvalingam", "write_to": "water" },
 		"water_name":        { "minzoom": 14, "maxzoom": 14 },
 		"water_name_detail": { "minzoom": 14, "maxzoom": 14, "write_to": "water_name" },
 
 		"aeroway":           { "minzoom": 11, "maxzoom": 14 },
 		"aerodrome_label":   { "minzoom": 10, "maxzoom": 14 },
 		"park":              { "minzoom": 11, "maxzoom": 14 },
-		"landuse":           { "minzoom":  4, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "simplify_ratio": 2, "simplify_algorithm": "visvalingam" },
-		"urban_areas":       { "minzoom":  4, "maxzoom":  8, "source": "landcover/ne_10m_urban_areas/ne_10m_urban_areas.shp", "source_columns": ["featurecla"], "simplify_below": 7, "simplify_level": 0.0003, "simplify_ratio": 2, "simplify_algorithm": "visvalingam", "write_to": "landuse" },
-		"landcover":         { "minzoom":  0, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "simplify_ratio": 2, "simplify_algorithm": "visvalingam" },
+		"landuse":           { "minzoom":  4, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "simplify_algorithm": "visvalingam" },
+		"urban_areas":       { "minzoom":  4, "maxzoom":  8, "source": "landcover/ne_10m_urban_areas/ne_10m_urban_areas.shp", "source_columns": ["featurecla"], "simplify_below": 7, "simplify_level": 0.0003, "simplify_algorithm": "visvalingam", "write_to": "landuse" },
+		"landcover":         { "minzoom":  0, "maxzoom": 14, "simplify_below": 13, "simplify_level": 0.0003, "simplify_algorithm": "visvalingam" },
 		"ice_shelf":         { "minzoom":  0, "maxzoom":  9, "source": "landcover/ne_10m_antarctic_ice_shelves_polys/ne_10m_antarctic_ice_shelves_polys.shp", "source_columns": ["featurecla"], "simplify_below": 13, "simplify_level": 0.0005, "simplify_algorithm": "visvalingam", "write_to": "landcover" },
 		"glacier":           { "minzoom":  2, "maxzoom":  9, "source": "landcover/ne_10m_glaciated_areas/ne_10m_glaciated_areas.shp", "source_columns": ["featurecla"], "simplify_below": 13, "simplify_level": 0.0005, "simplify_algorithm": "visvalingam", "write_to": "landcover" },
 		"mountain_peak":     { "minzoom": 11, "maxzoom": 14 }


### PR DESCRIPTION
earcut gets into some crazy situations if you don't use visvalingam to simplify polygons:

lakes in the United States cause earcut in maplibre to run especially long (100 times normal).