### PR TITLE
Parse decimal building heights

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -868,10 +868,10 @@ function GetPOIRank()
 end
 
 function SetBuildingHeightAttributes()
-	local height = tonumber(Find("height"), 10)
-	local minHeight = tonumber(Find("min_height"), 10)
-	local levels = tonumber(Find("building:levels"), 10)
-	local minLevel = tonumber(Find("building:min_level"), 10)
+	local height = tonumber(Find("height"))
+	local minHeight = tonumber(Find("min_height"))
+	local levels = tonumber(Find("building:levels"))
+	local minLevel = tonumber(Find("building:min_level"))
 
 	local renderHeight = BUILDING_FLOOR_HEIGHT
 	if height or levels then


### PR DESCRIPTION
This PR is AI generated.

## Parse decimal building heights

The OpenMapTiles profile parses `height`, `min_height`, `building:levels`, and
`building:min_level` with `tonumber(value, 10)`.

That works for integer tags, but newer Lua versions reject decimal strings when
an explicit base is supplied. Valid OSM values such as `height=18.5` and
`building:levels=3.5` therefore parse as `nil` and fall back to the default
one-floor render height. LuaJIT accepts the same values with the base argument,
so the same input can produce different `render_height` values depending on the
Lua runtime used to build tilemaker.

Parse these four fields with plain `tonumber(value)` instead. That keeps
integer handling unchanged, accepts decimal OSM values, and makes the profile
consistent across Lua runtimes.

The change is intentionally scoped to the OpenMapTiles building height helper.
It does not alter layer selection, building feature counts, minzoom handling, or
the existing fallback height for buildings with no usable height/level tags.

## Examples

The examples below are from Liechtenstein CI artifacts generated from the same
input.

### Decimal `height`

Source object:

```
way 490877222
height=18.5
building=detached
```

OSM link:

```
https://www.openstreetmap.org/way/490877222
```

Pre-fix output on a newer Lua runtime:

```
render_height=3.66
```

Pre-fix output on LuaJIT:

```
render_height=18.5
```

Post-fix output:

```
render_height=18.5
```

![Decimal height comparison](https://raw.githubusercontent.com/Symmetricity/tilemaker/pr-assets/building-heights/pr-assets/building-heights/height-18-5.png)

### Decimal `building:levels`

Source object:

```
way 165295920
building:levels=3.5
building=school
```

OSM link:

```
https://www.openstreetmap.org/way/165295920
```

Pre-fix output on a newer Lua runtime:

```
render_height=3.66
```

Pre-fix output on LuaJIT:

```
render_height=12.81
```

Post-fix output:

```
render_height=12.81
```

![Decimal building levels comparison](https://raw.githubusercontent.com/Symmetricity/tilemaker/pr-assets/building-heights/pr-assets/building-heights/levels-3-5.png)

These examples show both parts of the bug: decimal tags were being ignored on
some Lua runtimes, and generated tile content could differ across CI runners
for the same input.

![Building height overview](https://raw.githubusercontent.com/Symmetricity/tilemaker/pr-assets/building-heights/pr-assets/building-heights/overview.png)

## Reproduce

With a newer Lua runtime:

```
lua -e 'print(tonumber("18.5", 10)); print(tonumber("18.5"))'
```

Before this change, the first expression returns `nil`, so
`SetBuildingHeightAttributes()` falls back to `BUILDING_FLOOR_HEIGHT`.

After this change, decimal height and level values parse as numbers and the
rendered building attributes use the source tag values.

## Testing

- `git diff --check origin/master..HEAD`
- `luac -p resources/process-openmaptiles.lua`
- Focused Lua check that `tonumber("18.5", 10)` is rejected by the local newer
  Lua runtime while `tonumber("18.5")` is accepted
- Local generated-tile artifact comparison for decimal `height` and decimal
  `building:levels` examples

## Related Issues And PRs

Related upstream context:

- #121 includes prior maintainer guidance to parse OSM height tags with plain
  `tonumber`.
- PR #263 added the current `render_height` and `render_min_height` attributes
  for 3D building rendering.
- PR #692 is an open building-related PR that expands `building:part` handling,
  but it does not directly address this Lua-runtime decimal parsing issue.

I did not find an existing upstream issue, PR, or discussion that directly
reports decimal building heights being ignored on newer Lua runtimes.
