### PR TITLE
Use fixed polygon clip cache level

### DIFF
--- a/include/clip_cache.h
+++ b/include/clip_cache.h
@@ -13,12 +13,42 @@ class ClipCache {
 public:
 	ClipCache(size_t threadNum, unsigned int baseZoom):
 		baseZoom(baseZoom),
+		useFixedZoom(false),
+		fixedZoom(0),
+		clipCache(threadNum * 16),
+		clipCacheMutex(threadNum * 16),
+		clipCacheSize(threadNum * 16) {
+	}
+
+	ClipCache(size_t threadNum, unsigned int baseZoom, unsigned int fixedZoom):
+		baseZoom(baseZoom),
+		useFixedZoom(true),
+		fixedZoom(fixedZoom),
 		clipCache(threadNum * 16),
 		clipCacheMutex(threadNum * 16),
 		clipCacheSize(threadNum * 16) {
 	}
 
 	const std::shared_ptr<T> get(uint zoom, TileCoordinate x, TileCoordinate y, NodeID objectID) const{
+		if (useFixedZoom) {
+			if (zoom <= fixedZoom)
+				return nullptr;
+
+			while (zoom > fixedZoom) {
+				zoom--;
+				x /= 2;
+				y /= 2;
+			}
+
+			std::lock_guard<std::mutex> lock(clipCacheMutex[objectID % clipCacheMutex.size()]);
+			const auto& cache = clipCache[objectID % clipCache.size()];
+			const auto& rv = cache.find(std::make_tuple(zoom, TileCoordinates(x, y), objectID));
+			if (rv != cache.end())
+				return rv->second;
+
+			return nullptr;
+		}
+
 		// Look for a previously clipped version at z-1, z-2, ...
 
 		std::lock_guard<std::mutex> lock(clipCacheMutex[objectID % clipCacheMutex.size()]);
@@ -37,9 +67,12 @@ public:
 	}
 
 	void add(const TileBbox& bbox, const NodeID objectID, const T& output) {
+		if (useFixedZoom && bbox.zoom != fixedZoom)
+			return;
+
 		// The point of caching is to reuse the clip, so caching at the terminal zoom is
 		// pointless.
-		if (bbox.zoom == baseZoom)
+		if (!useFixedZoom && bbox.zoom == baseZoom)
 			return;
 
 		std::shared_ptr<T> copy = std::make_shared<T>();
@@ -71,6 +104,8 @@ public:
 
 private:
 	unsigned int baseZoom;
+	bool useFixedZoom;
+	unsigned int fixedZoom;
 	std::vector<std::map<std::tuple<uint16_t, TileCoordinates, NodeID>, std::shared_ptr<T>>> clipCache;
 	mutable std::vector<std::mutex> clipCacheMutex;
 	std::vector<size_t> clipCacheSize;

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -27,7 +27,7 @@ TileDataSource::TileDataSource(size_t threadNum, unsigned int indexZoom, bool in
 	linestringStores(threadNum),
 	multilinestringStores(threadNum),
 	multipolygonStores(threadNum),
-	multiPolygonClipCache(ClipCache<MultiPolygon>(threadNum, indexZoom)),
+	multiPolygonClipCache(ClipCache<MultiPolygon>(threadNum, indexZoom, std::min(indexZoom, static_cast<unsigned int>(CLUSTER_ZOOM)))),
 	multiLinestringClipCache(ClipCache<MultiLinestring>(threadNum, indexZoom))
 {
 	// TileDataSource can only index up to zoom 14. The caller is responsible for

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -348,9 +348,6 @@ int main(const int argc, const char* argv[]) {
 
 	// ----	Write out data
 
-	// Launch the pool with threadNum threads
-	boost::asio::thread_pool pool(options.threadNum);
-
 	// Mutex is hold when IO is performed
 	std::mutex io_mutex;
 
@@ -460,86 +457,101 @@ int main(const int argc, const char* argv[]) {
 	// Cluster tiles: breadth-first for z0..z5, depth-first for z6
 	sortTileCoordinates(config.baseZoom, options.threadNum, tileCoordinates);
 
-	std::size_t batchSize = 0;
-	for(std::size_t startIndex = 0; startIndex < tileCoordinates.size(); startIndex += batchSize) {
-		// Compute how many tiles should be assigned to this batch --
-		// higher-zoom tiles are cheaper to compute, lower-zoom tiles more expensive.
-		batchSize = 0;
-		size_t weight = 0;
-		while (weight < 1000 && startIndex + batchSize < tileCoordinates.size()) {
-			const auto& zoom = tileCoordinates[startIndex + batchSize].first;
-			if (zoom > 12)
-				weight++;
-			else if (zoom > 11)
-				weight += 10;
-			else if (zoom > 10)
-				weight += 100;
-			else
-				weight += 1000;
+	auto writeTiles = [&](bool cachedTiles) {
+		boost::asio::thread_pool pool(options.threadNum);
+		std::size_t batchSize = 0;
+		for(std::size_t startIndex = 0; startIndex < tileCoordinates.size(); startIndex += batchSize) {
+			while (startIndex < tileCoordinates.size() && (tileCoordinates[startIndex].first <= CLUSTER_ZOOM) != cachedTiles)
+				startIndex++;
 
-			batchSize++;
-		}
+			if (startIndex >= tileCoordinates.size())
+				break;
 
-		boost::asio::post(pool, [=, &tileCoordinates, &pool, &sharedData, &sources, &attributeStore, &io_mutex, &tilesWritten, &lastTilesWritten]() {
-			std::vector<std::string> tileTimings;
-			std::size_t endIndex = std::min(tileCoordinates.size(), startIndex + batchSize);
-			for(std::size_t i = startIndex; i < endIndex; ++i) {
-				unsigned int zoom = tileCoordinates[i].first;
-				TileCoordinates coords = tileCoordinates[i].second;
+			// Compute how many tiles should be assigned to this batch --
+			// higher-zoom tiles are cheaper to compute, lower-zoom tiles more expensive.
+			batchSize = 0;
+			size_t weight = 0;
+			while (weight < 1000 && startIndex + batchSize < tileCoordinates.size()) {
+				const auto& zoom = tileCoordinates[startIndex + batchSize].first;
+				if ((zoom <= CLUSTER_ZOOM) != cachedTiles)
+					break;
 
-#ifdef CLOCK_MONOTONIC
-				timespec start, end;
-				if (options.logTileTimings)
-					clock_gettime(CLOCK_MONOTONIC, &start);
-#endif
+				if (zoom > 12)
+					weight++;
+				else if (zoom > 11)
+					weight += 10;
+				else if (zoom > 10)
+					weight += 100;
+				else
+					weight += 1000;
 
-				std::vector<std::vector<OutputObjectID>> data;
-				for (auto source : sources) {
-					data.emplace_back(source->getObjectsForTile(sortOrders, zoom, coords));
-				}
-				outputProc(sharedData, sources, attributeStore, data, coords, zoom);
-
-#ifdef CLOCK_MONOTONIC
-				if (options.logTileTimings) {
-					clock_gettime(CLOCK_MONOTONIC, &end);
-					uint64_t tileNs = 1e9 * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
-					std::string output = "z" + std::to_string(zoom) + "/" + std::to_string(coords.x) + "/" + std::to_string(coords.y) + " took " + std::to_string(tileNs/1e6) + " ms";
-					tileTimings.push_back(output);
-				}
-#endif
+				batchSize++;
 			}
 
-			if (options.logTileTimings) {
-				const std::lock_guard<std::mutex> lock(io_mutex);
-				std::cout << std::endl;
-				for (const auto& output : tileTimings)
-					std::cout << output << std::endl;
-			}
+			boost::asio::post(pool, [=, &tileCoordinates, &sharedData, &sources, &attributeStore, &io_mutex, &tilesWritten, &lastTilesWritten]() {
+				std::vector<std::string> tileTimings;
+				std::size_t endIndex = std::min(tileCoordinates.size(), startIndex + batchSize);
+				for(std::size_t i = startIndex; i < endIndex; ++i) {
+					unsigned int zoom = tileCoordinates[i].first;
+					TileCoordinates coords = tileCoordinates[i].second;
 
-			tilesWritten += (endIndex - startIndex); 
+#ifdef CLOCK_MONOTONIC
+					timespec start, end;
+					if (options.logTileTimings)
+						clock_gettime(CLOCK_MONOTONIC, &start);
+#endif
 
-			if (io_mutex.try_lock()) {
-				uint64_t written = tilesWritten.load();
-
-				if (written >= lastTilesWritten + tileCoordinates.size() / 100 || ISATTY) {
-					lastTilesWritten = written;
-					// Show progress grouped by z6 (or lower)
-					size_t z = tileCoordinates[startIndex].first;
-					size_t x = tileCoordinates[startIndex].second.x;
-					size_t y = tileCoordinates[startIndex].second.y;
-					if (z > CLUSTER_ZOOM) {
-						x = x / (1 << (z - CLUSTER_ZOOM));
-						y = y / (1 << (z - CLUSTER_ZOOM));
-						z = CLUSTER_ZOOM;
+					std::vector<std::vector<OutputObjectID>> data;
+					for (auto source : sources) {
+						data.emplace_back(source->getObjectsForTile(sortOrders, zoom, coords));
 					}
-					cout << "z" << z << "/" << x << "/" << y << ", writing tile " << written << " of " << tileCoordinates.size() << "               \r" << std::flush;
+					outputProc(sharedData, sources, attributeStore, data, coords, zoom);
+
+#ifdef CLOCK_MONOTONIC
+					if (options.logTileTimings) {
+						clock_gettime(CLOCK_MONOTONIC, &end);
+						uint64_t tileNs = 1e9 * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
+						std::string output = "z" + std::to_string(zoom) + "/" + std::to_string(coords.x) + "/" + std::to_string(coords.y) + " took " + std::to_string(tileNs/1e6) + " ms";
+						tileTimings.push_back(output);
+					}
+#endif
 				}
-				io_mutex.unlock();
-			}
-		});
-	}
-	// Wait for all tasks in the pool to complete.
-	pool.join();
+
+				if (options.logTileTimings) {
+					const std::lock_guard<std::mutex> lock(io_mutex);
+					std::cout << std::endl;
+					for (const auto& output : tileTimings)
+						std::cout << output << std::endl;
+				}
+
+				tilesWritten += (endIndex - startIndex);
+
+				if (io_mutex.try_lock()) {
+					uint64_t written = tilesWritten.load();
+
+					if (written >= lastTilesWritten + tileCoordinates.size() / 100 || ISATTY) {
+						lastTilesWritten = written;
+						// Show progress grouped by z6 (or lower)
+						size_t z = tileCoordinates[startIndex].first;
+						size_t x = tileCoordinates[startIndex].second.x;
+						size_t y = tileCoordinates[startIndex].second.y;
+						if (z > CLUSTER_ZOOM) {
+							x = x / (1 << (z - CLUSTER_ZOOM));
+							y = y / (1 << (z - CLUSTER_ZOOM));
+							z = CLUSTER_ZOOM;
+						}
+						cout << "z" << z << "/" << x << "/" << y << ", writing tile " << written << " of " << tileCoordinates.size() << "               \r" << std::flush;
+					}
+					io_mutex.unlock();
+				}
+			});
+		}
+		// Wait for all tasks in the pool to complete.
+		pool.join();
+	};
+
+	writeTiles(true);
+	writeTiles(false);
 
 	// ----	Close tileset
 
@@ -564,4 +576,3 @@ int main(const int argc, const char* argv[]) {
 
 	cout << endl << "Filled the tileset with good things at " << sharedData.outputFile << endl;
 }
-


### PR DESCRIPTION
# Use fixed polygon clip cache level

This PR was AI generated.

## Summary

This makes multipolygon clip-cache reuse deterministic by caching polygon clips
at tilemaker's existing z6 object-clustering level, then writing z0..z6 tiles
before z7+ tiles.

Higher zoom polygon tiles previously reused whichever lower-zoom cached clip
happened to be present. In a multithreaded run, that ancestor could depend on
worker scheduling. Clipping an already clipped polygon through different
ancestor paths can produce different encoded polygon geometry, even when the
source data and command line are unchanged.

Linestring clip-cache behavior is unchanged.

## Background

The existing clip cache is intentional and performance-sensitive. It was added
as part of #612, which extracted `ClipCache` and reduced memory use by lazily
reconstructing way-backed geometries. PR #607 explains the intended cache model:
when writing higher zooms, tilemaker prefers clipping a cached lower-zoom
geometry over clipping the original geometry again. That avoids repeated work
for very large polygons.

This PR keeps that optimization but makes the parent level deterministic for
polygons. Rather than searching z-1, z-2, and so on until any cached ancestor is
found, multipolygons now use the z6 ancestor. z6 is already tilemaker's object
clustering level, so the change follows an existing locality boundary instead
of adding a new one.

## Investigation

This was found while investigating generated-tile semantic differences. A
separate fix exposed a repeatability issue where normal multithreaded runs could
emit different polygon coordinates for the same tile. The first observed local
case was:

- tile: z11/1077/1329
- layer: `water`
- tags: `class=lake`
- source: OSM relation 9404214, a large Rhine water multipolygon with inner
  rings
- symptom: matching feature counts and tags, but different polygon coordinates
  between repeated runs

Additional checks:

- running with `--threads=1` was stable
- temporarily disabling polygon `ClipCache` reads made repeated normal
  multithreaded runs semantically match again
- revalidating clipped polygons after spike removal did not fix the scheduling
  sensitivity
- a full zoom-barrier scheduler made local repeats deterministic, but was too
  expensive on a medium fixture

The narrowed root cause is shared parent-tile clip-cache reuse. A higher zoom
tile could reuse a z10 parent in one run and a z6 parent in another run,
depending on which worker populated the cache first.

## Implementation

This PR adds an optional fixed-zoom mode to `ClipCache`.

For multipolygons only:

- cache entries are written only at `min(basezoom, CLUSTER_ZOOM)`
- cache lookups for higher zooms map directly to that fixed parent tile
- z0..z6 tiles are written before z7+ tiles so the fixed parent cache entries
  are available before child tiles are processed

The existing ancestor-search behavior remains available and is still used for
linestrings.

## Results

### Small fixture / CI

The fix was tested stacked on the currently submitted PR changes in fork CI run
`25960612652`.

After rerunning a known intermittent Windows crash in tile generation, the run
passed native generated-tile verification:

- macOS 14 Makefile
- macOS latest Makefile
- Ubuntu 22.04 CMake
- Ubuntu 22.04 Makefile
- Windows CMake

Repeat outputs and cross-runner outputs matched semantically. Raw MBTiles and
PMTiles bytes still differed, but decoded MVT content matched.

The clean, isolated branch was also checked locally against the Liechtenstein
fixture using upstream `resources/config-openmaptiles.json` and
`resources/process-openmaptiles.lua`.

That isolated check is useful, but it also shows why this PR should be read as
one part of the broader determinism work:

- upstream `master` repeat output differed in 15 decoded MBTiles layers:
  1 `water` geometry difference and 14 `poi` differences
- the clean fixed-z6 branch removed the observed z11 water repeat difference,
  but still showed unrelated `poi` differences because the isolated branch does
  not include the Lua POI-order determinism fix
- upstream-vs-fixed output differed in polygon geometry as expected:
  204 decoded MBTiles layer differences, mostly `landcover`, `landuse`,
  `water`, and `park`

Two visual checks were prepared from that fixture:

- Rhine water polygon, OSM relation 9404214:
  https://www.openstreetmap.org/relation/9404214#map=15/47.16020/9.49300
  - upstream repeat output was not stable for z11/1077/718 XYZ
  - the fixed-z6 output matched the shorter 19-point outline seen in one
    upstream repeat, instead of the upstream run that added an extra clipped
    corner point
- high-zoom water clipping near Triesen:
  https://www.openstreetmap.org/#map=17/47.07210/9.48670
  - fixed-z6 changes the clipped edge geometry compared with upstream dynamic
    parent reuse
  - the change is an expected output change from making the parent clip source
    deterministic

![Rhine water polygon repeat comparison](https://raw.githubusercontent.com/Symmetricity/tilemaker/pr-assets/fixed-z6-clip-cache/pr-assets/fixed-z6-clip-cache/rhine-water-repeat-difference.png)

![High-zoom water edge comparison](https://raw.githubusercontent.com/Symmetricity/tilemaker/pr-assets/fixed-z6-clip-cache/pr-assets/fixed-z6-clip-cache/high-zoom-water-edge-change.png)

### Larger local fixture

A local Austria fixture was used for a larger timing check:

- input: Austria extract, 754 MB
- profile: `resources/config-openmaptiles.json` and
  `resources/process-openmaptiles.lua`
- output: PMTiles
- command output redirected to log files for both runs
- source PBF effectively warm in the page cache for both runs
- semantic verification was not run for the timing comparison

Results:

| Build | Wall time | User time | System time | CPU | Max RSS |
| --- | ---: | ---: | ---: | ---: | ---: |
| upstream `master` | 3:53.30 | 540.47s | 466.40s | 431% | 3,537,824 KB |
| fixed z6 cache | 3:33.61 | 552.21s | 398.39s | 445% | 3,461,776 KB |

On this fixture, the fixed-z6 branch was about 8.4% faster wall-clock, used
about 5.6% less total CPU time, and used about 2.1% less peak RSS. Treat these
as fixture-specific results rather than a guarantee.

An earlier larger PMTiles repeat test on the same Austria fixture produced
47,742 addressed tiles. The fixed-z6 outputs differed at the raw tile-byte
level, but the semantic verifier checked 43,124 raw-different PMTiles tile
pairs and confirmed matching decoded content.

## Planet Estimate

This has not been measured on a planet build.

PR #612 reported a planet build at 67m51s and 42 GB RAM on a 48-core Hetzner
CCX63. If the Austria wall-time ratio transferred directly, that would estimate
roughly 62 minutes for the same planet build. Applying the Austria RSS ratio
directly would estimate roughly 41 GB RAM.

Those numbers are only directional:

- planet output has a different mix of very large polygons and high-zoom tiles
- memory is dominated by node/way/object stores, not only the clip cache
- the z6 phase boundary may help or hurt depending on workload balance
- the local Austria run used a different machine and a much smaller input

The safer expectation is that this should be approximately performance-neutral
to modestly faster on large polygon-heavy outputs, with memory roughly neutral.

## Expected Improvement

The main improvement is deterministic decoded tile content for multipolygon
outputs that previously depended on worker scheduling.

This should make repeated tilemaker runs less sensitive to thread timing and
platform scheduling. It also keeps the monster-polygon clip cache rather than
disabling it.

## Possible Regressions

This can change polygon geometry compared with previous output because clipping
is not perfectly associative:

```text
clip(original, z6 parent), then clip(child)
```

can differ slightly from:

```text
clip(original, z8 parent), then clip(child)
```

Expected visual differences, if any, should be localized to polygon edges,
especially water, landuse, landcover, and building polygons that cross tile or
z6-cluster boundaries.

This does not make generated archives byte-for-byte deterministic. Archive
ordering, compression, and raw tile bytes can still differ while decoded MVT
content matches.

There is also a scheduling tradeoff: z0..z6 tiles now complete before z7+ tiles
are posted. The tested Austria fixture did not show a slowdown, but a workload
with unusually expensive low-zoom/z6 tiles could see reduced parallelism during
that phase.

## Related Issues and PRs

- #612 introduced the current `ClipCache` structure and explains the memory and
  concurrency goals behind the surrounding code.
- #607 introduced the monster-polygon clipping cache behavior this PR preserves.
- #597 and #482 provide relevant clipping-performance and clipping-correctness
  context.
- #697 reports invalid polygons after clipping at tile boundaries. This PR is
  related to polygon clipping, but it should not be claimed as a fix for #697
  without targeted reproduction against that issue's fixture.

No directly matching upstream issue or PR was found for the scheduling-sensitive
deterministic-output bug.

## Testing

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build -j2`
- fork CI run `25960612652`, stacked test branch, native generated-tile
  semantic verification passed after rerunning the known intermittent Windows
  tile-generation crash
- local Austria upstream/fixed-z6 timing comparison, PMTiles output, no
  semantic verification for the timing run
