### PR TITLE
Write rings in opposite order since Y axis is inverted (relative to B…

### DIFF
--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -192,15 +192,18 @@ bool writeRing(
 
 	bool firstPoint = true;
 	fbuilder.add_ring(points);
-	for (const Point& point : ring) {
-		pair<int, int> xy = std::make_pair(point.get<0>(), point.get<1>());
+	for (auto it = ring.rbegin(); it != ring.rend(); ++it) {
+    	const Point& point = *it;
 
-		if (firstPoint || xy != lastXy) {
-			firstPoint = false;
-			lastXy = xy;
-			fbuilder.set_point(xy.first, xy.second);
-		}
-	}
+    	pair<int, int> xy =
+    		std::make_pair(point.get<0>(), point.get<1>());
+
+    	if (firstPoint || xy != lastXy) {
+    		firstPoint = false;
+    		lastXy = xy;
+    		fbuilder.set_point(xy.first, xy.second);
+    	}
+    }
 
 	return true;
 }
@@ -228,6 +231,8 @@ void writeMultiPolygon(
 	}
 	if (geom::is_empty(current))
 		return;
+
+	geom::correct(current);
 
 	geom::validity_failure_type failure;
 	if (verbose && !geom::is_valid(current, failure)) { 


### PR DESCRIPTION
I'm rendering tiles using ESRI.  ESRI's ArcGIS JS renderer is very strict.  If Polygons are not clockwise oriented, then they will render, but they won't fill.  The reason is that when counter-clockwise, ESRI assumes the ring is an exclusion.

Tilemaker is writing almost all polygons backwards (the rings are in counter-clockwise orientation).  This is because after simplification or clipping, we call geometry::correct on the polygon.  This orients the polygon correctly according to Boost.  However, the Y value of points are inverted in vector tiles relative to a normal coordinate plane.  Boost doesn't know this, so as soon as we "correct" a polygon, the orientation is backwards.

This PR fixes the problem by doing two things:
1. We call geometry::correct on all polygons just before writing them to the vector tile.
2. We change the writeRing algorithm to traverse the the rings backwards

Doing these two things solves the problem and now the ESRI renderer is happy.