### PR TITLE
On Ubuntu and Debian, suggest using lua 5.3 rather than 5.1

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,7 +17,7 @@ Then:
 
 Start with:
 
-    sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-system-dev lua5.1 liblua5.1-0-dev libshp-dev libsqlite3-dev rapidjson-dev
+    sudo apt install build-essential libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-system-dev lua5.3 liblua5.3-dev libshp-dev libsqlite3-dev rapidjson-dev
 
 Once you've installed those, then `cd` back to your Tilemaker directory and simply:
 


### PR DESCRIPTION
lua 5.3 should be available for any recent Ubuntu or Debian. Reasons for preferring 5.3 over 5.1 include the availability of UTF8 libraries.  If 5.1 is explicitly installed alongside 5.3 it's possible to end up with different versions with different shared library locations, which can confuse.