### PR TITLE
Decode PBF blobs by data field

### DIFF
--- a/src/pbf_reader.cpp
+++ b/src/pbf_reader.cpp
@@ -68,7 +68,10 @@ protozero::data_view PbfReader::PbfReader::readBlob(int32_t datasize, std::istre
 	if (input.eof())
 		throw std::runtime_error("readBlob: unexpected eof");
 
+	enum class BlobDataType { None, Raw, Zlib };
+
 	int32_t rawSize = -1;
+	BlobDataType dataType = BlobDataType::None;
 	protozero::data_view view;
 	protozero::pbf_message<Schema::Blob> message{&blobStorage[0], blobStorage.size()};
 	while (message.next()) {
@@ -77,23 +80,34 @@ protozero::data_view PbfReader::PbfReader::readBlob(int32_t datasize, std::istre
 				rawSize = message.get_int32();
 				break;
 			case Schema::Blob::oneof_data_bytes_raw:
+				dataType = BlobDataType::Raw;
 				view = message.get_view();
 				break;
 			case Schema::Blob::oneof_data_bytes_zlib_data:
+				dataType = BlobDataType::Zlib;
 				view = message.get_view();
 				break;
+			case Schema::Blob::oneof_data_bytes_lzma_data:
+			case Schema::Blob::oneof_data_bytes_lz4_data:
+			case Schema::Blob::oneof_data_bytes_zstd_data:
+				throw std::runtime_error("Blob: unsupported compression tag: " + std::to_string(static_cast<uint32_t>(message.tag())));
 			default:
 				throw std::runtime_error("Blob: unknown tag: " + std::to_string(static_cast<uint32_t>(message.tag())));
 		}
 	}
 
-	if (rawSize == -1)
-		// Data is not compressed, can return it directly.
+	if (dataType == BlobDataType::None)
+		throw std::runtime_error("Blob: missing data");
+
+	if (dataType == BlobDataType::Raw)
 		return view;
 
-	blobStorage2.resize(rawSize);
+	if (rawSize != -1)
+		blobStorage2.resize(rawSize);
+	else
+		blobStorage2.clear();
 	decompress_string(blobStorage2, view.data(), view.size(), false);
-	return { &blobStorage2[0], blobStorage2.size() };
+	return { blobStorage2.data(), blobStorage2.size() };
 }
 
 PbfReader::HeaderBBox PbfReader::PbfReader::readHeaderBBox(protozero::data_view data) {
@@ -587,4 +601,3 @@ PbfReader::HeaderBlock PbfReader::PbfReader::readHeaderFromFile(std::istream& in
 
 	return header;
 }
-


### PR DESCRIPTION
This PR is AI generated.

## Summary

This fixes PBF Blob decoding so tilemaker uses the actual Blob data field to
decide whether payload bytes are raw or zlib-compressed.

The current reader uses `raw_size == -1` to decide that a Blob is uncompressed:

```cpp
if (rawSize == -1)
	return view;
```

That is not the right discriminator. In the OSM-binary storage format,
`raw_size` is optional metadata for the uncompressed size, while the payload
type is carried by the Blob `oneof data` field:

- `raw`: uncompressed payload
- `zlib_data`: zlib-compressed payload
- `lzma_data`, `lz4_data`, `zstd_data`: other compressed payloads

Reference:
https://github.com/openstreetmap/OSM-binary/blob/master/osmpbf/fileformat.proto

If a Blob contains `zlib_data` but omits `raw_size`, the old code returns the
compressed bytes directly to the protozero parser. Protozero then attempts to
parse compressed data as a `HeaderBlock` or `PrimitiveBlock`, which can surface
as errors such as `protozero::invalid_tag_exception` or
`protozero::end_of_buffer_exception`.

## Implementation

The patch keeps the change local to `PbfReader::readBlob()`:

- Track which Blob data field was present.
- Return bytes directly only when the Blob contains the `raw` field.
- Inflate `zlib_data` even when `raw_size` is omitted.
- Preserve the existing pre-sized output buffer when `raw_size` is available.
- Report missing Blob payloads and unsupported compression fields explicitly.

No block scheduling, offset handling, storage, or protozero object parsing logic
is changed.

## Expected Behavior

Before this change, a zlib-compressed Blob without `raw_size` could be silently
misclassified as raw data. The failure would happen later, when protozero tried
to parse compressed bytes as protobuf message content.

After this change, tilemaker determines the payload type from the Blob data
field. Raw payloads still avoid a copy/decompression step, while zlib payloads
are decompressed before parsing.

## Possible Regressions

The normal path for common PBFs with `zlib_data` and `raw_size` should behave
the same, except the compression decision is now based on the data field rather
than the metadata field.

For zlib Blobs that omit `raw_size`, the decompression buffer may need to grow
dynamically because tilemaker does not know the uncompressed size up front.
That is a small allocation cost on this uncommon path and avoids parsing the
wrong bytes.

For unusual raw Blobs that include `raw_size`, this changes behavior from
attempting to decompress raw bytes to returning the raw payload. That follows
the Blob data field and should be more correct.

Unsupported compression fields remain unsupported, but the error message is now
explicit.

## Related Issues And PRs

I did not find an existing upstream PR for the same `raw_size`/`zlib_data`
change.

I also did not find an upstream issue that directly reports a zlib Blob without
`raw_size`. This may be relevant to broader PBF parsing failures, but this PR
does not claim to fix those reports without a matching reproducer.

## Testing

Code checks:

```bash
git diff --cached --check
```

Local build:

```bash
cmake -S . -B local-builds/pbf-zlib-without-raw-size -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build local-builds/pbf-zlib-without-raw-size --target tilemaker -j1
```

Focused parser test:

```bash
make test_pbf_reader -j1
```

Result:

```text
1 tests, 29 assertions, 0 failures
```
