### PR TITLE
Clamp affected tiles calculation to sane latitudes

### DIFF
--- a/include/coordinates.h
+++ b/include/coordinates.h
@@ -93,6 +93,8 @@ double rad2deg(double rad);
 // max/min latitudes
 constexpr double MaxLat = 85.0511;
 constexpr double MinLat = -MaxLat;
+constexpr double MaxLatp = 180.0;
+constexpr double MinLatp = -MaxLatp;
 
 // Project latitude (spherical Mercator)
 // (if calling with raw coords, remember to divide/multiply by 10000000.0)

--- a/src/coordinates_geom.cpp
+++ b/src/coordinates_geom.cpp
@@ -117,13 +117,15 @@ void impl_insertIntermediateTiles(T const &points, uint baseZoom, std::unordered
 		p2 = *it;
 
 		// Calculate p2 tile, and mark it
-		double tileXf2 = lon2tilexf(p2.x(), baseZoom), tileYf2 = latp2tileyf(p2.y(), baseZoom);
+		double p2y = std::min(MaxLat, std::max(MinLat, p2.y()));
+		double tileXf2 = lon2tilexf(p2.x(), baseZoom), tileYf2 = latp2tileyf(p2y, baseZoom);
 		TileCoordinate tileX2 = static_cast<TileCoordinate>(tileXf2), tileY2 = static_cast<TileCoordinate>(tileYf2);
 		tileSet.insert(TileCoordinates(tileX2, tileY2));
 		if (it == points.begin()) continue;	// first point, so no line
 
 		// Calculate p1 tile
-		double tileXf1 = lon2tilexf(p1.x(), baseZoom), tileYf1 = latp2tileyf(p1.y(), baseZoom);
+		double p1y = std::min(MaxLat, std::max(MinLat, p1.y()));
+		double tileXf1 = lon2tilexf(p1.x(), baseZoom), tileYf1 = latp2tileyf(p1y, baseZoom);
 		TileCoordinate tileX1 = static_cast<TileCoordinate>(tileXf1), tileY1 = static_cast<TileCoordinate>(tileYf1);
 		tileSet.insert(TileCoordinates(tileX1,tileY1));
 

--- a/src/coordinates_geom.cpp
+++ b/src/coordinates_geom.cpp
@@ -117,14 +117,14 @@ void impl_insertIntermediateTiles(T const &points, uint baseZoom, std::unordered
 		p2 = *it;
 
 		// Calculate p2 tile, and mark it
-		double p2y = std::min(MaxLat, std::max(MinLat, p2.y()));
+		double p2y = std::min(MaxLatp, std::max(MinLatp, p2.y()));
 		double tileXf2 = lon2tilexf(p2.x(), baseZoom), tileYf2 = latp2tileyf(p2y, baseZoom);
 		TileCoordinate tileX2 = static_cast<TileCoordinate>(tileXf2), tileY2 = static_cast<TileCoordinate>(tileYf2);
 		tileSet.insert(TileCoordinates(tileX2, tileY2));
 		if (it == points.begin()) continue;	// first point, so no line
 
 		// Calculate p1 tile
-		double p1y = std::min(MaxLat, std::max(MinLat, p1.y()));
+		double p1y = std::min(MaxLatp, std::max(MinLatp, p1.y()));
 		double tileXf1 = lon2tilexf(p1.x(), baseZoom), tileYf1 = latp2tileyf(p1y, baseZoom);
 		TileCoordinate tileX1 = static_cast<TileCoordinate>(tileXf1), tileY1 = static_cast<TileCoordinate>(tileYf1);
 		tileSet.insert(TileCoordinates(tileX1,tileY1));


### PR DESCRIPTION
Geometries outside web Mercator's standard boundaries could cause an integer underflow when calculating tile bounds, resulting in an implausibly large set of tiles and an out-of-memory error.

This PR clamps the Y coordinates to those which produce acceptable projected web Mercator. Fixes #921.