### PR TITLE
handle numeric values of layer and level tags with math.floor before AttributeInteger

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -314,7 +314,8 @@ function write_to_transportation_layer(minzoom, highway_class, subclass, ramp, s
 	if subclass and subclass ~= "" then
 		Attribute("subclass", subclass)
 	end
-	AttributeInteger("layer", tonumber(Find("layer")) or 0, accessMinzoom)
+	local layer = tonumber(Find("layer")) or 0
+	AttributeInteger("layer", math.floor(layer), accessMinzoom)
 	SetBrunnelAttributes()
 	-- We do not write any other attributes for areas.
 	if is_area then
@@ -755,13 +756,14 @@ function WritePOI(class,subclass,rank)
 	Attribute("class", class)
 	Attribute("subclass", subclass)
 	-- layer defaults to 0
-	AttributeInteger("layer", tonumber(Find("layer")) or 0)
+	local layer = tonumber(Find("layer")) or 0
+	AttributeInteger("layer", math.floor(layer))
 	-- indoor defaults to false
 	AttributeBoolean("indoor", (Find("indoor") == "yes"))
 	-- level has no default
 	local level = tonumber(Find("level"))
 	if level then
-		AttributeInteger("level", level)
+		AttributeInteger("level", math.floor(level))
 	end
 end
 


### PR DESCRIPTION
While calculating tiles for cartes.app, @laem and I noticed that numeric but non integer `layer` or `level` values make the calculation to crash, for example with this message :

```
Block 549/3727 lua runtime error 2:
maybe...Argument mismatch:string,number	 candidate is:
		std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,int,
		std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,int,char,

stack traceback:
	[C]: in function 'AttributeInteger'
	./resources/process-openmaptiles.lua:764: in function 'WritePOI'
	./resources/process-openmaptiles.lua:199: in function 'node_function'
table  `maybe...Argument mismatch:string,number	 candidate is:
		std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,int,
		std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,int,char,

stack traceback:
	[C]: in function 'AttributeInteger'
	./resources/process-openmaptiles.lua:764: in function 'WritePOI'
	./resources/process-openmaptiles.lua:199: in function 'node_function''  `maybe...Argument mismatch:string,number	 candidate is:
		std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,int,
		std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >,int,char,

stack traceback:
	[C]: in function 'AttributeInteger'
	./resources/process-openmaptiles.lua:764: in function 'WritePOI'
	./resources/process-openmaptiles.lua:199: in function 'node_function'
stack traceback:'  
Lua error on node 676795020
Block 552/3727 Erreur de segmentation (core dumped)
```

It happens for example on these elements:
- https://www.openstreetmap.org/node/676795020 with `level=-0.3`
- https://www.openstreetmap.org/way/8351694 with `layer=0.5`

This PR fixes this bug using `math.floor` which is not perfect, but I did not find a `round` function in Lua ?