### PR TITLE
fix area test for platforms in OMT process

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -381,7 +381,6 @@ function way_function()
 	local housenumber = Find("addr:housenumber")
 	local write_name = false
 	local construction = Find("construction")
-	local is_highway_area = highway~="" and Find("area")=="yes" and is_closed
 
 	-- Miscellaneous preprocessing
 	if Find("disused") == "yes" then return end
@@ -458,6 +457,7 @@ function way_function()
 	if highway ~= "" or public_transport == "platform" then
 		local access = Find("access")
 		local surface = Find("surface")
+		local is_area = (public_transport == "platform" or Find("area")=="yes") and is_closed
 
 		local h = highway
 		local is_road = true
@@ -511,13 +511,13 @@ function way_function()
 		end
 
 		-- Drop all areas except infrastructure for pedestrians handled above
-		if is_highway_area and h ~= "path" then
+		if is_area and h ~= "path" then
 			minzoom = INVALID_ZOOM
 		end
 
 		-- Write to layer
 		if minzoom <= 14 then
-			write_to_transportation_layer(minzoom, h, subclass, ramp, service, false, is_road, is_highway_area)
+			write_to_transportation_layer(minzoom, h, subclass, ramp, service, false, is_road, is_area)
 
 			-- Write names
 			if not is_closed and (HasNames() or Holds("ref")) then


### PR DESCRIPTION
A cartes.app user [noticed ](https://codeberg.org/cartes/web/issues/1190) that `public_transport=platform` were never considered as areas.
I checked `process_openmaptiles.lua` and indeed noticed an inconsistency between:
`local is_highway_area = highway~="" and Find("area")=="yes" and is_closed`, only for `highway`
and
`if highway ~= "" or public_transport == "platform" then`, also for `public_transport`

I modified the first in `local is_area = (public_transport == "platform" or Find("area")=="yes") and is_closed` since `area=yes` [is not required](https://wiki.openstreetmap.org/wiki/Talk:Tag:public_transport%3Dplatform#Assume_that_closed_way_is_always_an_area) on `public_transport=platform`

This modification has been validated in https://codeberg.org/cartes/serveur/pulls/86