### PR TITLE
Optimise locking when storing types per key

### DIFF
--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <unordered_set>
 
 #include "osm_lua_processing.h"
 #include "attribute_store.h"
@@ -17,7 +18,7 @@ const std::string EMPTY_STRING = "";
 thread_local kaguya::State *g_luaState = nullptr;
 thread_local OsmLuaProcessing* osmLuaProcessing = nullptr;
 
-std::mutex vectorLayerMetadataMutex;
+std::deque<std::mutex> vectorLayerMetadataMutexes;
 std::unordered_map<std::string, std::string> OsmLuaProcessing::dataStore;
 std::mutex OsmLuaProcessing::dataStoreMutex;
 
@@ -241,6 +242,9 @@ OsmLuaProcessing::OsmLuaProcessing(
 	materializeGeometries(materializeGeometries) {
 
 	sigusr1Handler.initialize();
+	if (vectorLayerMetadataMutexes.size() <= layers.layers.size()) {
+		vectorLayerMetadataMutexes.resize(layers.layers.size() + 1);
+	}
 
 	// ----	Initialise Lua
 	g_luaState = &luaState;
@@ -1031,9 +1035,14 @@ std::string OsmLuaProcessing::FindInRelation(const std::string &key) {
 }
 
 // Record attribute name/type for vector_layers table
+thread_local std::vector<std::unordered_set<std::string>> alreadySeen;
+
 void OsmLuaProcessing::setVectorLayerMetadata(const uint_least8_t layer, const string &key, const uint type) {
-	std::lock_guard<std::mutex> lock(vectorLayerMetadataMutex);
+	if (alreadySeen.size() <= layer) alreadySeen.resize(layer + 1);
+	if (alreadySeen[layer].count(key)) return;
+	std::lock_guard<std::mutex> lock(vectorLayerMetadataMutexes[layer]);
 	layers.layers[layer].attributeMap[key] = type;
+	alreadySeen[layer].insert(key);
 }
 
 // Scan relation (but don't write geometry)


### PR DESCRIPTION
In #877 @pa5cal identified a slowdown caused by locking when we write to `attributeMap` for a given layer, which we use to record the types for each attribute in the vector tile (eventually written into the `vector_layers` JSON).

We had some discussion of fixes in the thread, and then in true "you wait three months for a bus" fashion, we also have #912 which also provides a fix. This PR takes from those to provide the simplest possible solution:

- We keep a record of what keys per layer have already been written in thread_local storage
- We use an `unordered_set`, which means we can use `count` to avoid the `find`/`end` threading issue
- We aren't worried about subsequently checking the type: first one always wins

I think this should achieve the issue while keeping the code compact and readable for what is a fairly marginal feature (the `vector_layers` JSON isn't used by most consumers). I've done some moderate testing on this but would be happy to see further reports.