### PR TITLE
Simplify buildings algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ file(GLOB tilemaker_src_files
 	src/shp_mem_tiles.cpp
 	src/shp_processor.cpp
 	src/significant_tags.cpp
+	src/simplify_buildings.cpp
 	src/sorted_node_store.cpp
 	src/sorted_way_store.cpp
 	src/tag_map.cpp

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ tilemaker: \
 	src/shp_mem_tiles.o \
 	src/shp_processor.o \
 	src/significant_tags.o \
+	src/simplify_buildings.o \
 	src/sorted_node_store.o \
 	src/sorted_way_store.o \
 	src/tag_map.o \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,7 +77,7 @@ You can add optional parameters to layers:
 * `simplify_level` - how much to simplify features (in degrees of longitude) on the zoom level `simplify_below-1`
 * `simplify_length` - how much to simplify features (in kilometers) on the zoom level `simplify_below-1`, preceding `simplify_level`
 * `simplify_ratio` - (optional: the default value is 2.0) the actual simplify level will be `simplify_level * pow(simplify_ratio, (simplify_below-1) - <current zoom>)`
-* `simplify_algorithm` - which simplification algorithm to use (defaults to Douglas-Peucker; you can also specify `"visvalingam"`, which can be better for landuse and similar polygons)
+* `simplify_algorithm` - which simplification algorithm to use (defaults to Douglas-Peucker; you can also specify `"visvalingam"`, which can be better for landuse and similar polygons, or `"buildings"`, which preserves rectilinear shapes)
 * `filter_below` - filter areas by minimum size below this zoom level
 * `filter_area` - minimum size (in square degrees of longitude) for the zoom level `filter_below-1`
 * `feature_limit` - restrict the number of features written to each tile

--- a/include/geom.h
+++ b/include/geom.h
@@ -34,6 +34,7 @@ typedef boost::geometry::model::polygon<Point> Polygon;
 typedef boost::geometry::model::multi_polygon<Polygon> MultiPolygon;
 typedef boost::geometry::model::multi_linestring<Linestring> MultiLinestring;
 typedef boost::geometry::model::box<Point> Box;
+typedef boost::geometry::model::segment<Point> Segment;
 typedef boost::geometry::ring_type<Polygon>::type Ring;
 typedef boost::geometry::interior_type<Polygon>::type InteriorRing;
 typedef boost::variant<Point,Linestring,MultiLinestring,MultiPolygon> Geometry;

--- a/include/shared_data.h
+++ b/include/shared_data.h
@@ -46,6 +46,7 @@ struct LayerDef {
 	
 	static const uint DOUGLAS_PEUCKER = 0;
 	static const uint VISVALINGAM = 1;
+	static const uint BUILDINGS = 2;
 };
 
 ///\brief Defines layers used in map rendering

--- a/include/simplify_buildings.h
+++ b/include/simplify_buildings.h
@@ -1,0 +1,38 @@
+/*! \file */ 
+#ifndef _SIMPLIFY_BUILDINGS_H
+#define _SIMPLIFY_BUILDINGS_H
+
+struct BuildingSimplifyConfig {
+	// "Short" segment: the short side of the stub being removed (in coordinate units).
+	// For lat/lon coordinates use e.g. 5.0/100000.0; scale accordingly for projected coords.
+	double distance_filter = 5.0 / 100000.0;
+
+	// Area guard: don't remove stubs where d1*d2 (product of the two stub sides) exceeds this.
+	// Prevents collapsing significant right-angle jogs.  Set very large to disable.
+	double area_filter = 50.0;
+
+	// Narrow-edge exception: bypass the area guard when either stub side is shorter than this.
+	double area_narrow = 2.0;
+
+	// Minimum sine of the angle between the two outer lines (ring[km1]→ring[k] and
+	// ring[kp2]→ring[kp3]).  When these lines are nearly parallel their intersection is at
+	// infinity; the fallback midpoint passes the length check via the triangle inequality
+	// and destroys a significant corner.  0.1 ≈ sin(5.7°) — reject anything more parallel.
+	static constexpr double PARALLEL_TOL = 0.1;
+
+	// Degrees tolerance for removing collinear points (straight-line removal).
+	static constexpr double COLLINEAR_TOL = 8.0;
+
+	// Degrees tolerance for snapping the intersection to a right angle.
+	static constexpr double SNAP_TOL = 3.0;
+
+	// Parametric tolerance for the proper-intersection test: values in [tol, 1-tol] count.
+	// Keeps endpoint-touching segments from being treated as intersecting.
+	static constexpr double INTERSECT_TOL = 0.001;
+};
+
+void simplify_building(Polygon &poly, const BuildingSimplifyConfig &cfg);
+void simplify_building(MultiPolygon &mp, const BuildingSimplifyConfig &cfg);
+void simplifyBuildings(MultiPolygon &mp, double max_distance);
+
+#endif //_SIMPLIFY_BUILDINGS_H

--- a/src/geom.cpp
+++ b/src/geom.cpp
@@ -225,26 +225,68 @@ bool repair_multi_polygon(MultiPolygon &mp)
 
 // ---------------
 // Union multipolygons
-// from https://github.com/boostorg/geometry/discussions/947
+// Groups polygons into connected components by bbox intersection (via R-tree +
+// union-find), then runs the binary reduction only within each component.
+// Disjoint polygons are concatenated directly, skipping the expensive union_()
+// call that Boost still runs even for non-overlapping geometry.
 void union_many(std::vector<MultiPolygon> &to_unify) {
-	if (to_unify.size()<2) return;
-	size_t step = 1;
-	size_t half_step;
+	if (to_unify.size() < 2) return;
 
-	// the outer loop doubles the distance between two polygons to be merged at every iteration
-	do {
-		half_step = step;
-		step *= 2;
-		size_t i = 0;
+	namespace bgi = boost::geometry::index;
+	typedef std::pair<Box, size_t> BoxIdx;
 
-		// the inner loop merges polygons at i and i+half_step storing the result at i
+	std::vector<Box> boxes(to_unify.size());
+	for (size_t i = 0; i < to_unify.size(); i++)
+		boost::geometry::envelope(to_unify[i], boxes[i]);
+
+	// Union-find with path compression
+	std::vector<size_t> parent(to_unify.size());
+	for (size_t i = 0; i < to_unify.size(); i++) parent[i] = i;
+	std::function<size_t(size_t)> find = [&](size_t x) -> size_t {
+		return parent[x] == x ? x : (parent[x] = find(parent[x]));
+	};
+
+	// Incrementally build an R-tree; unite each polygon with all prior ones
+	// whose bboxes intersect (transitivity is handled by union-find)
+	bgi::rtree<BoxIdx, bgi::quadratic<16>> rtree;
+	for (size_t i = 0; i < to_unify.size(); i++) {
+		for (auto const &v : rtree | bgi::adaptors::queried(bgi::intersects(boxes[i]))) {
+			size_t ri = find(i), rj = find(v.second);
+			if (ri != rj) parent[ri] = rj;
+		}
+		rtree.insert({boxes[i], i});
+	}
+
+	// Bucket indices by component root (roots are in 0..n-1)
+	std::vector<std::vector<size_t>> components(to_unify.size());
+	for (size_t i = 0; i < to_unify.size(); i++)
+		components[find(i)].push_back(i);
+
+	// Union within each component; concatenate all results into to_unify[0]
+	MultiPolygon result;
+	for (auto &comp : components) {
+		if (comp.empty()) continue;
+		if (comp.size() == 1) {
+			for (auto &p : to_unify[comp[0]]) result.push_back(std::move(p));
+			continue;
+		}
+		std::vector<MultiPolygon> sub;
+		sub.reserve(comp.size());
+		for (size_t idx : comp) sub.push_back(std::move(to_unify[idx]));
+
+		size_t step = 1, half_step;
 		do {
-			MultiPolygon unified;
-			boost::geometry::union_(to_unify.at(i), to_unify.at(i + half_step), unified);
-			to_unify.at(i) = std::move(unified);
-			i += step;
-		} while (i + half_step < to_unify.size());
-	} while (step < to_unify.size());
+			half_step = step; step *= 2;
+			for (size_t i = 0; i + half_step < sub.size(); i += step) {
+				MultiPolygon unified;
+				boost::geometry::union_(sub[i], sub[i + half_step], unified);
+				sub[i] = std::move(unified);
+			}
+		} while (step < sub.size());
+
+		for (auto &p : sub[0]) result.push_back(std::move(p));
+	}
+	to_unify[0] = std::move(result);
 }
 
 // ---------------

--- a/src/shared_data.cpp
+++ b/src/shared_data.cpp
@@ -324,7 +324,8 @@ void Config::readConfig(rapidjson::Document &jsonConfig, bool &hasClippingBox, B
 		int    combinePolyBelow=it->value.HasMember("combine_polygons_below") ? it->value["combine_polygons_below"].GetInt() : 0;
 		bool sortZOrderAscending = it->value.HasMember("z_order_ascending") ? it->value["z_order_ascending"].GetBool() : (featureLimit==0);
 		string algo           = it->value.HasMember("simplify_algorithm") ? it->value["simplify_algorithm"].GetString() : "";
-		uint simplifyAlgo = algo=="visvalingam" ? LayerDef::VISVALINGAM : LayerDef::DOUGLAS_PEUCKER;
+		uint simplifyAlgo = algo=="visvalingam" ? LayerDef::VISVALINGAM : 
+		                    algo=="buildings"   ? LayerDef::BUILDINGS : LayerDef::DOUGLAS_PEUCKER;
 		string source = it->value.HasMember("source") ? it->value["source"].GetString() : "";
 		vector<string> sourceColumns;
 		bool allSourceColumns = false;

--- a/src/simplify_buildings.cpp
+++ b/src/simplify_buildings.cpp
@@ -1,0 +1,309 @@
+#include "geom.h"
+#include "simplify_buildings.h"
+#include <vector>
+#include <array>
+#include <cmath>
+#include <algorithm>
+#include <iostream>
+
+// Building simplification algorithm
+// This aims to retain the typical rectilinear shape of a building while reducing vertices. Based on original Ruby code.
+
+// Rtree storing (bounding_box, segment_endpoints) for self-intersection detection.
+// We identify segments by their endpoint coordinates so we can skip segments that
+// are being replaced during a candidate check, without needing index stability.
+typedef std::pair<Point, Point> seg_pts;
+typedef std::pair<Box, seg_pts> rtree_val;
+typedef boost::geometry::index::rtree<rtree_val, boost::geometry::index::quadratic<16>> seg_rtree;
+
+
+// ============================================================
+// Low-level geometry helpers
+// ============================================================
+
+static double seg_len(const Point &a, const Point &b) {
+	double dx = b.x()-a.x(), dy = b.y()-a.y();
+	return std::sqrt(dx*dx + dy*dy);
+}
+
+static Box make_box(const Point &a, const Point &b) {
+	Box box;
+	boost::geometry::envelope(Segment(a, b), box);
+	return box;
+}
+
+static void rtree_add(seg_rtree &rt, const Point &a, const Point &b) {
+	rt.insert({make_box(a, b), {a, b}});
+}
+
+// Convert a closed Boost ring to an open std::vector<point>
+static std::vector<Point> ring_to_open(const Ring &r) {
+	std::vector<Point> v(r.begin(), r.end());
+	if (v.size() > 1 &&
+	    v.front().x() == v.back().x() && v.front().y() == v.back().y())
+		v.pop_back();
+	return v;
+}
+
+// Write an open vector back into a Boost ring (re-closing it)
+static void open_to_ring(const std::vector<Point> &v, Ring &r) {
+	r.clear();
+	for (auto const &p : v) r.push_back(p);
+	if (!v.empty()) r.push_back(v[0]);
+}
+
+// Add all segments of an open ring to an rtree
+static void add_ring_to_rtree(const std::vector<Point> &v, seg_rtree &rt) {
+	size_t n = v.size();
+	for (size_t k = 0; k < n; k++)
+		rtree_add(rt, v[k], v[(k+1)%n]);
+}
+
+// Proper-intersection test (interior crossing only)
+static bool properly_intersects(const Point &l1, const Point &l2,
+                                const Point &m1, const Point &m2,
+                                double tol = 0.001) {
+	double a=l1.x(), b=l1.y(), c=l2.x(), d=l2.y();
+	double p=m1.x(), q=m1.y(), r=m2.x(), s=m2.y();
+	double det = (c-a)*(s-q) - (r-p)*(d-b);
+	if (det == 0.0) return false;
+	double lv = ((s-q)*(r-a) + (p-r)*(s-b)) / det;
+	double gv = ((b-d)*(r-a) + (c-a)*(s-b)) / det;
+	return (tol < lv && lv < 1.0-tol) && (tol < gv && gv < 1.0-tol);
+}
+
+// Query the rtree for segments that properly intersect (a→b), skipping the four
+// segments listed in `skip` (identified by exact endpoint coordinates — these are
+// the segments being replaced in the current candidate operation).
+static bool hits_rtree(const Point &a, const Point &b,
+                        const seg_rtree &rt,
+                        const std::array<seg_pts,4> &skip,
+                        double tol) {
+	Box bbox = make_box(a, b);
+	for (auto const &v : rt | boost::geometry::index::adaptors::queried(
+	                               boost::geometry::index::intersects(bbox))) {
+		const Point &p1 = v.second.first;
+		const Point &p2 = v.second.second;
+		bool is_skip = false;
+		for (auto const &sk : skip) {
+			if ((p1.x()==sk.first.x()  && p1.y()==sk.first.y() &&
+			     p2.x()==sk.second.x() && p2.y()==sk.second.y()) ||
+			    (p1.x()==sk.second.x() && p1.y()==sk.second.y() &&
+			     p2.x()==sk.first.x()  && p2.y()==sk.first.y())) {
+				is_skip = true; break;
+			}
+		}
+		if (!is_skip && properly_intersects(a, b, p1, p2, tol)) return true;
+	}
+	return false;
+}
+
+// Check against a foreign rtree (other rings already simplified — no skip needed).
+static bool hits_foreign(const Point &a, const Point &b,
+                         const seg_rtree &rt, double tol) {
+	Box bbox = make_box(a, b);
+	for (auto const &v : rt | boost::geometry::index::adaptors::queried(
+	                               boost::geometry::index::intersects(bbox))) {
+		if (properly_intersects(a, b, v.second.first, v.second.second, tol)) return true;
+	}
+	return false;
+}
+
+// ============================================================
+// Step 1: Remove collinear points
+// ============================================================
+
+// Signed turn angle at 'turn' in degrees, normalised to [0, 360).
+static double turn_angle(const Point &from, const Point &turn, const Point &to) {
+	double rad = std::atan2(to.y()-turn.y(), to.x()-turn.x())
+	           - std::atan2(from.y()-turn.y(), from.x()-turn.x());
+	double deg = rad * (180.0 / M_PI);
+	return deg - 360.0 * std::floor(deg / 360.0);
+}
+
+// Remove points whose turn angle is within tol° of 180° (collinear with neighbours).
+static void remove_collinear(std::vector<Point> &ring) {
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		size_t n = ring.size();
+		for (size_t i = 1; i+1 < n; i++) {
+			double a = turn_angle(ring[i-1], ring[i], ring[i+1]);
+			if (a >= 180.0-BuildingSimplifyConfig::COLLINEAR_TOL && a <= 180.0+BuildingSimplifyConfig::COLLINEAR_TOL) {
+				ring.erase(ring.begin() + i);
+				changed = true;
+				break;
+			}
+		}
+	}
+}
+
+// ============================================================
+// Step 2: Find intersection of two extended lines
+// ============================================================
+
+// Returns the intersection point of the line through pL1→pL2 and the line through pM1→pM2.
+// When the angle between them is within snap_tol° of 90°, snaps to an exact right angle
+// by projecting pM2 perpendicularly onto line L.
+// Falls back to midpoint of the two "inner" points if lines are parallel.
+static Point line_intersection(const Point &pL1, const Point &pL2,
+                               const Point &pM1, const Point &pM2) {
+	double xL1=pL1.x(), yL1=pL1.y(), xL2=pL2.x(), yL2=pL2.y();
+	double xM1=pM1.x(), yM1=pM1.y(), xM2=pM2.x(), yM2=pM2.y();
+
+	// Express lines as ax+by+c=0
+	double a1=yL1-yL2, b1=xL2-xL1, c1=(yL2-yL1)*xL1-(xL2-xL1)*yL1;
+	double a2=yM1-yM2, b2=xM2-xM1, c2=(yM2-yM1)*xM1-(xM2-xM1)*yM1;
+
+	// Angle between the two lines
+	double ang = std::atan2(a2*b1-a1*b2, a1*a2+b1*b2) * (180.0/M_PI) + 180.0;
+
+	// Snap to 90°: drop perpendicular from pM2 onto line L
+	// (future: use fast atan2 from https://mazzo.li/posts/vectorized-atan2.html if needed)
+	if ((ang > 90.0-BuildingSimplifyConfig::SNAP_TOL && ang < 90.0+BuildingSimplifyConfig::SNAP_TOL) ||
+	    (ang > 270.0-BuildingSimplifyConfig::SNAP_TOL && ang < 270.0+BuildingSimplifyConfig::SNAP_TOL)) {
+		double denom = (xL2-xL1)*(xL2-xL1) + (yL2-yL1)*(yL2-yL1);
+		if (denom < 1e-20) return Point((xL2+xM1)/2.0, (yL2+yM1)/2.0);
+		double t = ((xM2-xL1)*(xL2-xL1) + (yM2-yL1)*(yL2-yL1)) / denom;
+		return Point(xL1+(xL2-xL1)*t, yL1+(yL2-yL1)*t);
+	}
+
+	// General case: find intersection
+	double num = a1*b2-a2*b1;
+	if (std::abs(num) < 1e-20) return Point((xL2+xM1)/2.0, (yL2+yM1)/2.0);
+	return Point((b1*c2-b2*c1)/num, (c1*a2-c2*a1)/num);
+}
+
+// Simplify a single open ring (ring[0] != ring.back()) in-place.
+// `other_rt` is an optional rtree of already-simplified rings to prevent
+// cross-ring self-intersections (pass nullptr if not needed).
+static void simplify_open_ring(std::vector<Point> &ring,
+                               const BuildingSimplifyConfig &cfg,
+                               const seg_rtree* other_rt = nullptr) {
+	remove_collinear(ring);
+
+	while (true) {
+		size_t m = ring.size();
+		if (m < 4) break;
+
+		// segs[k] = |ring[k] → ring[(k+1)%m]|
+		std::vector<double> segs(m);
+		for (size_t k = 0; k < m; k++)
+			segs[k] = seg_len(ring[k], ring[(k+1)%m]);
+
+		// Build fresh rtree from current ring for this pass
+		seg_rtree rt;
+		for (size_t k = 0; k < m; k++)
+			rtree_add(rt, ring[k], ring[(k+1)%m]);
+
+		double shortest = cfg.distance_filter;
+		int    best     = -1;
+		Point  best_xy;
+
+		for (size_t k = 0; k < m; k++) {
+			if (segs[k] >= shortest) continue;
+
+			double d1 = segs[k];
+			double d2 = segs[(k+1)%m];
+
+			// Area filter: skip if the stub area d1*d2 is too large,
+			// unless one side is a narrow sliver (area_narrow exception).
+			if (d1*d2 > cfg.area_filter && d1 >= cfg.area_narrow && d2 >= cfg.area_narrow)
+				continue;
+
+			// Indices of the six points surrounding the stub.
+			// The stub to remove: ring[k] → ring[kp1] → ring[kp2]
+			// (ring[k] is replaced; ring[kp1] and ring[kp2] are deleted)
+			size_t km1=(k+m-1)%m, km2=(k+m-2)%m;
+			size_t kp1=(k+1)%m, kp2=(k+2)%m, kp3=(k+3)%m;
+
+			// Reject if the two outer lines are nearly parallel.
+			{
+				double dx_L = ring[k].x()-ring[km1].x(), dy_L = ring[k].y()-ring[km1].y();
+				double dx_M = ring[kp3].x()-ring[kp2].x(), dy_M = ring[kp3].y()-ring[kp2].y();
+				double cross = dx_L*dy_M - dy_L*dx_M;
+				double scale = std::sqrt((dx_L*dx_L+dy_L*dy_L) * (dx_M*dx_M+dy_M*dy_M));
+				if (std::abs(cross) < BuildingSimplifyConfig::PARALLEL_TOL * scale) continue;
+			}
+
+			// Intersection of line(ring[km1],ring[k]) and line(ring[kp2],ring[kp3])
+			Point xy = line_intersection(ring[km1], ring[k],
+			                             ring[kp2], ring[kp3]);
+
+			// Reject if the new path (km1→xy→kp3) is longer than the old detour
+			double old_len = segs[km1] + segs[k] + segs[kp1] + segs[kp2];
+			double new_len = seg_len(xy, ring[km1]) + seg_len(xy, ring[kp3]);
+			if (new_len > old_len) continue;
+
+			// Self-intersection check via rtree.
+			// The four segments being replaced are skipped; any other intersection rejects.
+			std::array<seg_pts,4> skip = {{
+				{ring[km1], ring[k]},    // segs[km1]
+				{ring[k],   ring[kp1]}, // segs[k]
+				{ring[kp1], ring[kp2]}, // segs[kp1]
+				{ring[kp2], ring[kp3]}, // segs[kp2]
+			}};
+			if (hits_rtree(ring[km1], xy,        rt, skip, BuildingSimplifyConfig::INTERSECT_TOL)) continue;
+			if (hits_rtree(xy,        ring[kp3], rt, skip, BuildingSimplifyConfig::INTERSECT_TOL)) continue;
+
+			// Cross-ring check (e.g. simplified inners when processing the outer)
+			if (other_rt) {
+				if (hits_foreign(ring[km1], xy,        *other_rt, BuildingSimplifyConfig::INTERSECT_TOL)) continue;
+				if (hits_foreign(xy,        ring[kp3], *other_rt, BuildingSimplifyConfig::INTERSECT_TOL)) continue;
+			}
+
+			shortest = segs[k];
+			best     = (int)k;
+			best_xy  = xy;
+		}
+
+		if (best < 0) break;
+
+		// Apply: delete ring[kp1] and ring[kp2], set ring[k] = best_xy.
+		// Build a new ring to avoid index-shifting bugs on wraparound cases.
+		size_t k   = (size_t)best;
+		size_t kp1 = (k+1)%m, kp2 = (k+2)%m;
+
+		std::vector<Point> new_ring;
+		new_ring.reserve(m-2);
+		for (size_t i = 0; i < m; i++) {
+			if (i == kp1 || i == kp2) continue;
+			new_ring.push_back(i == k ? best_xy : ring[i]);
+		}
+		ring = std::move(new_ring);
+	}
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+// Simplify a single polygon (outer ring + inner rings) in-place.
+void simplify_building(Polygon &poly, const BuildingSimplifyConfig &cfg) {
+	seg_rtree inners_rt;
+
+	for (auto &inner : poly.inners()) {
+		std::vector<Point> open = ring_to_open(inner);
+		simplify_open_ring(open, cfg, inners_rt.empty() ? nullptr : &inners_rt);
+		open_to_ring(open, inner);
+		add_ring_to_rtree(open, inners_rt);
+	}
+
+	std::vector<Point> open = ring_to_open(poly.outer());
+	simplify_open_ring(open, cfg, inners_rt.empty() ? nullptr : &inners_rt);
+	open_to_ring(open, poly.outer());
+}
+
+// Simplify all polygons in a multipolygon.
+void simplify_building(MultiPolygon &mp, const BuildingSimplifyConfig &cfg) {
+	for (auto &poly : mp) simplify_building(poly, cfg);
+}
+
+// Simplify with config derived from standard max_distance
+void simplifyBuildings(MultiPolygon &mp, double max_distance) {
+	BuildingSimplifyConfig cfg;
+	cfg.distance_filter = max_distance;
+	cfg.area_filter = max_distance * max_distance / 2;
+	cfg.area_narrow = max_distance / 2;
+	simplify_building(mp, cfg);
+}

--- a/src/tile_worker.cpp
+++ b/src/tile_worker.cpp
@@ -6,6 +6,7 @@
 #include <signal.h>
 #include "helpers.h"
 #include "visvalingam.h"
+#include "simplify_buildings.h"
 using namespace std;
 extern bool verbose;
 
@@ -120,6 +121,7 @@ void writeMultiLinestring(
 			if (simplifyAlgo==LayerDef::VISVALINGAM) {
 				tmp.push_back(simplifyVis(ls, simplifyLevel));
 			} else {
+				// buildings algorithm not supported for linestrings, so fall back to DP
 				tmp.push_back(simplify(ls, simplifyLevel));
 			}
 		}
@@ -226,6 +228,11 @@ void writeMultiPolygon(
 	if (simplifyLevel>0) {
 		if (simplifyAlgo == LayerDef::VISVALINGAM) {
 			current = simplifyVis(current, simplifyLevel/bbox.xscale);
+		} else if (simplifyAlgo == LayerDef::BUILDINGS) {
+			if (current.size() > 1 || boost::geometry::num_points(current)>5) {
+				geom::correct(current); // self-intersections can break simplification
+				simplifyBuildings(current, simplifyLevel/bbox.xscale);
+			}
 		} else {
 			current = simplify(current, simplifyLevel/bbox.xscale);
 		}


### PR DESCRIPTION
This adds a specialised simplification algorithm for buildings, which aims to preserve their rectilinear nature while reducing vertices. You can try it out using a layer config like this:

    "building": { "minzoom": 13, "maxzoom": 14, "combine_polygons_below": 15,
                  "simplify_algorithm": "buildings", "simplify_below": 15, "simplify_level": 0.0001 }

It works best with `combine_polygons_below`. Typical output is like this:

<img width="1164" height="820" alt="image" src="https://github.com/user-attachments/assets/7f4d21b0-a336-42d5-86f4-e38f46ee6bec" />

from this source data:

<img width="931" height="685" alt="image" src="https://github.com/user-attachments/assets/92b38958-8fbf-4a23-a8d7-75cc34ad763d" />

The algorithm was developed in Ruby, and ported to C++ with the help of Claude.

Performance is moderate - there are some opportunities for optimisation (such as replacing atan2 with a faster implementation), but given that the main impact is from `combine_polygons_below` anyway, this isn't a massive deal.