### PR TITLE
Fix shapefile z6 index

### DIFF
--- a/src/shp_mem_tiles.cpp
+++ b/src/shp_mem_tiles.cpp
@@ -82,7 +82,7 @@ bool ShpMemTiles::mayIntersect(const std::string& layerName, const Box& box) con
 			uint32_t z6x = x / (1u << (spatialIndexZoom - CLUSTER_ZOOM));
 			uint32_t z6y = y / (1u << (spatialIndexZoom - CLUSTER_ZOOM));
 
-			auto& bitvec = sparseLayerVector[z6x * CLUSTER_ZOOM + z6y];
+			auto& bitvec = sparseLayerVector[z6x * CLUSTER_ZOOM_WIDTH + z6y];
 
 			uint32_t divisor = 1u << (spatialIndexZoom - CLUSTER_ZOOM);
 			uint64_t index = 2u * ((x - z6x * divisor) * divisor + (y - z6y * divisor));
@@ -214,7 +214,7 @@ void ShpMemTiles::StoreGeometry(
 			uint32_t z6x = x / (1u << (spatialIndexZoom - CLUSTER_ZOOM));
 			uint32_t z6y = y / (1u << (spatialIndexZoom - CLUSTER_ZOOM));
 
-			uint32_t sparseIndex = z6x * CLUSTER_ZOOM + z6y;
+			uint32_t sparseIndex = z6x * CLUSTER_ZOOM_WIDTH + z6y;
 			auto& bitvec = sparseLayerVector[sparseIndex];
 
 			if (bitvec.empty())


### PR DESCRIPTION
This PR is AI generated.

## Summary

- fixes the sparse shapefile bitmap index so each z6 tile uses a distinct slot
- replaces `CLUSTER_ZOOM` with `CLUSTER_ZOOM_WIDTH` in the flattened z6 index
  calculation

## Background

`ShpMemTiles` stores an indexed shapefile bitmap in a sparse outer vector with
one entry per z6 tile. The comments describe the outer vector as a z6 grid.

Two lookup paths flattened that grid with:

```cpp
z6x * CLUSTER_ZOOM + z6y
```

`CLUSTER_ZOOM` is the zoom level, not the width of the z6 grid. At z6 the grid
width is `1 << 6`, exposed as `CLUSTER_ZOOM_WIDTH`. Multiplying by the zoom
level aliases unrelated z6 cells into the same sparse bitmap slot.

I checked the history around the sparse shapefile bitmap. I found the memory
and lazy-refinement rationale for the bitmap, but not a rationale for using the
zoom value as the row stride.

## Change

Use `CLUSTER_ZOOM_WIDTH` as the row stride in both:

- `ShpMemTiles::mayIntersect()`
- `ShpMemTiles::StoreGeometry()`

The bitmap layout, lazy refinement behavior, and memory model are otherwise
unchanged.

## Expected Behavior

Indexed shapefile intersection checks should no longer share bitmap state
between unrelated z6 cells. This can prevent false positives or false negatives
caused by aliasing and should make shapefile-backed output more consistent with
the intended spatial index.

The memory footprint of the outer sparse vector is unchanged; this changes
which existing slot is used, not the number of slots.

## Testing

- `git diff --check`
- RelWithDebInfo CMake configure/build
- `ctest --output-on-failure` (no CMake tests are registered in this repo)
