### PR TITLE
Speed up runtime by reducing allocation churn in tile generation

### DIFF
--- a/include/coordinates_geom.h
+++ b/include/coordinates_geom.h
@@ -23,7 +23,7 @@ public:
 	TileBbox(TileCoordinates i, uint z, bool h, bool e);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
-	std::vector<Point> scaleRing(Ring const &src) const;
+	Ring scaleRing(Ring const &src) const;
 	MultiPolygon scaleGeometry(MultiPolygon const &src) const;
 	std::pair<double, double> floorLatpLon(double latp, double lon) const;
 

--- a/include/coordinates_geom.h
+++ b/include/coordinates_geom.h
@@ -23,7 +23,9 @@ public:
 	TileBbox(TileCoordinates i, uint z, bool h, bool e);
 
 	std::pair<int,int> scaleLatpLon(double latp, double lon) const;
+	void scaleRing(Ring &dst, Ring const &src) const;
 	Ring scaleRing(Ring const &src) const;
+	void scaleGeometry(MultiPolygon &dst, MultiPolygon const &src) const;
 	MultiPolygon scaleGeometry(MultiPolygon const &src) const;
 	std::pair<double, double> floorLatpLon(double latp, double lon) const;
 

--- a/include/geometry/correct.hpp
+++ b/include/geometry/correct.hpp
@@ -10,6 +10,7 @@
  * ----------------------------------------------------------------------------
  */
 
+#include <utility>
 #include <vector>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
@@ -25,7 +26,7 @@ namespace impl {
 template<typename C, typename T>
 static inline void result_combine(C &result, T &&new_element)
 {
-    result.push_back(new_element);
+    result.push_back(std::forward<T>(new_element));
 
    	for(std::size_t i = 0; i < result.size() - 1; ) {
         if(!boost::geometry::intersects(result[i], result.back())) {

--- a/include/geometry/correct.hpp
+++ b/include/geometry/correct.hpp
@@ -281,9 +281,11 @@ static inline std::vector<ring_t> correct(ring_t const &ring, boost::geometry::o
 	dissolve_find_intersections(new_ring, pseudo_vertices, start_keys);
 
 	if(start_keys.empty()) {
-		if(std::abs(boost::geometry::area(new_ring)) > remove_spike_min_area) 
-			return { new_ring };
-		else
+		if(std::abs(boost::geometry::area(new_ring)) > remove_spike_min_area) {
+			std::vector<ring_t> result;
+			result.push_back(std::move(new_ring));
+			return result;
+		} else
 			return { };
 	}
 

--- a/include/geometry/correct.hpp
+++ b/include/geometry/correct.hpp
@@ -97,6 +97,8 @@ static inline void dissolve_find_intersections(
 	if(ring.empty()) return;
 
 	boost::geometry::index::rtree<std::pair< boost::geometry::model::segment<point_t>, std::size_t >, boost::geometry::index::quadratic<16>> index;
+	std::vector<point_t> output;
+	output.reserve(2);
 
 	// Generate all by-pass intersections in the graph
 	// Generate a list of all by-pass intersections
@@ -113,7 +115,7 @@ static inline void dissolve_find_intersections(
 			auto const &line_2 = iter.first;
 			auto j = iter.second;
 			
-			std::vector<point_t> output;
+			output.clear();
 			boost::geometry::intersection(line_1, line_2, output);
 
 			for(auto const &p: output) {

--- a/include/osm_lua_processing.h
+++ b/include/osm_lua_processing.h
@@ -276,6 +276,8 @@ private:
 	const inline Point getPoint() {
 		return Point(lon/10000000.0,latp/10000000.0);
 	}
+
+	double projectedPolygonArea(const Polygon &p);
 	
 	OSMStore &osmStore;	// global OSM store
 
@@ -310,6 +312,7 @@ private:
 	bool multiLinestringInited;
 	MultiPolygon multiPolygonCache;
 	bool multiPolygonInited;
+	geom::model::polygon<DegPoint> areaPolygonCache;
 
 	NodeID lastStoredGeometryId;
 	OutputGeometryType lastStoredGeometryType;

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -332,6 +332,7 @@ public:
 	template<class WayIt>
 	Polygon llListPolygon(WayIt begin, WayIt end) const {
 		Polygon poly;
+		poly.outer().reserve(end - begin);
 		fillPoints(poly.outer(), begin, end);
 		boost::geometry::correct(poly);
 		return poly;
@@ -341,6 +342,7 @@ public:
 	template<class WayIt>
 	Linestring llListLinestring(WayIt begin, WayIt end) const {
 		Linestring ls;
+		ls.reserve(end - begin);
 		fillPoints(ls, begin, end);
 		return ls;
 	}

--- a/include/sharded_way_store.h
+++ b/include/sharded_way_store.h
@@ -14,6 +14,7 @@ public:
 	void reopen() override;
 	void batchStart() override;
 	std::vector<LatpLon> at(WayID wayid) const override;
+	void at(WayID wayid, std::vector<LatpLon>& output) const override;
 	bool requiresNodes() const override;
 	void insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) override;
 	void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;

--- a/include/sorted_way_store.h
+++ b/include/sorted_way_store.h
@@ -88,6 +88,7 @@ public:
 	void reopen() override;
 	void batchStart() override;
 	std::vector<LatpLon> at(WayID wayid) const override;
+	void at(WayID wayid, std::vector<LatpLon>& output) const override;
 	bool requiresNodes() const override { return true; }
 	void insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) override;
 	void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;
@@ -107,6 +108,7 @@ public:
 	);
 
 	static std::vector<NodeID> decodeWay(uint16_t flags, const uint8_t* input);
+	static void decodeWay(uint16_t flags, const uint8_t* input, std::vector<NodeID>& output);
 
 private:
 	bool compressWays;

--- a/include/tile_data.h
+++ b/include/tile_data.h
@@ -114,7 +114,7 @@ inline OutputObjectID outputObjectWithId<OutputObjectXYID>(const OutputObjectXYI
 
 template<typename OO> void collectLowZoomObjectsForTile(
 	const unsigned int& indexZoom,
-	typename std::vector<std::vector<OO>> objects,
+	const typename std::vector<std::vector<OO>>& objects,
 	unsigned int zoom,
 	const TileCoordinates& dstIndex,
 	std::vector<OutputObjectID>& output

--- a/include/way_store.h
+++ b/include/way_store.h
@@ -15,6 +15,7 @@ public:
 	// meaningful for SortedWayStore
 	virtual void batchStart() = 0;
 	virtual std::vector<LatpLon> at(WayID wayid) const = 0;
+	virtual void at(WayID wayid, std::vector<LatpLon>& output) const = 0;
 	virtual bool requiresNodes() const = 0;
 	virtual void insertLatpLons(std::vector<ll_element_t>& newWays) = 0;
 	virtual void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) = 0;

--- a/include/way_stores.h
+++ b/include/way_stores.h
@@ -15,6 +15,7 @@ public:
 	void reopen() override;
 	void batchStart() override {}
 	std::vector<LatpLon> at(WayID wayid) const override;
+	void at(WayID wayid, std::vector<LatpLon>& output) const override;
 	bool requiresNodes() const override { return false; }
 	void insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) override;
 	void insertNodes(const std::vector<std::pair<WayID, std::vector<NodeID>>>& newWays) override;

--- a/src/coordinates_geom.cpp
+++ b/src/coordinates_geom.cpp
@@ -33,8 +33,8 @@ pair<int,int> TileBbox::scaleLatpLon(double latp, double lon) const {
 
 // Scaling with naive self-intersection check - if we've added the new point
 // within the last 5 points, then backtrack to the last time we added it
-Ring TileBbox::scaleRing(Ring const &src) const {
-	Ring points;
+void TileBbox::scaleRing(Ring &points, Ring const &src) const {
+	points.clear();
 	points.reserve(src.size());
 	for(auto const &i: src) {
 		auto scaled = scaleLatpLon(i.y(), i.x()); // -> .first is x, .second is y
@@ -48,31 +48,46 @@ Ring TileBbox::scaleRing(Ring const &src) const {
 		}
 		if (!found) points.push_back(Point(scaled.first,scaled.second));
 	}
+}
+
+Ring TileBbox::scaleRing(Ring const &src) const {
+	Ring points;
+	scaleRing(points, src);
 	return points;
+}
+
+void TileBbox::scaleGeometry(MultiPolygon &dst, MultiPolygon const &src) const {
+	if (dst.size() < src.size())
+		dst.resize(src.size());
+
+	size_t polygonCount = 0;
+	for(auto const &poly: src) {
+		Polygon &p = dst[polygonCount];
+
+		// Copy the outer ring
+		scaleRing(p.outer(), poly.outer());
+		if (p.outer().size()<4)
+			continue;
+
+		// Copy the inner rings
+		if (p.inners().size() < poly.inners().size())
+			p.inners().resize(poly.inners().size());
+		size_t innerCount = 0;
+		for(auto const &r: poly.inners()) {
+			Ring &points = p.inners()[innerCount];
+			scaleRing(points, r);
+			if (points.size()>=4)
+				innerCount++;
+		}
+		p.inners().resize(innerCount);
+		polygonCount++;
+	}
+	dst.resize(polygonCount);
 }
 
 MultiPolygon TileBbox::scaleGeometry(MultiPolygon const &src) const {
 	MultiPolygon dst;
-	dst.reserve(src.size());
-	for(auto const &poly: src) {
-		Polygon p;
-
-		// Copy the outer ring
-		Ring points = scaleRing(poly.outer());
-		if (points.size()<4) continue;
-		p.outer() = std::move(points);
-
-		// Copy the inner rings
-		p.inners().reserve(poly.inners().size());
-		for(auto const &r: poly.inners()) {
-			points = scaleRing(r);
-			if (points.size()<4) continue;
-			p.inners().push_back(std::move(points));
-		}
-
-		// Add to multipolygon
-		dst.push_back(std::move(p));
-	}
+	scaleGeometry(dst, src);
 	return dst;
 }
 

--- a/src/coordinates_geom.cpp
+++ b/src/coordinates_geom.cpp
@@ -33,10 +33,10 @@ pair<int,int> TileBbox::scaleLatpLon(double latp, double lon) const {
 
 // Scaling with naive self-intersection check - if we've added the new point
 // within the last 5 points, then backtrack to the last time we added it
-std::vector<Point> TileBbox::scaleRing(Ring const &src) const {
-	std::vector<Point> points;
+Ring TileBbox::scaleRing(Ring const &src) const {
+	Ring points;
 	points.reserve(src.size());
-	for(auto &i: src) {
+	for(auto const &i: src) {
 		auto scaled = scaleLatpLon(i.y(), i.x()); // -> .first is x, .second is y
 		bool found = false;
 		for (size_t j=1; j<5; j++) {
@@ -53,30 +53,25 @@ std::vector<Point> TileBbox::scaleRing(Ring const &src) const {
 
 MultiPolygon TileBbox::scaleGeometry(MultiPolygon const &src) const {
 	MultiPolygon dst;
-	for(auto poly: src) {
+	dst.reserve(src.size());
+	for(auto const &poly: src) {
 		Polygon p;
 
 		// Copy the outer ring
-		std::vector<Point> points = scaleRing(poly.outer());
+		Ring points = scaleRing(poly.outer());
 		if (points.size()<4) continue;
-		Ring outer;
-		geom::append(outer,points);
-		geom::append(p,outer);
+		p.outer() = std::move(points);
 
 		// Copy the inner rings
-		int num_rings = 0;
-		for(auto &r: poly.inners()) {
+		p.inners().reserve(poly.inners().size());
+		for(auto const &r: poly.inners()) {
 			points = scaleRing(r);
 			if (points.size()<4) continue;
-			Ring inner;
-			geom::append(inner,points);
-			num_rings++;
-			geom::interior_rings(p).resize(num_rings);
-			geom::append(p, inner, num_rings-1);
+			p.inners().push_back(std::move(points));
 		}
 
 		// Add to multipolygon
-		dst.push_back(p);
+		dst.push_back(std::move(p));
 	}
 	return dst;
 }

--- a/src/geom.cpp
+++ b/src/geom.cpp
@@ -197,10 +197,11 @@ char bit_code(Point const &p, Box const &bbox) {
 }
 
 // Sutherland-Hodgeman polygon clipping algorithm
-void fast_clip(Ring &points, Box const &bbox) {
+void fast_clip(Ring &points, Box const &bbox, Ring &result) {
 	// clip against each side of the clip rectangle
 	for (char edge = 1; edge <= 8; edge *= 2) {
-		Ring result;
+		result.clear();
+		result.reserve(points.size() + 4);
 		Point prev = points[points.size() - 1];
 		bool prevInside = (bit_code(prev, bbox) & edge)==0;
 
@@ -214,20 +215,26 @@ void fast_clip(Ring &points, Box const &bbox) {
 			prev = p;
 			prevInside = inside;
 		}
-		points = std::move(result);
+		points.swap(result);
 		if (points.size()==0) break;
 	}
 }
 
+void fast_clip(Ring &points, Box const &bbox) {
+	Ring result;
+	fast_clip(points, bbox, result);
+}
+
 // Wrappers for polygon/multipolygon
 void fast_clip(Polygon &polygon, Box const &bbox) {
-	fast_clip(polygon.outer(), bbox);
+	Ring result;
+	fast_clip(polygon.outer(), bbox, result);
 	if (polygon.outer().empty()) {
 		polygon.inners().resize(0);
 		return;
 	}
 	for (auto &inner: polygon.inners()) {
-		fast_clip(inner, bbox);
+		fast_clip(inner, bbox, result);
 	}
 	polygon.inners().erase(std::remove_if(
 		polygon.inners().begin(), polygon.inners().end(), 

--- a/src/geom.cpp
+++ b/src/geom.cpp
@@ -200,6 +200,15 @@ char bit_code(Point const &p, Box const &bbox) {
 void fast_clip(Ring &points, Box const &bbox, Ring &result) {
 	// clip against each side of the clip rectangle
 	for (char edge = 1; edge <= 8; edge *= 2) {
+		bool needsClip = false;
+		for (auto const &p: points) {
+			if (bit_code(p, bbox) & edge) {
+				needsClip = true;
+				break;
+			}
+		}
+		if (!needsClip) continue;
+
 		result.clear();
 		result.reserve(points.size() + 4);
 		Point prev = points[points.size() - 1];

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -512,21 +512,43 @@ void reverse_project(DegPoint& p) {
     geom::set<1>(p, latp2lat(geom::get<1>(p)));
 }
 
+template <typename DstRing, typename SrcRing>
+void projectRing(DstRing& dst, const SrcRing& src) {
+	dst.resize(src.size());
+	for (std::size_t i = 0; i < src.size(); ++i) {
+		geom::set<0>(dst[i], geom::get<0>(src[i]));
+		geom::set<1>(dst[i], latp2lat(geom::get<1>(src[i])));
+	}
+}
+
+#if BOOST_VERSION >= 106700
+double OsmLuaProcessing::projectedPolygonArea(const Polygon &p) {
+	areaPolygonCache.inners().resize(p.inners().size());
+	projectRing(areaPolygonCache.outer(), p.outer());
+	for (std::size_t i = 0; i < p.inners().size(); ++i) {
+		projectRing(areaPolygonCache.inners()[i], p.inners()[i]);
+	}
+
+	geom::strategy::area::spherical<> sph_strategy(RadiusMeter);
+	return geom::area(areaPolygonCache, sph_strategy);
+}
+#endif
+
 // Returns area
 double OsmLuaProcessing::Area() {
 	if (!IsClosed()) return 0;
 
 #if BOOST_VERSION >= 106700
-	geom::strategy::area::spherical<> sph_strategy(RadiusMeter);
 	if (isRelation) {
 		// Boost won't calculate area of a multipolygon, so we just total up the member polygons
-		return multiPolygonArea(multiPolygonCached());
+		double totalArea = 0;
+		const MultiPolygon &mp = multiPolygonCached();
+		for (MultiPolygon::const_iterator it = mp.begin(); it != mp.end(); ++it) {
+			totalArea += projectedPolygonArea(*it);
+		}
+		return totalArea;
 	} else if (isWay) {
-		// Reproject back into lat/lon and then run Boo
-		geom::model::polygon<DegPoint> p;
-		geom::assign(p,polygonCached());
-		geom::for_each_point(p, reverse_project);
-		return geom::area(p, sph_strategy);
+		return projectedPolygonArea(polygonCached());
 	}
 #else
 	if (isRelation) {

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -652,10 +652,12 @@ void OsmLuaProcessing::Layer(const string &layerName, bool area) {
 			}
 			else if (isWay) {
 				//Is there a more efficient way to do this?
-				Linestring ls = linestringCached();
+				const Linestring &ls = linestringCached();
 				Polygon p;
+				p.outer().reserve(ls.size());
 				geom::assign_points(p, ls);
-				mp.push_back(p);
+				mp.reserve(1);
+				mp.push_back(std::move(p));
 
 				auto correctionResult = CorrectGeometry(mp);
 				if(correctionResult == CorrectGeometryResult::Invalid) return;
@@ -872,8 +874,10 @@ Point OsmLuaProcessing::calculateCentroid(CentroidAlgorithm algorithm) {
 				geom::centroid(ls, centroid);
 			}
 		} else {
+			const Linestring &ls = linestringCached();
 			Polygon p;
-			geom::assign_points(p, linestringCached());
+			p.outer().reserve(ls.size());
+			geom::assign_points(p, ls);
 
 			if (algorithm == CentroidAlgorithm::Polylabel) {
 				// CONSIDER: pick precision intelligently

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -4,6 +4,7 @@
 using namespace std;
 
 thread_local GeometryCache<Linestring> linestringCache;
+thread_local std::vector<LatpLon> wayNodes;
 
 OsmMemTiles::OsmMemTiles(
 	size_t threadNum,
@@ -87,10 +88,10 @@ Geometry OsmMemTiles::buildWayGeometry(
 }
 
 void OsmMemTiles::populateLinestring(Linestring& ls, NodeID objectID) const {
-	std::vector<LatpLon> nodes = wayStore.at(OSM_ID(objectID));
-	ls.reserve(nodes.size());
+	wayStore.at(OSM_ID(objectID), wayNodes);
+	ls.reserve(wayNodes.size());
 
-	for (const LatpLon& node : nodes) {
+	for (const LatpLon& node : wayNodes) {
 		boost::geometry::range::push_back(ls, boost::geometry::make<Point>(node.lon/10000000.0, node.latp/10000000.0));
 	}
 }

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -34,6 +34,7 @@ LatpLon OsmMemTiles::buildNodeGeometry(
 		Linestring& ls = getOrBuildLinestring(objectID);
 		Point centroid;
 		Polygon p;
+		p.outer().reserve(ls.size());
 		geom::assign_points(p, ls);
 		geom::centroid(p, centroid);
 		return LatpLon{(int32_t)(centroid.y()*10000000.0), (int32_t)(centroid.x()*10000000.0)};
@@ -124,8 +125,10 @@ void OsmMemTiles::populateMultiPolygon(MultiPolygon& dst, NodeID objectID) {
 	Linestring ls;
 	populateLinestring(ls, objectID);
 	Polygon p;
+	p.outer().reserve(ls.size());
 	geom::assign_points(p, ls);
-	dst.push_back(p);
+	dst.reserve(dst.size() + 1);
+	dst.push_back(std::move(p));
 }
 
 void OsmMemTiles::Clear() {

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -85,6 +85,7 @@ Geometry OsmMemTiles::buildWayGeometry(
 
 void OsmMemTiles::populateLinestring(Linestring& ls, NodeID objectID) const {
 	std::vector<LatpLon> nodes = wayStore.at(OSM_ID(objectID));
+	ls.reserve(nodes.size());
 
 	for (const LatpLon& node : nodes) {
 		boost::geometry::range::push_back(ls, boost::geometry::make<Point>(node.lon/10000000.0, node.latp/10000000.0));

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -62,7 +62,8 @@ Geometry OsmMemTiles::buildWayGeometry(
 		geom::append(current_ls, ls[0]);
 
 		for(size_t i = 1; i < ls.size(); ++i) {
-			if(!geom::intersects(Linestring({ ls[i-1], ls[i] }), bbox.clippingBox)) {
+			boost::geometry::model::segment<Point> segment(ls[i-1], ls[i]);
+			if(!geom::intersects(segment, bbox.clippingBox)) {
 				if(current_ls.size() > 1)
 					out.push_back(std::move(current_ls));
 				current_ls.clear();

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -60,6 +60,7 @@ Geometry OsmMemTiles::buildWayGeometry(
 			return out;
 
 		Linestring current_ls;
+		current_ls.reserve(ls.size());
 		geom::append(current_ls, ls[0]);
 
 		for(size_t i = 1; i < ls.size(); ++i) {
@@ -68,6 +69,7 @@ Geometry OsmMemTiles::buildWayGeometry(
 				if(current_ls.size() > 1)
 					out.push_back(std::move(current_ls));
 				current_ls.clear();
+				current_ls.reserve(ls.size() - i);
 			}
 			geom::append(current_ls, ls[i]);
 		}

--- a/src/osm_mem_tiles.cpp
+++ b/src/osm_mem_tiles.cpp
@@ -60,6 +60,14 @@ Geometry OsmMemTiles::buildWayGeometry(
 		if(ls.empty())
 			return out;
 
+		Box extBox = bbox.getExtendBox();
+		const double minX = extBox.min_corner().x(), maxX = extBox.max_corner().x();
+		const double minY = extBox.min_corner().y(), maxY = extBox.max_corner().y();
+		auto pointInsideExtBox = [minX, maxX, minY, maxY](const Point& p) {
+			return p.x() >= minX && p.x() <= maxX && p.y() >= minY && p.y() <= maxY;
+		};
+		bool needsIntersection = !pointInsideExtBox(ls[0]);
+
 		Linestring current_ls;
 		current_ls.reserve(ls.size());
 		geom::append(current_ls, ls[0]);
@@ -73,13 +81,18 @@ Geometry OsmMemTiles::buildWayGeometry(
 				current_ls.reserve(ls.size() - i);
 			}
 			geom::append(current_ls, ls[i]);
+			if (!needsIntersection)
+				needsIntersection = !pointInsideExtBox(ls[i]);
 		}
 
 		if(current_ls.size() > 1)
 			out.push_back(std::move(current_ls));
 
+		if (!needsIntersection)
+			return out;
+
 		MultiLinestring result;
-		geom::intersection(out, bbox.getExtendBox(), result);
+		geom::intersection(out, extBox, result);
 		return result;
 
 	}

--- a/src/sharded_way_store.cpp
+++ b/src/sharded_way_store.cpp
@@ -24,16 +24,22 @@ void ShardedWayStore::batchStart() {
 }
 
 std::vector<LatpLon> ShardedWayStore::at(WayID wayid) const {
+	std::vector<LatpLon> rv;
+	at(wayid, rv);
+	return rv;
+}
+
+void ShardedWayStore::at(WayID wayid, std::vector<LatpLon>& output) const {
 	for (int i = 0; i < shards(); i++) {
 		size_t index = (lastWayShard + i) % shards();
 		if (stores[index]->contains(0, wayid)) {
 			lastWayShard = index;
-			return stores[index]->at(wayid);
+			stores[index]->at(wayid, output);
+			return;
 		}
 	}
 
-	// Superfluous return to silence a compiler warning
-	return stores[shards() - 1]->at(wayid);
+	stores[shards() - 1]->at(wayid, output);
 }
 
 bool ShardedWayStore::requiresNodes() const {
@@ -78,4 +84,3 @@ const WayStore& ShardedWayStore::shard(size_t shard) const {
 }
 
 size_t ShardedWayStore::shards() const { return nodeStore.shards(); }
-

--- a/src/sorted_node_store.cpp
+++ b/src/sorted_node_store.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <map>
 #include <bitset>
+#include <array>
 #include "sorted_node_store.h"
 #include "external/libpopcnt.h"
 #include "external/streamvbyte.h"
@@ -14,15 +15,26 @@ namespace SortedNodeStoreTypes {
 	const uint16_t ChunkSize = 256;
 	const uint16_t ChunkAlignment = 16;
 	const uint32_t ChunkCompressed = 1 << 31;
+	const uint8_t ChunkCacheSize = 4;
+
+	struct CachedChunk {
+		CachedChunk(): id(-1) {}
+
+		int64_t id;
+		std::array<int32_t, ChunkSize> lons;
+		std::array<int32_t, ChunkSize> latps;
+	};
 
 	struct ThreadStorage {
 		ThreadStorage():
 			collectingOrphans(true),
 			groupStart(-1),
 			localNodes(nullptr),
-			cachedChunk(-1),
 			arenaSpace(0),
-			arenaPtr(nullptr) {}
+			arenaPtr(nullptr) {
+				for (uint8_t i = 0; i < ChunkCacheSize; ++i)
+					cacheOrder[i] = i;
+			}
 		// When SortedNodeStore first starts, it's not confident that it has seen an
 		// entire segment, so it's in "collecting orphans" mode. Once it crosses a
 		// threshold of 64K elements, it ceases to be in this mode.
@@ -33,9 +45,8 @@ namespace SortedNodeStoreTypes {
 		uint64_t groupStart = -1;
 		std::vector<NodeStore::element_t>* localNodes = nullptr;
 
-		int64_t cachedChunk = -1;
-		std::vector<int32_t> cacheChunkLons;
-		std::vector<int32_t> cacheChunkLatps;
+		std::array<CachedChunk, ChunkCacheSize> cacheChunks;
+		std::array<uint8_t, ChunkCacheSize> cacheOrder;
 
 		uint32_t arenaSpace = 0;
 		char* arenaPtr = nullptr;
@@ -52,6 +63,13 @@ namespace SortedNodeStoreTypes {
 
 		auto& rv = threadStorage.back();
 		return rv.second;
+	}
+
+	void promoteCacheSlot(ThreadStorage& tls, size_t orderIndex) {
+		const uint8_t slot = tls.cacheOrder[orderIndex];
+		for (size_t i = orderIndex; i > 0; --i)
+			tls.cacheOrder[i] = tls.cacheOrder[i - 1];
+		tls.cacheOrder[0] = slot;
 	}
 }
 
@@ -166,25 +184,40 @@ LatpLon SortedNodeStore::at(const NodeID id) const {
 
 		const size_t neededChunk = groupIndex * ChunkSize + chunk;
 
-		// Really naive caching strategy - just cache the last-used chunk.
-		// Probably good enough?
+		// Keep a few recently decoded chunks per worker. Way geometry tends to
+		// revisit adjacent chunks, but not always the immediately preceding one.
 		ThreadStorage& tls = s(this);
-		if (tls.cachedChunk != neededChunk) {
-			tls.cachedChunk = neededChunk;
-			tls.cacheChunkLons.reserve(256);
-			tls.cacheChunkLatps.reserve(256);
+		size_t orderIndex = ChunkCacheSize;
+		for (size_t i = 0; i < ChunkCacheSize; ++i) {
+			if (tls.cacheChunks[tls.cacheOrder[i]].id == neededChunk) {
+				orderIndex = i;
+				break;
+			}
+		}
+
+		size_t cacheSlot;
+		if (orderIndex == ChunkCacheSize) {
+			cacheSlot = tls.cacheOrder[ChunkCacheSize - 1];
+			CachedChunk& cached = tls.cacheChunks[cacheSlot];
+			cached.id = neededChunk;
 
 			uint8_t* latpData = ptr->data;
 			uint8_t* lonData = ptr->data + latpSize;
 			uint32_t recovdata[256] = {0};
 
 			streamvbyte_decode(latpData, recovdata, n);
-			tls.cacheChunkLatps[0] = ptr->firstLatp;
-			zigzag_delta_decode(recovdata, &tls.cacheChunkLatps[1], n, tls.cacheChunkLatps[0]);
+			cached.latps[0] = ptr->firstLatp;
+			zigzag_delta_decode(recovdata, &cached.latps[1], n, cached.latps[0]);
 
 			streamvbyte_decode(lonData, recovdata, n);
-			tls.cacheChunkLons[0] = ptr->firstLon;
-			zigzag_delta_decode(recovdata, &tls.cacheChunkLons[1], n, tls.cacheChunkLons[0]);
+			cached.lons[0] = ptr->firstLon;
+			zigzag_delta_decode(recovdata, &cached.lons[1], n, cached.lons[0]);
+
+			promoteCacheSlot(tls, ChunkCacheSize - 1);
+		} else {
+			cacheSlot = tls.cacheOrder[orderIndex];
+			if (orderIndex != 0)
+				promoteCacheSlot(tls, orderIndex);
 		}
 
 		size_t nodeOffset = 0;
@@ -195,7 +228,8 @@ LatpLon SortedNodeStore::at(const NodeID id) const {
 		if (!(ptr->nodeMask[nodeMaskByte] & (1 << nodeMaskBit)))
 			throw std::out_of_range("SortedNodeStore: node " + std::to_string(id) + " missing, no node");
 
-		return { tls.cacheChunkLatps[nodeOffset], tls.cacheChunkLons[nodeOffset] };
+		const CachedChunk& cached = tls.cacheChunks[cacheSlot];
+		return { cached.latps[nodeOffset], cached.lons[nodeOffset] };
 	}
 
 	UncompressedChunkInfo* ptr = (UncompressedChunkInfo*)basePtr;

--- a/src/sorted_way_store.cpp
+++ b/src/sorted_way_store.cpp
@@ -194,6 +194,7 @@ std::vector<LatpLon> SortedWayStore::at(WayID id) const {
 
 	std::vector<NodeID> nodes = SortedWayStore::decodeWay(wayPtr->flags, wayPtr->data);
 	std::vector<LatpLon> rv;
+	rv.reserve(nodes.size());
 	for (const NodeID& node : nodes)
 		rv.push_back(nodeStore.at(node));
 	return rv;

--- a/src/sorted_way_store.cpp
+++ b/src/sorted_way_store.cpp
@@ -28,6 +28,7 @@ namespace SortedWayStoreTypes {
 		uint64_t groupStart;
 		std::vector<std::pair<WayID, std::vector<NodeID>>>* localWays;
 		std::vector<uint8_t> encodedWay;
+		std::vector<NodeID> decodedWay;
 	};
 
 	thread_local std::deque<std::pair<const SortedWayStore*, ThreadStorage>> threadStorage;
@@ -136,6 +137,12 @@ bool SortedWayStore::contains(size_t shard, WayID id) const {
 }
 
 std::vector<LatpLon> SortedWayStore::at(WayID id) const {
+	std::vector<LatpLon> rv;
+	at(id, rv);
+	return rv;
+}
+
+void SortedWayStore::at(WayID id, std::vector<LatpLon>& rv) const {
 	const size_t groupIndex = id / (GroupSize * ChunkSize);
 	const size_t chunk = (id % (GroupSize * ChunkSize)) / ChunkSize;
 	const uint64_t chunkMaskByte = chunk / 8;
@@ -192,12 +199,13 @@ std::vector<LatpLon> SortedWayStore::at(WayID id) const {
 		wayPtr = (EncodedWay*)(endOfWayOffsetPtr + chunkPtr->wayOffsets[wayOffset] * LargeWayAlignment);
 	}
 
-	std::vector<NodeID> nodes = SortedWayStore::decodeWay(wayPtr->flags, wayPtr->data);
-	std::vector<LatpLon> rv;
+	ThreadStorage& tls = s(this);
+	SortedWayStore::decodeWay(wayPtr->flags, wayPtr->data, tls.decodedWay);
+	const std::vector<NodeID>& nodes = tls.decodedWay;
+	rv.clear();
 	rv.reserve(nodes.size());
 	for (const NodeID& node : nodes)
 		rv.push_back(nodeStore.at(node));
-	return rv;
 }
 
 void SortedWayStore::insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) {
@@ -317,11 +325,18 @@ void SortedWayStore::collectOrphans(const std::vector<std::pair<WayID, std::vect
 
 std::vector<NodeID> SortedWayStore::decodeWay(uint16_t flags, const uint8_t* input) {
 	std::vector<NodeID> rv;
+	decodeWay(flags, input, rv);
+	return rv;
+};
+
+void SortedWayStore::decodeWay(uint16_t flags, const uint8_t* input, std::vector<NodeID>& rv) {
+	rv.clear();
 
 	bool isCompressed = flags & CompressedWay;
 	bool isClosed = flags & ClosedWay;
 
 	const uint16_t length = flags & 0b0000011111111111;
+	rv.reserve(length + (isClosed ? 1 : 0));
 
 	if (!(flags & UniformUpperBits)) {
 		// The nodes don't all share the same upper int; unpack which
@@ -367,7 +382,6 @@ std::vector<NodeID> SortedWayStore::decodeWay(uint16_t flags, const uint8_t* inp
 
 	if (isClosed)
 		rv.push_back(rv[0]);
-	return rv;
 };
 
 uint16_t SortedWayStore::encodeWay(const std::vector<NodeID>& way, std::vector<uint8_t>& output, bool compress) {

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -231,7 +231,8 @@ Geometry TileDataSource::buildWayGeometry(OutputGeometryType const geomType,
 			geom::append(current_ls, ls[0]);
 
 			for(size_t i = 1; i < ls.size(); ++i) {
-				if(!geom::intersects(Linestring({ ls[i-1], ls[i] }), bbox.clippingBox)) {
+				boost::geometry::model::segment<Point> segment(ls[i-1], ls[i]);
+				if(!geom::intersects(segment, bbox.clippingBox)) {
 					if(current_ls.size() > 1)
 						out.push_back(std::move(current_ls));
 					current_ls.clear();

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -227,6 +227,14 @@ Geometry TileDataSource::buildWayGeometry(OutputGeometryType const geomType,
 			if(ls.empty())
 				return out;
 
+			Box extBox = bbox.getExtendBox();
+			const double minX = extBox.min_corner().x(), maxX = extBox.max_corner().x();
+			const double minY = extBox.min_corner().y(), maxY = extBox.max_corner().y();
+			auto pointInsideExtBox = [minX, maxX, minY, maxY](const Point& p) {
+				return p.x() >= minX && p.x() <= maxX && p.y() >= minY && p.y() <= maxY;
+			};
+			bool needsIntersection = !pointInsideExtBox(ls[0]);
+
 			Linestring current_ls;
 			geom::append(current_ls, ls[0]);
 
@@ -238,13 +246,18 @@ Geometry TileDataSource::buildWayGeometry(OutputGeometryType const geomType,
 					current_ls.clear();
 				}
 				geom::append(current_ls, ls[i]);
+				if (!needsIntersection)
+					needsIntersection = !pointInsideExtBox(ls[i]);
 			}
 
 			if(current_ls.size() > 1)
 				out.push_back(std::move(current_ls));
 
+			if (!needsIntersection)
+				return out;
+
 			MultiLinestring result;
-			geom::intersection(out, bbox.getExtendBox(), result);
+			geom::intersection(out, extBox, result);
 			return result;
 		}
 

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -340,7 +340,10 @@ Geometry TileDataSource::buildWayGeometry(OutputGeometryType const geomType,
 			}
 
 			MultiPolygon mp;
-			geom::assign(mp, input);
+			if (cachedClip == nullptr)
+				mp = std::move(uncached);
+			else
+				geom::assign(mp, input);
 			fast_clip(mp, box);
 			geom::correct(mp);
 			geom::validity_failure_type failure = geom::validity_failure_type::no_failure;
@@ -353,7 +356,13 @@ Geometry TileDataSource::buildWayGeometry(OutputGeometryType const geomType,
 				}
 				if (!valid && (failure==geom::failure_self_intersections || failure==geom::failure_intersecting_interiors)) {
 					MultiPolygon output;
-					geom::intersection(input, box, output);
+					if (cachedClip == nullptr) {
+						MultiPolygon original;
+						populateMultiPolygon(original, objectID);
+						geom::intersection(original, box, output);
+					} else {
+						geom::intersection(input, box, output);
+					}
 					geom::correct(output);
 
 					// retry with Boost intersection if fast_clip has caused self-intersections

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -594,5 +594,15 @@ NodeID TileDataSource::storeMultiLinestring(const MultiLinestring& src) {
 
 void TileDataSource::populateMultiPolygon(MultiPolygon& dst, NodeID objectID) {
 	const auto &input = retrieveMultiPolygon(objectID);
-	boost::geometry::assign(dst, input);
+	dst.resize(input.size());
+	for(std::size_t i = 0; i < input.size(); ++i) {
+		dst[i].outer().resize(input[i].outer().size());
+		boost::geometry::assign(dst[i].outer(), input[i].outer());
+
+		dst[i].inners().resize(input[i].inners().size());
+		for(std::size_t j = 0; j < input[i].inners().size(); ++j) {
+			dst[i].inners()[j].resize(input[i].inners()[j].size());
+			boost::geometry::assign(dst[i].inners()[j], input[i].inners()[j]);
+		}
+	}
 }

--- a/src/tile_data.cpp
+++ b/src/tile_data.cpp
@@ -477,7 +477,7 @@ void TileDataSource::addGeometryToIndex(
 	const std::vector<OutputObject>& outputs,
 	const uint64_t id
 ) {
-	for (Linestring ls : geom) {
+	for (const auto& ls : geom) {
 		unordered_set<TileCoordinates> tileSet;
 		insertIntermediateTiles(ls, indexZoom, tileSet);
 		for (auto it = tileSet.begin(); it != tileSet.end(); ++it) {
@@ -496,7 +496,7 @@ void TileDataSource::addGeometryToIndex(
 ) {
 	unordered_set<TileCoordinates> tileSet;
 	bool singleOuter = geom.size()==1;
-	for (Polygon poly : geom) {
+	for (const auto& poly : geom) {
 		unordered_set<TileCoordinates> tileSetTmp;
 		insertIntermediateTiles(poly.outer(), indexZoom, tileSetTmp);
 		fillCoveredTiles(tileSetTmp);

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -10,6 +10,7 @@ using namespace std;
 extern bool verbose;
 
 thread_local bool enabledUserSignal = false;
+thread_local MultiPolygon scaledMultiPolygon;
 typedef std::vector<OutputObjectID>::const_iterator OutputObjectsConstIt;
 typedef std::pair<OutputObjectsConstIt, OutputObjectsConstIt> OutputObjectsConstItPair;
 
@@ -220,7 +221,8 @@ void writeMultiPolygon(
 	unsigned simplifyAlgo,
 	const MultiPolygon& mp
 ) {
-	MultiPolygon current = bbox.scaleGeometry(mp);
+	bbox.scaleGeometry(scaledMultiPolygon, mp);
+	MultiPolygon &current = scaledMultiPolygon;
 	if (simplifyLevel>0) {
 		if (simplifyAlgo == LayerDef::VISVALINGAM) {
 			current = simplifyVis(current, simplifyLevel/bbox.xscale);

--- a/src/visvalingam.cpp
+++ b/src/visvalingam.cpp
@@ -49,6 +49,10 @@ struct visItem {
 struct minHeap {
 	std::vector<visItem *> h;
 
+	void Reserve(size_t size) {
+		h.reserve(size);
+	}
+
 	void Push(visItem *item) {
 		item->index = h.size();
 		h.push_back(item);
@@ -142,9 +146,9 @@ struct minHeap {
 
 template<typename GeometryType>
 static double doubleTriangleArea(GeometryType const &ls, int start, int i1, int i2, int i3) {
-	Point a = ls[i1 + start];
-	Point b = ls[i2 + start];
-	Point c = ls[i3 + start];
+	Point const &a = ls[i1 + start];
+	Point const &b = ls[i2 + start];
+	Point const &c = ls[i3 + start];
 
 	return std::abs((b.x() - a.x()) * (c.y() - a.y()) - (b.y() - a.y()) * (c.x() - a.x()));
 }
@@ -158,6 +162,7 @@ GeometryType visvalingam(const GeometryType &ls, double threshold, size_t retain
 
 	// build the initial minheap linked list.
 	minHeap heap;
+	heap.Reserve(end - start);
 
 	visItem linkedListStart;
 	linkedListStart.area = INFINITY;
@@ -232,6 +237,7 @@ GeometryType visvalingam(const GeometryType &ls, double threshold, size_t retain
 	}
 
 	GeometryType output;
+	output.reserve(end - start - removed);
 	visItem *item = &linkedListStart;
 	while (item != NULL) {
 		output.emplace_back(ls[item->pointIndex + start]);
@@ -250,6 +256,7 @@ Polygon simplifyVis(const Polygon &p, double max_distance) {
 	Polygon output;
 	double threshold = max_distance * max_distance * 4;
 	output.outer() = visvalingam(p.outer(), threshold, 4);
+	output.inners().reserve(p.inners().size());
 	for (const auto &ring : p.inners()) {
 		output.inners().emplace_back(visvalingam(ring, threshold, 4));
 	}
@@ -257,6 +264,7 @@ Polygon simplifyVis(const Polygon &p, double max_distance) {
 }
 MultiPolygon simplifyVis(const MultiPolygon &mp, double max_distance) { 
 	MultiPolygon output;
+	output.reserve(mp.size());
 	for (const auto &p : mp) {
 		output.emplace_back(simplifyVis(p, max_distance));
 	}

--- a/src/way_stores.cpp
+++ b/src/way_stores.cpp
@@ -23,8 +23,14 @@ bool BinarySearchWayStore::contains(size_t shard, WayID id) const {
 }
 
 std::vector<LatpLon> BinarySearchWayStore::at(WayID wayid) const {
+	std::vector<LatpLon> rv;
+	at(wayid, rv);
+	return rv;
+}
+
+void BinarySearchWayStore::at(WayID wayid, std::vector<LatpLon>& rv) const {
 	std::lock_guard<std::mutex> lock(mutex);
-	
+
 	auto iter = std::lower_bound(mLatpLonLists->begin(), mLatpLonLists->end(), wayid, [](auto const &e, auto wayid) { 
 		return e.first < wayid; 
 	});
@@ -32,12 +38,11 @@ std::vector<LatpLon> BinarySearchWayStore::at(WayID wayid) const {
 	if(iter == mLatpLonLists->end() || iter->first != wayid)
 		throw std::out_of_range("Could not find way with id " + std::to_string(wayid));
 
-	std::vector<LatpLon> rv;
+	rv.clear();
 	rv.reserve(iter->second.size());
 	// TODO: copy iter->second to rv more efficiently
 	for (const LatpLon& el : iter->second)
 		rv.push_back(el);
-	return rv;
 }
 
 void BinarySearchWayStore::insertLatpLons(std::vector<WayStore::ll_element_t> &newWays) {


### PR DESCRIPTION
This PR is AI generated.

## Summary

In a warmed Austria OpenMapTiles tile generation run, this reduced wall time by
about 6.4% and user CPU by about 9-10%. In heaptrack runs on a smaller fixture,
allocation calls fell by about 47% and temporary allocations by about 74%.

This PR reduces allocation churn and unnecessary geometry work in several hot
paths used while generating tiles.

The changes are grouped around the same goal: keep existing output behavior,
but avoid repeated temporary allocations, avoid avoidable geometry copies, and
skip cheap-to-detect no-op work before it reaches heavier geometry routines.

The largest measured effect is in tile generation with the OpenMapTiles
profile: fewer geometry/vector reallocations, fewer decoded sorted-node chunks,
and less work in clipping/indexing paths.

## Implementation

### Node and way lookup hot paths

- Cache a small number of recent sorted-node chunks per worker instead of only
  one chunk.
- Avoid copying geometry while indexing objects.
- Fill way geometry buffers directly instead of building temporary output and
  copying it afterward.
- Reserve OSMStore and way geometry buffers before filling them.

These changes target repeated lookups and geometry population during PBF-backed
tile generation.

### Geometry construction and scaling

- Move freshly built or corrected rings into their destination containers where
  the source is no longer needed.
- Pre-size populated multipolygons and closed-way polygon rings.
- Reserve split-linestring and Visvalingam output storage.
- Reuse projection/scaling output buffers for polygon area and scaled geometry
  calculations.

These changes reduce short-lived `std::vector` allocation/reallocation in
geometry preparation paths.

### Clipping and intersection paths

- Reuse the scratch ring used by the fast polygon clipper.
- Skip fast clipping for bounded linestrings that are already inside the clip
  box.
- Use line segments directly for line tile-intersection checks.
- Reuse dissolve intersection output storage.
- Move uncached multipolygons into the clipping path instead of copying them
  when the current function owns the geometry.
- Skip Sutherland-Hodgman edge passes when no point needs clipping against that
  edge.

These changes keep the same clipping model, but reduce repeated temporary
storage and avoid unnecessary pass-through clipping work.

## Performance

I compared current upstream master with this performance stack applied directly
on top of upstream master, without other unmerged PRs.

Branches/binaries:

```text
upstream: b437d7c
performance stack: ba8db48
```

Runtime fixture:

```text
fixture: Austria Geofabrik extract
profile: OpenMapTiles profile
output: PMTiles
store: no --store
threads: 8
warmup: PBF plus coastline/landcover sidecar files
```

Three alternating warmed runs, upstream first:

```text
wall time:   -2.19s  (-6.42%)
user CPU:    -19.34s (-9.28%)
system CPU:  +2.09s  (+6.00%)
RSS:         -47.6 MiB (-1.07%)
```

Three alternating warmed runs, performance stack first:

```text
wall time:   -2.17s  (-6.38%)
user CPU:    -20.05s (-9.75%)
system CPU:  +2.21s  (+5.93%)
RSS:         +47.4 MiB (+1.08%)
```

The wall-time and user-CPU improvement reproduced in both orders. RSS moved in
opposite directions depending on run order, so I would treat native RSS as
neutral rather than claiming a memory saving.

Perf counters from the warmed forward run:

```text
instructions:      -10.63%
cycles:            -7.08%
task clock:        -7.38%
branches:          -10.16%
branch misses:     -3.62%
cache references:  -3.12%
cache misses:      -3.52%
L1 loads:          -8.66%
L1 load misses:    -5.02%
dTLB loads:        -3.60%
dTLB load misses:  -4.08%
```

Allocation profile:

```text
fixture: Liechtenstein Geofabrik extract
same profile/output/thread shape
```

Heaptrack/Massif over three pairs:

```text
allocation calls:       -3,492,919 (-46.72%)
temporary allocations:    -650,325 (-73.87%)
heaptrack runtime:          -2.49s (-36.23%)
heaptrack peak heap: unchanged at 2 GiB
Massif peak total:       +21.31 MB (+1.09%)
Massif stack peak:       +48 bytes (+0.05%)
leaked bytes: unchanged
```

Raw allocation counts:

| metric | upstream | performance stack | delta |
|---|---:|---:|---:|
| allocation calls | 7,475,754 | 3,982,835 | -3,492,919 |
| temporary allocations | 880,362.7 | 230,037.3 | -650,325.3 |

## Possible Regressions

The changes are intended to preserve generated tile behavior. They mostly alter
temporary storage ownership, reserve sizes, and fast-path checks.

Potential risks:

- The sorted-node cache keeps a few decoded chunks per worker instead of one,
  which may retain a small amount of extra per-thread cache memory.
- Some geometry buffers now reserve or reuse capacity more deliberately. This
  reduces allocation churn, but retained capacity may slightly change heap
  shape.
- The clipping fast paths depend on existing bounds checks. Incorrect bounds
  handling would be a correctness bug, so those changes are kept narrow and
  only skip work when the existing geometry is already inside the tested box or
  no points need clipping for a given edge.

## Testing

Code checks:

```sh
git diff --check
```

Build:

```sh
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build --parallel 8
```

CTest:

```sh
ctest --test-dir build --output-on-failure
```

Result:

```text
No tests were found
```
