### PR TITLE
document `include_ids` and `compress` in configuration readme

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -32,7 +32,7 @@ It also includes these global settings:
 * `maxzoom` - the maximum zoom level at which any tiles will be generated
 * `basezoom` - the zoom level for which tilemaker will generate tiles internally (should usually be the same as `maxzoom`)
 * `include_ids` - whether you want to store the OpenStreetMap IDs for each way/node within your vector tiles. This option is not compatible with the merging options defined by the `combine_xxx` settings (see the dedicated paragraph below)
-* `compress` - whether to compress vector tiles (Any of "gzip","deflate" or "none"(default))
+* `compress` - for mbtiles output, whether to compress vector tiles (Any of "gzip","deflate" or "none"(default)). For pmtiles output, compression is hardcoded to gzip
 * `combine_below` - whether to merge adjacent linestrings of the same type: will be done at zoom levels below that specified here (e.g. `"combine_below": 14` to merge at z1-13)
 * `name`, `version` and `description` - about your project (these are written into the MBTiles file)
 * `high_resolution` (optional) - whether to use extra coordinate precision at the maximum zoom level (makes tiles a bit bigger)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,7 +31,7 @@ It also includes these global settings:
 * `minzoom` - the minimum zoom level at which any tiles will be generated
 * `maxzoom` - the maximum zoom level at which any tiles will be generated
 * `basezoom` - the zoom level for which tilemaker will generate tiles internally (should usually be the same as `maxzoom`)
-* `include_ids` - whether you want to store the OpenStreetMap IDs for each way/node within your vector tiles
+* `include_ids` - whether you want to store the OpenStreetMap IDs for each way/node within your vector tiles. This option is not compatible with the merging options defined by the `combine_xxx` settings (see the dedicated paragraph below)
 * `compress` - whether to compress vector tiles (Any of "gzip","deflate" or "none"(default))
 * `combine_below` - whether to merge adjacent linestrings of the same type: will be done at zoom levels below that specified here (e.g. `"combine_below": 14` to merge at z1-13)
 * `name`, `version` and `description` - about your project (these are written into the MBTiles file)
@@ -115,7 +115,16 @@ For example:
         }
       }
     }
-	
+
+### Including IDs
+
+Be careful when using both the `include_ids: true` setting to include IDs and the `combine_xxx` settings to lighten tiles : they are not compatible. During the merging process, items with identical tags are combined in a collection, with only 1 ID being retained for all the merged items. If you need to have the exact ID for each item (for example, for a clickable map), you need to remove the merging settings in the target levels and layers:
+
+* set `combine_points: false` (`true` is the default value) in the target layers
+* set `combine_below` and `combine_polygons_below` below the target zoom level (or remove them)
+
+If you need the include OSM types as well, you will need to modify the `process.lua` script, check issue [#740](https://github.com/systemed/tilemaker/issues/740) for more information.
+
 ## Lua processing reference
 
 Your Lua file can supply these functions for tilemaker to call:


### PR DESCRIPTION
Following #830, I propose this very simple PR to document in CONFIGURATION.md the incompatibility between `include_ids` and `combine_xxx` settings. (I don't think I'll be able to dive into the code to generate a warning when both options are used)