### PR TITLE
Make POI tag ranking deterministic and rank-aware

### DIFF
--- a/resources/process-debug.lua
+++ b/resources/process-debug.lua
@@ -503,6 +503,7 @@ end
 -- returns rank, class, subclass
 function GetPOIRank(obj)
 	local k,list,v,class,rank
+	local bestRank,bestClass,bestSubclass
 
 	-- Can we find the tag?
 	for _,k in ipairs(poiTagKeys) do
@@ -511,9 +512,12 @@ function GetPOIRank(obj)
 			v = Find(k)	-- k/v are the OSM tag pair
 			class = poiClasses[v] or v
 			rank  = poiClassRanks[class] or 25
-			return rank, class, v
+			if not bestRank or rank<bestRank then
+				bestRank,bestClass,bestSubclass = rank,class,v
+			end
 		end
 	end
+	if bestRank then return bestRank,bestClass,bestSubclass end
 
 	-- Catch-all for shops
 	local shop = Find("shop")

--- a/resources/process-debug.lua
+++ b/resources/process-debug.lua
@@ -155,6 +155,7 @@ poiTags         = { aerialway = Set { "station" },
 					sport = Set { "american_football", "archery", "athletics", "australian_football", "badminton", "baseball", "basketball", "beachvolleyball", "billiards", "bmx", "boules", "bowls", "boxing", "canadian_football", "canoe", "chess", "climbing", "climbing_adventure", "cricket", "cricket_nets", "croquet", "curling", "cycling", "disc_golf", "diving", "dog_racing", "equestrian", "fatsal", "field_hockey", "free_flying", "gaelic_games", "golf", "gymnastics", "handball", "hockey", "horse_racing", "horseshoes", "ice_hockey", "ice_stock", "judo", "karting", "korfball", "long_jump", "model_aerodrome", "motocross", "motor", "multi", "netball", "orienteering", "paddle_tennis", "paintball", "paragliding", "pelota", "racquet", "rc_car", "rowing", "rugby", "rugby_league", "rugby_union", "running", "sailing", "scuba_diving", "shooting", "shooting_range", "skateboard", "skating", "skiing", "soccer", "surfing", "swimming", "table_soccer", "table_tennis", "team_handball", "tennis", "toboggan", "volleyball", "water_ski", "yoga" },
 					tourism = Set { "alpine_hut", "aquarium", "artwork", "attraction", "bed_and_breakfast", "camp_site", "caravan_site", "chalet", "gallery", "guest_house", "hostel", "hotel", "information", "motel", "museum", "picnic_site", "theme_park", "viewpoint", "zoo" },
 					waterway = Set { "dock" } }
+poiTagKeys      = { "aerialway", "amenity", "barrier", "building", "highway", "historic", "landuse", "leisure", "railway", "shop", "sport", "tourism", "waterway" }
 
 -- POI "class" values: based on https://github.com/openmaptiles/openmaptiles/blob/master/layers/poi/poi.yaml
 poiClasses      = { townhall="town_hall", public_building="town_hall", courthouse="town_hall", community_centre="town_hall",
@@ -504,7 +505,8 @@ function GetPOIRank(obj)
 	local k,list,v,class,rank
 
 	-- Can we find the tag?
-	for k,list in pairs(poiTags) do
+	for _,k in ipairs(poiTagKeys) do
+		list = poiTags[k]
 		if list[Find(k)] then
 			v = Find(k)	-- k/v are the OSM tag pair
 			class = poiClasses[v] or v
@@ -535,4 +537,3 @@ function split(inputstr, sep) -- https://stackoverflow.com/a/7615129/4288232
 	end
 	return t
 end
-

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -844,6 +844,7 @@ end
 -- returns rank, class, subclass
 function GetPOIRank()
 	local k,list,v,class,rank,subclassKey
+	local bestRank,bestClass,bestSubclass
 
 	-- Can we find the tag?
 	for _,k in ipairs(poiTagKeys) do
@@ -857,9 +858,12 @@ function GetPOIRank()
 				class = v
 				v = Find(subclassKey)
 			end
-			return rank, class, v
+			if not bestRank or rank<bestRank then
+				bestRank,bestClass,bestSubclass = rank,class,v
+			end
 		end
 	end
+	if bestRank then return bestRank,bestClass,bestSubclass end
 
 	-- Catch-all for shops
 	local shop = Find("shop")

--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -258,6 +258,7 @@ poiTags         = { aerialway = Set { "station" },
 					sport = Set { "american_football", "archery", "athletics", "australian_football", "badminton", "baseball", "basketball", "beachvolleyball", "billiards", "bmx", "boules", "bowls", "boxing", "canadian_football", "canoe", "chess", "climbing", "climbing_adventure", "cricket", "cricket_nets", "croquet", "curling", "cycling", "disc_golf", "diving", "dog_racing", "equestrian", "fatsal", "field_hockey", "free_flying", "gaelic_games", "golf", "gymnastics", "handball", "hockey", "horse_racing", "horseshoes", "ice_hockey", "ice_stock", "judo", "karting", "korfball", "long_jump", "model_aerodrome", "motocross", "motor", "multi", "netball", "orienteering", "paddle_tennis", "paintball", "paragliding", "pelota", "racquet", "rc_car", "rowing", "rugby", "rugby_league", "rugby_union", "running", "sailing", "scuba_diving", "shooting", "shooting_range", "skateboard", "skating", "skiing", "soccer", "surfing", "swimming", "table_soccer", "table_tennis", "team_handball", "tennis", "toboggan", "volleyball", "water_ski", "yoga" },
 					tourism = Set { "alpine_hut", "aquarium", "artwork", "attraction", "bed_and_breakfast", "camp_site", "caravan_site", "chalet", "gallery", "guest_house", "hostel", "hotel", "information", "motel", "museum", "picnic_site", "theme_park", "viewpoint", "zoo" },
 					waterway = Set { "dock" } }
+poiTagKeys      = { "aerialway", "amenity", "barrier", "building", "highway", "historic", "landuse", "leisure", "railway", "shop", "sport", "tourism", "waterway" }
 
 -- POI "class" values: based on https://github.com/openmaptiles/openmaptiles/blob/master/layers/poi/poi.yaml
 poiClasses      = { townhall="town_hall", public_building="town_hall", courthouse="town_hall", community_centre="town_hall",
@@ -842,10 +843,11 @@ end
 -- Calculate POIs (typically rank 1-4 go to 'poi' z12-14, rank 5+ to 'poi_detail' z14)
 -- returns rank, class, subclass
 function GetPOIRank()
-	local k,list,v,class,rank
+	local k,list,v,class,rank,subclassKey
 
 	-- Can we find the tag?
-	for k,list in pairs(poiTags) do
+	for _,k in ipairs(poiTagKeys) do
+		list = poiTags[k]
 		if list[Find(k)] then
 			v = Find(k)	-- k/v are the OSM tag pair
 			class = poiClasses[v] or k


### PR DESCRIPTION
This PR is AI generated.

## Make POI tag ranking deterministic and rank-aware

`GetPOIRank()` returns the first matching POI tag group. It currently iterates
`poiTags` with `pairs()`, but Lua does not specify table traversal order for
non-array tables. That means an object with more than one matching POI tag can
receive different `class`, `subclass`, and rank values depending on Lua table
iteration order.

OpenMapTiles ranks POIs by class priority in ascending order:

- `layers/poi/class.sql` defines `poi_class_rank(class)`
- `layers/poi/poi.sql` orders POIs with `poi_class_rank(...) ASC`

Tilemaker's OpenMapTiles profile mirrors that priority with `poiClassRanks`.
Use an explicit `poiTagKeys` array and iterate it with `ipairs()`, but do not
stop at the first matching key. Instead, evaluate all explicit matching POI tag
groups and return the candidate with the lowest numeric `poiClassRanks` value.
The explicit key order remains the deterministic tie-break for equal ranks.
OpenMapTiles does not define a secondary equal-rank ordering in `layer_poi()`,
so this tie-break is tilemaker's deterministic profile order rather than a
claim about SQL result order.

Apply the same change to both OpenMapTiles profiles,
`process-openmaptiles.lua` and `process-debug.lua`.

## Examples

An object with both of these tags has two valid POI matches:

```text
amenity=school
tourism=attraction
```

Before this change, whichever key `pairs(poiTags)` returned first determined
the output. The object could be classified from either matching tag group.

After this change, both candidates are evaluated and the OpenMapTiles-style
rank priority is used:

```text
4:attraction:attraction
```

That matches the profile rank table because `attraction` has a higher priority
than `school`.

For the sports pitch case from the visual evidence:

```text
leisure=pitch
sport=soccer
```

The previous deterministic-only version consistently selected the first
profile key:

```text
25:pitch:soccer
```

This version selects the better-ranked class:

```text
8:stadium:soccer
```

For equal ranks, the explicit key order is still used as the tie-break. For
example:

```text
leisure=sports_centre
sport=tennis
```

returns the first equal-rank candidate in `process-openmaptiles.lua`:

```text
25:leisure:sports_centre
```

## Reproduce

Load the OpenMapTiles process file and evaluate POIs that have multiple
matching tag groups:

```sh
lua - <<'LUA'
dofile('resources/process-openmaptiles.lua')
local cases = {
  { name='school_attraction', tags={ amenity='school', tourism='attraction' } },
  { name='pitch_soccer', tags={ leisure='pitch', sport='soccer' } },
  { name='sports_centre_tennis_tie', tags={ leisure='sports_centre', sport='tennis' } },
}
for _,case in ipairs(cases) do
  function Find(k) return case.tags[k] or '' end
  local rank, class, subclass = GetPOIRank()
  print(case.name .. ' ' .. rank .. ':' .. class .. ':' .. subclass)
end
LUA
```

Expected output:

```text
school_attraction 4:attraction:attraction
pitch_soccer 8:stadium:soccer
sports_centre_tennis_tie 25:leisure:sports_centre
```

The same ranking issue and fix apply to `resources/process-debug.lua`.

## Testing

- `git diff --check origin/master..HEAD`
- `luac -p resources/process-openmaptiles.lua resources/process-debug.lua`
- Focused Lua checks for `GetPOIRank()` in both process files:
  - `amenity=school` + `tourism=attraction`
  - `leisure=pitch` + `sport=soccer`
  - `leisure=sports_centre` + `sport=tennis`

## Related Issues And PRs

I did not find an existing upstream issue, PR, or discussion that directly
reports this `pairs(poiTags)` ordering issue.

Related POI context:

- #845 discusses updating `process-openmaptiles.lua` to match newer
  OpenMapTiles POI schema coverage. This PR does not change the schema mapping;
  it only makes the current mapping deterministic and rank-aware.
