### PR TITLE
Read relation blocks without multipolygons

### DIFF
--- a/src/pbf_processor.cpp
+++ b/src/pbf_processor.cpp
@@ -279,7 +279,7 @@ bool PbfProcessor::ReadRelations(
 	int boundaryKey = findStringPosition(pb, "boundary");
 	int innerKey= findStringPosition(pb, "inner");
 	int outerKey= findStringPosition(pb, "outer");
-	if (typeKey >-1 && mpKey>-1) {
+	if (typeKey >-1) {
 		int j = -1;
 		for (PbfReader::Relation pbfRelation : pg.relations()) {
 			j++;


### PR DESCRIPTION
This PR is AI generated.

## Summary

- allows relation primitive blocks to be processed even when the block string
  table does not contain `"multipolygon"`
- keeps the existing per-relation filtering and multipolygon/boundary handling

## Background

`ReadRelations()` skipped an entire relation primitive block unless the block
string table contained both `"type"` and `"multipolygon"`:

```cpp
if (typeKey >-1 && mpKey>-1) {
```

That means a valid block containing boundaries or custom relations, but no
literal `"multipolygon"` string, never reached the existing relation loop.

The later per-relation logic already handles non-multipolygon relations:

- `relationIsType()` returns `false` when a value key is missing
- boundary relations are handled separately
- custom relation writing remains gated by `output.canWriteRelations()`

I checked the history around relation processing. The guard appears to have
come from the older multipolygon-only path and survived later relation support;
I did not find a rationale for skipping whole blocks solely because the
`"multipolygon"` string is absent.

## Change

Enter the relation loop whenever the block has a `"type"` key. Leave the
existing per-relation checks to decide whether each relation is a multipolygon,
boundary, custom writable relation, or should be skipped.

## Expected Behavior

Profiles that only need multipolygons should behave the same. Profiles that
write or scan other relation types can now see valid relation blocks that were
previously skipped when `"multipolygon"` was absent from the block string table.

The change may process more relation blocks for profiles that enable custom
relation writing, but those blocks were already intended to be considered by
the later filtering logic.

## Testing

- `git diff --check`
- RelWithDebInfo CMake configure/build
- `ctest --output-on-failure` (no CMake tests are registered in this repo)
