### PR TITLE
Handle open way centroids as lines

### DIFF
--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -862,14 +862,25 @@ Point OsmLuaProcessing::calculateCentroid(CentroidAlgorithm algorithm) {
 		}
 		return Point(centroid.x()*10000000.0, centroid.y()*10000000.0);
 	} else if (isWay) {
-		Polygon p;
-		geom::assign_points(p, linestringCached());
-
-		if (algorithm == CentroidAlgorithm::Polylabel) {
-			// CONSIDER: pick precision intelligently
-			centroid = mapbox::polylabel(p);
+		if (!isClosed) {
+			const Linestring &ls = linestringCached();
+			if (ls.empty())
+				throw geom::centroid_exception();
+			if (ls.size()==1) {
+				centroid = ls.front();
+			} else {
+				geom::centroid(ls, centroid);
+			}
 		} else {
-			geom::centroid(p, centroid);
+			Polygon p;
+			geom::assign_points(p, linestringCached());
+
+			if (algorithm == CentroidAlgorithm::Polylabel) {
+				// CONSIDER: pick precision intelligently
+				centroid = mapbox::polylabel(p);
+			} else {
+				geom::centroid(p, centroid);
+			}
 		}
 		return Point(centroid.x()*10000000.0, centroid.y()*10000000.0);
 	} else {


### PR DESCRIPTION
This PR is AI generated.

## Handle open way centroids as lines

`LayerAsCentroid()` defaults to the `polylabel` algorithm for 2D geometries.
That is appropriate for polygonal areas, but open ways are linestrings. The
current code assigns every way into a polygon before calculating the
representative point, so open ways can be passed through polygon/polylabel
logic even though they are not closed areas.

This change keeps the existing polygon path for closed ways, but handles open
ways from the cached linestring directly:

- empty open ways keep the existing error path by throwing
  `geom::centroid_exception`
- single-point open ways use that point
- multi-point open ways use Boost.Geometry's linestring centroid

Closed ways and relations still use the existing polygon/polylabel behavior.
The stored output is still a point, so this changes how the point is calculated
for open ways without changing output layers, attributes, or geometry storage.

This also avoids a temporary polygon conversion for open ways, but the intent
is correctness rather than a performance optimization.

## Reproduce

Generate OpenMapTiles-compatible output for an extract that contains open ways
which are emitted through `LayerAsCentroid()`, for example named POI-like ways
handled by `WritePOI()` or the catch-all `poi_detail` path in
`process-openmaptiles.lua`.

Before this change, those open ways are assigned into a polygon and labeled via
polygon logic. That can produce representative points that depend on polygon
handling for invalid/open rings.

After this change, open ways use line geometry for their representative point,
while closed ways continue to use polygon labeling.

In the generated-tile CI investigation, the focused open-way centroid patch
changed only `poi` geometry in the local Liechtenstein debug output. Tile
counts, feature counts, attributes, and polygon layers were unchanged in that
run.

## Testing

- `git diff --check origin/master..HEAD`
- `cmake --build build -j2`

## Related Issues And PRs

I did not find an existing upstream issue or PR that directly reports open ways
being labeled through polygon/polylabel handling.

Related centroid/polylabel context:

- #785 discusses `polylabel` behavior and precision for `LayerAsCentroid()` /
  `Centroid()`.
- #392 discusses point-on-surface style label placement for polygons.
- #641 fixed other `LayerAsCentroid()` behavior around Lua interop and relation
  members.
