### PR TITLE
Fix AppendVector random access iterator

### DIFF
--- a/include/append_vector.h
+++ b/include/append_vector.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <queue>
 #include <cstdint>
+#include <iterator>
 
 // Tilemaker collects OutputObjects in a list that
 // - spills to disk
@@ -32,114 +33,111 @@ namespace AppendVectorNS {
 			using reference         = T&;
 
 			Iterator(AppendVector<T>& appendVector, uint16_t vec, uint16_t offset):
-				appendVector(&appendVector), vec(vec), offset(offset) {}
+				appendVector(&appendVector), index(difference_type(vec) * APPEND_VECTOR_SIZE + offset) {}
 
 			Iterator():
-				appendVector(nullptr), vec(0), offset(0) {}
+				appendVector(nullptr), index(0) {}
 
 
 			bool operator<(const Iterator& other) const {
-				if (vec < other.vec)
-					return true;
+				return index < other.index;
+			}
 
-				if (vec > other.vec)
-					return false;
+			bool operator>(const Iterator& other) const {
+				return other < *this;
+			}
 
-				return offset < other.offset;
+			bool operator<=(const Iterator& other) const {
+				return !(other < *this);
 			}
 
 			bool operator>=(const Iterator& other) const {
 				return !(*this < other);
 			}
 
-			Iterator operator-(int delta) const {
-				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
-				absolute -= delta;
-				return Iterator(*appendVector, absolute / APPEND_VECTOR_SIZE, absolute % APPEND_VECTOR_SIZE);
+			Iterator operator-(difference_type delta) const {
+				Iterator result = *this;
+				result -= delta;
+				return result;
 			}
 
-			Iterator operator+(int delta) const {
-				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
-				absolute += delta;
-				return Iterator(*appendVector, absolute / APPEND_VECTOR_SIZE, absolute % APPEND_VECTOR_SIZE);
+			Iterator operator+(difference_type delta) const {
+				Iterator result = *this;
+				result += delta;
+				return result;
+			}
+
+			friend Iterator operator+(difference_type delta, const Iterator& iterator) {
+				return iterator + delta;
 			}
 
 			bool operator==(const Iterator& other) const {
-				return appendVector == other.appendVector && vec == other.vec && offset == other.offset;
+				return appendVector == other.appendVector && index == other.index;
 			}
 
 			bool operator!=(const Iterator& other) const {
 				return !(*this == other);
 			}
 
-			std::ptrdiff_t operator-(const Iterator& other) const {
-				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
-				int64_t otherAbsolute = other.vec * APPEND_VECTOR_SIZE + other.offset;
-
-				return absolute - otherAbsolute;
+			difference_type operator-(const Iterator& other) const {
+				return index - other.index;
 			}
 
 			reference operator*() const {
-				auto& vector = appendVector->vecs[vec];
-				auto& el = vector[offset];
+				auto& vector = appendVector->vecs[index / APPEND_VECTOR_SIZE];
+				auto& el = vector[index % APPEND_VECTOR_SIZE];
 				return el;
 			}
 
+			reference operator[](difference_type delta) const {
+				return *(*this + delta);
+			}
+
 			pointer operator->() const {
-				auto& vector = appendVector->vecs[vec];
-				auto& el = vector[offset];
+				auto& vector = appendVector->vecs[index / APPEND_VECTOR_SIZE];
+				auto& el = vector[index % APPEND_VECTOR_SIZE];
 				return &el;
 			}
 
-			Iterator& operator+= (int delta) {
-				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
-				absolute += delta;
-
-				vec = absolute / APPEND_VECTOR_SIZE;
-				offset = absolute % APPEND_VECTOR_SIZE;
+			Iterator& operator+= (difference_type delta) {
+				index += delta;
 				return *this;
 			}
 
-			Iterator& operator-= (int delta) {
-				int64_t absolute = vec * APPEND_VECTOR_SIZE + offset;
-				absolute -= delta;
-
-				vec = absolute / APPEND_VECTOR_SIZE;
-				offset = absolute % APPEND_VECTOR_SIZE;
+			Iterator& operator-= (difference_type delta) {
+				index -= delta;
 				return *this;
 			}
 
 			// Prefix increment
 			Iterator& operator++() {
-				offset++;
-				if (offset == APPEND_VECTOR_SIZE) {
-					offset = 0;
-					vec++;
-				}
+				index++;
 				return *this;
 			}  
 
 			// Postfix increment
-			Iterator operator++(int) { Iterator tmp = *this; ++(*this); return tmp; }
+			Iterator operator++(int) {
+				Iterator result = *this;
+				++*this;
+				return result;
+			}
 
 			// Prefix decrement
 			Iterator& operator--() {
-				if (offset > 0) {
-					offset--;
-				} else {
-					vec--;
-					offset = APPEND_VECTOR_SIZE - 1;
-				}
-
+				index--;
 				return *this;
 			}
 
 			// Postfix decrement
-			Iterator operator--(int) { Iterator tmp = *this; --(*this); return tmp; }
+			Iterator operator--(int) {
+				Iterator result = *this;
+				--*this;
+				return result;
+			}
 
 		private:
 			mutable AppendVector<T>* appendVector;
-			int32_t vec, offset;
+			difference_type index;
 		};
 
 		AppendVector():

--- a/test/append_vector.test.cpp
+++ b/test/append_vector.test.cpp
@@ -1,4 +1,6 @@
 #include <iostream>
+#include <iterator>
+#include <type_traits>
 #include <boost/sort/sort.hpp>
 #include "external/minunit.h"
 #include "append_vector.h"
@@ -30,6 +32,32 @@ MU_TEST(test_append_vector) {
 	mu_check(*(vec.end() - 2) == 9998);
 	mu_check(*(vec.end() - 9000) == 1000);
 	mu_check(*(vec.begin() - -1) == 1);
+	mu_check(vec.begin()[25] == 25);
+	mu_check(25 + vec.begin() == vec.begin() + 25);
+	mu_check((vec.begin() + 25) - vec.begin() == 25);
+	mu_check(vec.end() - vec.begin() == 10000);
+	mu_check(vec.begin() < vec.end());
+	mu_check(vec.begin() <= vec.begin());
+	mu_check(vec.end() > vec.begin());
+	mu_check(vec.end() >= vec.end());
+
+	auto postfix = vec.begin();
+	mu_check(*(postfix++) == 0);
+	mu_check(*postfix == 1);
+	mu_check(*(postfix--) == 1);
+	mu_check(*postfix == 0);
+
+	const int32_t chunkBoundary = 8192;
+	auto boundary = vec.begin();
+	boundary += chunkBoundary;
+	mu_check(*boundary == chunkBoundary);
+	boundary -= 1;
+	mu_check(*boundary == chunkBoundary - 1);
+
+	static_assert(std::is_same<
+		std::iterator_traits<AppendVector<int32_t>::Iterator>::iterator_category,
+		std::random_access_iterator_tag
+	>::value, "AppendVector iterator should advertise random access");
 
 	boost::sort::block_indirect_sort(
 		vec.begin(),
@@ -95,4 +123,3 @@ int main() {
 	MU_REPORT();
 	return MU_EXIT_CODE;
 }
-


### PR DESCRIPTION
This PR was prepared with AI assistance.

`AppendVector::Iterator` advertises itself as a random access iterator and is
used by tile sorting code through Boost sorting algorithms. Several iterator
operations were implemented by repeatedly converting between chunk/offset and
absolute positions, while other random-access operations expected by sorting
implementations were missing.

This changes the iterator to track a single absolute index, then derive the
underlying chunk and offset only when dereferencing. It also fills out the
random-access operations used by standard/Boost sorting code, including
comparisons, iterator distance, offset addition/subtraction, and indexing.

The existing `append_vector` test now exercises the random-access operations,
including postfix movement and movement across the internal chunk boundary.

Why
---

On a current MSVC toolchain, an Austria-sized OpenMapTiles build could crash
while finalizing z6 output tiles, inside sorting of `AppendVector` iterators.
Diagnostics showed the sorter reaching an invalid iterator position before the
beginning of the vector. Making the iterator arithmetic use one absolute
position avoids inconsistent chunk/offset state and makes the advertised
iterator category match the supported operations.

Crash evidence
--------------

This appears to be exposed by newer MSVC/STL behavior rather than by the input
data. Older VS 2022/MSVC builds used locally had not reproduced this crash, but
the Windows artifact from a newer GitHub Actions release run on the fork
(`Symmetricity/tilemaker` run `27551026617`, artifact `7640269070`) reproduced
an access violation while generating Austria tiles. The user-visible failure was
`0xc0000005` during z6 finalization, around:

- `osm: finalizing z6 tile 2135/4096`

Rebuilding the same code shape with the current Windows toolchain
(MSVC 19.51 / VS 18 2026 Build Tools) also reproduced the crash. A diagnostic
build showed the active sort was `OutputObjectXY` over about 12.7 million
objects:

- `source=osm`, `type=OutputObjectXY`, `indexZoom=14`, `threads=8`,
  `objects=12680604`
- invalid iterator state: `vec=-1`, `offset=8191`, `absolute=-1`
- previous iterator state: `vec=0`, `offset=8190`, `absolute=8190`

That points to an iterator arithmetic/contract issue being surfaced by the
newer sort implementation. With this patch, the same MSVC 19.51 build completed
both Austria MBTiles and PMTiles generation.

Testing
---

- `cmake -S . -B ... -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build ... --parallel 8`
- `make test_append_vector`
- `make test`
- Windows MSVC 19.51 build with the `x64-windows-static-md` vcpkg triplet
- Windows Austria OpenMapTiles MBTiles generation: exit 0
- Windows Austria OpenMapTiles PMTiles generation: exit 0

Performance
-----------

Compared an upstream master build against the same commit plus this change,
using the same RelWithDebInfo build shape and OpenMapTiles profile.
The Austria PMTiles runtime/RSS profile used three alternating runs in each
order. Wall time was effectively unchanged between the forward and reverse
orders. A small peak-RSS high-water movement was observed, but heaptrack and
Massif on a smaller fixture showed allocation counts and heap shape unchanged,
so this does not appear to introduce a meaningful allocation regression.
