### PR TITLE
Increase AttributeStore lookup cache size

### DIFF
--- a/src/attribute_store.cpp
+++ b/src/attribute_store.cpp
@@ -101,8 +101,8 @@ const AttributePair& AttributePairStore::getPairUnsafe(uint32_t i) const {
 thread_local uint64_t tlsPairLookups = 0;
 thread_local uint64_t tlsPairLookupsUncached = 0;
 
-thread_local std::vector<const AttributePair*> cachedAttributePairPointers(64);
-thread_local std::vector<uint32_t> cachedAttributePairIndexes(64);
+thread_local std::vector<const AttributePair*> cachedAttributePairPointers(256);
+thread_local std::vector<uint32_t> cachedAttributePairIndexes(256);
 uint32_t AttributePairStore::addPair(AttributePair& pair, bool isHot) {
 	if (isHot) {
 		{
@@ -300,8 +300,8 @@ void AttributeSet::finalize() {
 
 // Remember recently queried/added sets so that we can return them in the
 // future without taking a lock.
-thread_local std::vector<const AttributeSet*> cachedAttributeSetPointers(64);
-thread_local std::vector<AttributeIndex> cachedAttributeSetIndexes(64);
+thread_local std::vector<const AttributeSet*> cachedAttributeSetPointers(256);
+thread_local std::vector<AttributeIndex> cachedAttributeSetIndexes(256);
 
 thread_local uint64_t tlsSetLookups = 0;
 thread_local uint64_t tlsSetLookupsUncached = 0;


### PR DESCRIPTION
This PR is AI generated.

## Summary

This is the AttributeStore cache-size part split out from #912, as requested
after #913 extracted the vector-layer metadata update cache.

It increases the small thread-local AttributeStore lookup caches from 64 to 256
entries:

- `cachedAttributePairPointers`
- `cachedAttributePairIndexes`
- `cachedAttributeSetPointers`
- `cachedAttributeSetIndexes`

The lookup behavior, shard selection, locking behavior, and generated output
semantics are otherwise unchanged.

## Background

`AttributeStore` already uses small thread-local direct-mapped caches to avoid
falling through to the shared sharded stores for repeated attribute pair/set
lookups. Large OpenMapTiles runs can have enough hot attribute combinations
that the current 64-entry caches collide frequently.

This keeps the existing cache design, but gives common attribute pairs and sets
more room to remain in the local worker cache.

## Performance

During candidate acceptance, this was measured on a warmed Austria
OpenMapTiles run with PMTiles output, no `--store`, and `--threads 8`. The
comparison was run in both forward and reverse alternating order on the
submitted/open PR stack used for performance investigations.

Combined six-run result:

| metric | baseline mean | candidate mean | delta | delta % |
|---|---:|---:|---:|---:|
| wall time | 36.398 s | 36.263 s | -0.135 s | -0.37% |
| user CPU | 223.018 s | 222.582 s | -0.437 s | -0.20% |
| system CPU | 22.345 s | 22.220 s | -0.125 s | -0.56% |
| peak RSS | 4,453,069 KiB | 4,402,425 KiB | -50,644 KiB | -1.14% |
| minor faults | 1,198,395 | 1,168,575 | -29,820 | -2.49% |
| voluntary context switches | 175,208 | 170,864 | -4,345 | -2.48% |
| involuntary context switches | 2,633 | 2,925 | +292 | +11.08% |

The runtime effect is small, but it reduced minor faults, voluntary context
switches, and peak RSS on that fixture.

## Possible Regressions

The intended output behavior is unchanged.

The cost is slightly larger thread-local vectors per worker thread:

- pair pointer cache: 64 -> 256 entries
- pair index cache: 64 -> 256 entries
- set pointer cache: 64 -> 256 entries
- set index cache: 64 -> 256 entries

This is still a small fixed-size per-thread cache and does not change shared
store ownership or synchronization.

## Testing

Build:

```sh
cmake -S . -B local-builds/attribute-store-lookup-cache-size -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build local-builds/attribute-store-lookup-cache-size --parallel 8
```

Code style:

```sh
git diff --check
```

Semantic checks from candidate acceptance:

```text
fixture: Liechtenstein Geofabrik extract
profile: OpenMapTiles profile

baseline repeat changed_tiles 0
candidate repeat changed_tiles 0
baseline -> candidate changed_tiles 0
```
