### PR TITLE
Write PMTiles archives in binary mode

### DIFF
--- a/src/pmtiles.cpp
+++ b/src/pmtiles.cpp
@@ -15,7 +15,7 @@ PMTiles::~PMTiles() { }
 
 void PMTiles::open(std::string &filename) {
 	std::cout << "Creating pmtiles at " << filename << std::endl;
-	outputStream.open(filename);
+	outputStream.open(filename, std::ios::out | std::ios::trunc | std::ios::binary);
 	// dummy header/root directory for now - we'll write it all later
 	char header[HEADER_ROOT] = "PMTiles";
 	outputStream.write(header, HEADER_ROOT);
@@ -122,7 +122,7 @@ void PMTiles::flushEntries(std::vector<pmtiles::entryv3> &rootEntries, std::vect
 	std::lock_guard<std::mutex> lock(fileMutex);
 	uint64_t location = outputStream.tellp();
 	uint64_t length = compressed.size();
-	outputStream << compressed;
+	outputStream.write(compressed.c_str(), compressed.size());
 
 	// append reference to the root directory
 	pmtiles::entryv3 rootEntry = pmtiles::entryv3(startId, location-leafStart, length, 0);
@@ -150,7 +150,7 @@ void PMTiles::saveTile(int zoom, int x, int y, std::string &data) {
 		std::lock_guard<std::mutex> lock(fileMutex);
 		// write to file
 		offset = TileOffset(static_cast<uint64_t>(outputStream.tellp()) - HEADER_ROOT, compressed.size());
-		outputStream << compressed;
+		outputStream.write(compressed.c_str(), compressed.size());
 		numTilesWritten++;
 		isNew = true;
 	}


### PR DESCRIPTION
This PR is AI generated.

## Write PMTiles archives in binary mode

PMTiles archives contain compressed binary tile, directory, and metadata
payloads. On Windows, an `std::ofstream` opened in text mode can translate
newline bytes while writing. When that happens, the bytes written to disk no
longer match the offsets and lengths tilemaker has already recorded in the
PMTiles header.

Open the PMTiles output stream with `std::ios::binary` and use explicit
`write()` calls for compressed string payloads. This keeps the on-disk byte
count aligned with the PMTiles header and matches how the existing code already
writes other binary data.

The change is intentionally small: it only touches PMTiles file writes in
`src/pmtiles.cpp`.

## Reproduce

On Windows, build tilemaker from current `master`, then generate a PMTiles
archive:

```
tilemaker liechtenstein.osm.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=liechtenstein.pmtiles --verbose
```

Verify the archive:

```
pmtiles verify liechtenstein.pmtiles
```

Before this change, Windows-generated PMTiles archives can fail verification
with a header length mismatch:

```
Failed to verify archive, total length of archive ... does not match header ...
```

After this change, the same Windows PMTiles outputs verify successfully.

## Testing

- `git diff --check`
- `cmake -S . -B build-pmtiles-binary-mode -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build-pmtiles-binary-mode --target tilemaker -j2`
- `./build-pmtiles-binary-mode/tilemaker test/monaco.pbf --config=resources/config-openmaptiles.json --process=resources/process-openmaptiles.lua --output=/tmp/tilemaker-pmtiles-binary-mode.pmtiles --verbose`
- `pmtiles verify /tmp/tilemaker-pmtiles-binary-mode.pmtiles`

A stacked fork CI run also verified the Windows PMTiles outputs successfully
with `pmtiles verify`. The overall run still failed because the new generated
tile verifier detected existing semantic differences between repeated tile
generation runs; that is separate from this PMTiles archive-structure fix.

## Related Issues And PRs

I did not find an open upstream issue, PR, or discussion that directly reports
this Windows text-mode PMTiles archive corruption.

Related PMTiles context:

- #794 / #795 fixed root-directory-only PMTiles header offsets. This change is
  separate because it prevents Windows text-mode byte translation from changing
  payload lengths after offsets have been calculated.
- #653 discusses PMTiles root/leaf directory size and clustering. This change
  does not address clustering or directory layout.
- Discussion #833 notes that PMTiles compression is currently hardcoded to
  gzip. This change does not alter compression behavior.
