### PR TITLE
Fix UsedWays bounds check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ test: \
 	test_significant_tags \
 	test_sorted_node_store \
 	test_sorted_way_store \
+	test_osm_store \
 	test_tile_coordinates_set
 
 test_append_vector: \
@@ -187,6 +188,10 @@ test_options_parser: \
 	src/options_parser.o \
 	test/options_parser.test.o
 	$(CXX) $(CXXFLAGS) -o test.options_parser $^ $(INC) $(LIB) $(LDFLAGS) && ./test.options_parser
+
+test_osm_store: \
+	test/osm_store.test.o
+	$(CXX) $(CXXFLAGS) -o test.osm_store $^ $(INC) $(LIB) $(LDFLAGS) && ./test.osm_store
 
 test_pooled_string: \
 	src/mmap_allocator.o \

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -78,13 +78,13 @@ public:
 	// Mark a way as used
 	void insert(WayID wayid) {
 		std::lock_guard<std::mutex> lock(mutex);
-		if (wayid>usedList.size()) usedList.resize(wayid+256);
+		if (wayid>=usedList.size()) usedList.resize(wayid+256);
 		usedList[wayid] = true;
 	}
 	
 	// See if a way is used
 	bool at(WayID wayid) const {
-		return (wayid>usedList.size()) ? false : usedList[wayid];
+		return (wayid>=usedList.size()) ? false : usedList[wayid];
 	}
 	
 	void clear() {

--- a/test/osm_store.test.cpp
+++ b/test/osm_store.test.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+#include "external/minunit.h"
+#include "osm_store.h"
+
+MU_TEST(test_usedways_grows_for_first_index) {
+	UsedWays usedWays;
+	usedWays.insert(0);
+	mu_check(usedWays.at(0));
+}
+
+MU_TEST(test_usedways_grows_at_current_size) {
+	UsedWays usedWays;
+	usedWays.insert(0);
+	usedWays.insert(256);
+	mu_check(usedWays.at(256));
+}
+
+MU_TEST_SUITE(test_suite_osm_store) {
+	MU_RUN_TEST(test_usedways_grows_for_first_index);
+	MU_RUN_TEST(test_usedways_grows_at_current_size);
+}
+
+int main() {
+	MU_RUN_SUITE(test_suite_osm_store);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}


### PR DESCRIPTION
This PR is AI generated.

## Summary

- fixes `UsedWays` bounds checks when the requested way id is exactly the
  current `usedList.size()`
- adds a small regression test for the first insert and exact-size growth cases

## Background

`UsedWays` stores relation-used way ids in a `std::vector<bool>`. Its existing
checks used `wayid > usedList.size()`, then indexed `usedList[wayid]`. When
`wayid == usedList.size()`, that is one past the end of the vector.

That can produce undefined behavior in both directions:

- `insert()` can write past the end instead of growing the vector first
- `at()` can read past the end instead of returning `false`

I checked the history around this code. The surrounding `UsedWays` storage was
introduced for memory savings, and later retained during relation-processing
changes, but I did not find a rationale for treating the exact-size boundary as
valid.

## Change

Use `>=` for the resize/read boundary so the vector grows before an exact-end
write, and exact-end reads are reported as absent.

This keeps the existing growth strategy and data structure unchanged.

## Expected Behavior

There should be no intended output change except avoiding undefined behavior at
the vector boundary. The exact-boundary case now grows by the same `+256`
increment that nearby out-of-range ids already used.

## Testing

- `git diff --check`
- `make test_osm_store`
- RelWithDebInfo CMake configure/build
- `ctest --output-on-failure` (no CMake tests are registered in this repo)
