### PR TITLE
Skip duplicate shapefile points

### DIFF
--- a/src/shp_processor.cpp
+++ b/src/shp_processor.cpp
@@ -30,7 +30,6 @@ void ShpProcessor::fillPointArrayFromShapefile(vector<Point> *points, SHPObject 
 			prevx = x[i];
 			prevy = latp;
 		}
-		points->emplace_back(geom::make<Point>(x[i], lat2latp(y[i])));
 	}
 }
 


### PR DESCRIPTION
This PR is AI generated.

## Summary

- removes an unconditional shapefile point append that bypassed the existing
  duplicate-point filter
- leaves the existing tolerance-based duplicate filtering unchanged

## Background

`ShpProcessor::fillPointArrayFromShapefile()` checks each vertex against the
previous accepted point before appending it. Immediately after that guarded
append, the function appended the same source vertex again unconditionally.

That second append means duplicate filtering did not actually filter the points
that it rejected, and accepted points were appended twice.

I checked the history around this code. The duplicate-point filter was
introduced to skip duplicated shapefile points; I did not find a rationale for
the later unconditional append, and it contradicts the comment and guarded
logic above it.

## Change

Remove the unconditional append so points are only added through the existing
duplicate check.

## Expected Behavior

Shapefile geometry loading should produce fewer repeated adjacent points. This
can reduce geometry size and downstream processing work for shapefile-backed
layers without changing the intended coordinate transformation or tolerance.

Visual output should either be unchanged or lose zero-length duplicate segments
that were not intended to be present.

## Testing

- `git diff --check`
- RelWithDebInfo CMake configure/build
- `ctest --output-on-failure` (no CMake tests are registered in this repo)
