### PR TITLE
create function to get OSM type

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -151,6 +151,7 @@ To do that, you use these methods:
 * `Attribute(key,value,minzoom)`: add an attribute to the most recently written layer. Argument `minzoom` is optional, use it if you do not want to write the attribute on lower zoom levels.
 * `AttributeNumeric(key,value,minzoom)`, `AttributeBoolean(key,value,minzoom)`: for numeric/boolean columns.
 * `Id()`: get the OSM ID of the current object.
+* `OsmType()`: get the OSM type of the current object.
 * `IsClosed()`: returns true if the current object is a closed area.
 * `IsMultiPolygon()`: returns true if the current object is a multipolygon.
 * `ZOrder(number)`: Set a numeric value (default 0) used to sort features within a layer. Use this feature to ensure a proper rendering order if the rendering engine itself does not support sorting. Sorting is not supported across layers merged with `write_to`. Features with different z-order are not merged if `combine_below` or `combine_polygons_below` is used. Use this in conjunction with `feature_limit` to only write the most important (highest z-order) features within a tile. (Values can be -50,000,000 to 50,000,000 and are lossy, particularly beyond -1000 to 1000.)

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -115,6 +115,9 @@ public:
 	// Get the ID of the current object
 	std::string Id() const;
 
+	// Get the Type of the current object
+	std::string OsmType() const;
+
 	// Gets a table of all the keys of the OSM tags
 	kaguya::LuaTable AllKeys(kaguya::State& luaState);
 

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -141,6 +141,7 @@ kaguya::LuaTable getAllTags(kaguya::State& luaState, const boost::container::fla
 }
 
 std::string rawId() { return osmLuaProcessing->Id(); }
+std::string rawOsmType() { return osmLuaProcessing->OsmType(); }
 kaguya::LuaTable rawAllKeys() {
 	if (osmLuaProcessing->isPostScanRelation) {
 		return osmLuaProcessing->AllKeys(*g_luaState);
@@ -247,6 +248,7 @@ OsmLuaProcessing::OsmLuaProcessing(
 
 	osmLuaProcessing = this;
 	luaState["Id"] = &rawId;
+	luaState["OsmType"] = &rawOsmType;
 	luaState["AllKeys"] = &rawAllKeys;
 	luaState["AllTags"] = &rawAllTags;
 	luaState["Holds"] = &rawHolds;
@@ -354,6 +356,11 @@ kaguya::LuaTable OsmLuaProcessing::remapAttributes(kaguya::LuaTable& in_table, c
 // Get the ID of the current object
 string OsmLuaProcessing::Id() const {
 	return to_string(originalOsmID);
+}
+
+// Get the Type of the current object
+string OsmLuaProcessing::OsmType() const {
+	return (isRelation ? "relation " : isWay ? "way " : "node ");
 }
 
 // Gets a table of all the keys of the OSM tags


### PR DESCRIPTION
### Context
Following #740 we use `Attribute("obj_type","way")` in process.lua `way_function` to include this information in cartes.app tiles. But it is not working well for ways that come from a relation, we have to check the tags, it is not a direct information.

### Solution
I wrote this PR to create a function `OsmType()` which returns the true OSM type of the object, on the same model than the existing `Id()` function.

### Example
Using this in process.lua:
```
Attribute("OsmId", Id())
Attribute("OsmType", OsmType())
```
I can directly get tiles with the correct type information
<img width="212" height="236" alt="image" src="https://github.com/user-attachments/assets/075f76a7-d1e3-40cd-884b-c5761ae212b3" />
