### PR TITLE
Allow `combine_below` on each layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Bug reports, suggestions and (especially!) pull requests are very welcome on the
 
 Formatting: braces and indents as shown, hard tabs (4sp). (Yes, I know.) Please be conservative about adding dependencies or increasing the memory requirement.
 
+To safely rebuild the project after making changes to the code, you need to run :
+
+    make clean
+    make
+    sudo make install
+
 ## Copyright
 
 tilemaker is maintained by Richard Fairhurst and supported by [many contributors](https://github.com/systemed/tilemaker/graphs/contributors). We particularly celebrate the invaluable contributions of Wouter van Kleunen, who passed away in 2022.

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -26,11 +26,12 @@ struct LayerDef {
 	uint simplifyAlgo;
 	uint filterBelow;
 	double filterArea;
-	uint combinePolygonsBelow;
 	bool sortZOrderAscending;
 	uint featureLimit;
 	uint featureLimitBelow;
 	bool combinePoints;
+	uint combineLinesBelow;
+	uint combinePolygonsBelow;
 	std::string source;
 	std::vector<std::string> sourceColumns;
 	bool allSourceColumns;
@@ -58,8 +59,8 @@ public:
 	// Define a layer (as read from the .json file)
 	uint addLayer(std::string name, uint minzoom, uint maxzoom,
 			uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, uint simplifyAlgo,
-			uint filterBelow, double filterArea, uint combinePolygonsBelow, bool sortZOrderAscending,
-			uint featureLimit, uint featureLimitBelow, bool combinePoints,
+			uint filterBelow, double filterArea, bool sortZOrderAscending,
+			uint featureLimit, uint featureLimitBelow, bool combinePoints, uint combineLinesBelow, uint combinePolygonsBelow,
 			const std::string &source,
 			const std::vector<std::string> &sourceColumns,
 			bool allSourceColumns,

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -139,8 +139,8 @@ void SharedData::writePMTilesBounds() {
 // Define a layer (as read from the .json file)
 uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 		uint simplifyBelow, double simplifyLevel, double simplifyLength, double simplifyRatio, uint simplifyAlgo,
-		uint filterBelow, double filterArea, uint combinePolygonsBelow, bool sortZOrderAscending,
-		uint featureLimit, uint featureLimitBelow, bool combinePoints,
+		uint filterBelow, double filterArea, bool sortZOrderAscending,
+		uint featureLimit, uint featureLimitBelow, bool combinePoints, uint combineLinesBelow, uint combinePolygonsBelow,
 		const std::string &source,
 		const std::vector<std::string> &sourceColumns,
 		bool allSourceColumns,
@@ -150,7 +150,7 @@ uint LayerDefinition::addLayer(string name, uint minzoom, uint maxzoom,
 
 	bool isWriteTo = !writeTo.empty();
 	LayerDef layer = { name, minzoom, maxzoom, simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, simplifyAlgo,
-		filterBelow, filterArea, combinePolygonsBelow, sortZOrderAscending, featureLimit, featureLimitBelow, combinePoints,
+		filterBelow, filterArea, sortZOrderAscending, featureLimit, featureLimitBelow, combinePoints, combineLinesBelow, combinePolygonsBelow,
 		source, sourceColumns, allSourceColumns, indexed, indexName,
 		std::map<std::string,uint>(), isWriteTo };
 	layers.push_back(layer);
@@ -317,10 +317,11 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		double simplifyRatio  = it->value.HasMember("simplify_ratio" ) ? it->value["simplify_ratio" ].GetDouble() : 2.0;
 		int    filterBelow    = it->value.HasMember("filter_below"   ) ? it->value["filter_below"   ].GetInt()    : 0;
 		double filterArea     = it->value.HasMember("filter_area"    ) ? it->value["filter_area"    ].GetDouble() : 0.5;
-		int    combinePolyBelow=it->value.HasMember("combine_polygons_below") ? it->value["combine_polygons_below"].GetInt() : 0;
 		int    featureLimit   = it->value.HasMember("feature_limit"  ) ? it->value["feature_limit"  ].GetInt()    : 0;
 		int  featureLimitBelow= it->value.HasMember("feature_limit_below") ? it->value["feature_limit_below"].GetInt() : (maxZoom+1);
 		bool combinePoints    = it->value.HasMember("combine_points" ) ? it->value["combine_points" ].GetBool()   : true;
+		int combineLinesBelow = it->value.HasMember("combine_lines_below"  ) ? it->value["combine_lines_below"  ].GetInt()    : combineBelow;
+		int    combinePolyBelow=it->value.HasMember("combine_polygons_below") ? it->value["combine_polygons_below"].GetInt() : 0;
 		bool sortZOrderAscending = it->value.HasMember("z_order_ascending") ? it->value["z_order_ascending"].GetBool() : (featureLimit==0);
 		string algo           = it->value.HasMember("simplify_algorithm") ? it->value["simplify_algorithm"].GetString() : "";
 		uint simplifyAlgo = algo=="visvalingam" ? LayerDef::VISVALINGAM : LayerDef::DOUGLAS_PEUCKER;
@@ -343,11 +344,14 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 
 		layers.addLayer(layerName, minZoom, maxZoom,
 				simplifyBelow, simplifyLevel, simplifyLength, simplifyRatio, simplifyAlgo,
-				filterBelow, filterArea, combinePolyBelow, sortZOrderAscending, featureLimit, featureLimitBelow, combinePoints,
+				filterBelow, filterArea, sortZOrderAscending, featureLimit, featureLimitBelow, combinePoints, combineLinesBelow, combinePolyBelow,
 				source, sourceColumns, allSourceColumns, indexed, indexName,
 				writeTo);
 
 		cout << "Layer " << layerName << " (z" << minZoom << "-" << maxZoom << ")";
+		cout << " - combine points: " << combinePoints;
+		cout << " - combine lines below " << combineLinesBelow;
+		cout << " - combine polygons below " << combinePolyBelow;
 		if (it->value.HasMember("write_to")) { cout << " -> " << it->value["write_to"].GetString(); }
 		cout << endl;
 	}

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -277,13 +277,13 @@ void ProcessObjects(
 	double simplifyLevel,
 	unsigned simplifyAlgo,
 	double filterArea,
-	bool combinePolygons,
 	bool combinePoints,
+	bool combineLines,
+	bool combinePolygons,
 	unsigned zoom,
 	const TileBbox &bbox,
 	vtzero::layer_builder& vtLayer
 ) {
-
 	for (auto jt = ooSameLayerBegin; jt != ooSameLayerEnd; ++jt) {
 		OutputObjectID oo = *jt;
 		if (zoom < oo.oo.minZoom) { continue; }
@@ -330,7 +330,7 @@ void ProcessObjects(
 			}
 
 			//This may increment the jt iterator
-			if (oo.oo.geomType == LINESTRING_ && zoom < sharedData.config.combineBelow) {
+			if (oo.oo.geomType == LINESTRING_ && combineLines) {
 				// Append successive linestrings, then reorder afterwards
 				while (jt<(ooSameLayerEnd-1) && oo.oo.compatible((jt+1)->oo)) {
 					jt++;
@@ -440,7 +440,6 @@ void ProcessLayer(
 		if (zoom < ld.filterBelow) { 
 			filterArea = meter2degp(ld.filterArea, latp) * pow(2.0, (ld.filterBelow-1) - zoom);
 		}
-
 		for (size_t i=0; i<sources.size(); i++) {
 			// Loop through output objects
 			auto ooListSameLayer = getObjectsAtSubLayer(data[i], layerNum);
@@ -449,7 +448,7 @@ void ProcessLayer(
 			ProcessObjects(sources[i], attributeStore, 
 				ooListSameLayer.first, end, sharedData, 
 				simplifyLevel, ld.simplifyAlgo,
-				filterArea, zoom < ld.combinePolygonsBelow, ld.combinePoints, zoom, bbox, vtLayer);
+				filterArea, ld.combinePoints, zoom < ld.combineLinesBelow, zoom < ld.combinePolygonsBelow, zoom, bbox, vtLayer);
 		}
 	}
 	if (verbose && std::time(0)-start>3) {


### PR DESCRIPTION
### Context
The fact that `combine_below` is defined in the `settings` part of `config.json` is not very flexible, and not consistent with `combine_points` and `combine_polygons_below` properties, defined in each layer.

### Solution
Following #837 I tried to copy the logic of `combinePoints` and `combinePolygonsBelow` layer properties to create a new property `combineLinesBelow` that will store the value read in each layer definition in `config.json`.

But it is not working 😥​

`tile_worker.cpp` is able to read the old `ld.combinePolygonsBelow` property but is not able to read the new `ld.combineLinesBelow` property. `shared_data.cpp` and `shared_data.h` seems fine to me, I just copied the logic of `combinePolygonsBelow`, I really can't see what I've missed. `ProcessObjects()` works fine if I force a value for its new boolean property `combineLines`, but in `ProcessLayer()` the new Layer property `ld.combineLinesBelow` value is always 0.

Could you help me correct this? Thanks!