### PR TITLE
Fix confirmed memory and frontend resource leaks

### DIFF
--- a/include/attribute_store.h
+++ b/include/attribute_store.h
@@ -167,7 +167,7 @@ struct AttributePair {
 		else if(hasBoolValue())
 			boost::hash_combine(rv, boolValue());
 		else {
-			throw new std::out_of_range("cannot hash pair, unknown value");
+			throw std::out_of_range("cannot hash pair, unknown value");
 		}
 
 		return rv;

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -2,7 +2,9 @@
 #ifndef _HELPERS_H
 #define _HELPERS_H
 
+#include <cstdio>
 #include <cstdint>
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -41,6 +43,16 @@ struct OffsetAndLength {
 	uint64_t length;
 };
 
+struct FileCloser {
+	void operator()(FILE* fp) const {
+		if (fp != nullptr)
+			fclose(fp);
+	}
+};
+
+using FilePtr = std::unique_ptr<FILE, FileCloser>;
+
+FilePtr openFile(const std::string &filename, const char *mode);
 uint64_t getFileSize(std::string filename);
 std::vector<OffsetAndLength> getNewlineChunks(const std::string &filename, uint64_t chunks);
 

--- a/include/shp_processor.h
+++ b/include/shp_processor.h
@@ -38,7 +38,7 @@ private:
 	void fillPointArrayFromShapefile(std::vector<Point> *points, SHPObject *shape, uint part);
 
 	// Read requested attributes from a shapefile, and encode into an OutputObject
-	AttributeIndex readShapefileAttributes(DBFHandle &dbf, int recordNum, 
+	AttributeIndex readShapefileAttributes(DBFHandle dbf, int recordNum,
 	                                       std::unordered_map<int,std::string> &columnMap,
 	                                       std::unordered_map<int,int> &columnTypeMap,
 	                                       LayerDef &layer, uint &minzoom);
@@ -49,4 +49,3 @@ private:
 };
 
 #endif //_SHP_PROCESSOR_H
-

--- a/src/geojson_processor.cpp
+++ b/src/geojson_processor.cpp
@@ -3,6 +3,7 @@
 #include "helpers.h"
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/post.hpp>
+#include <exception>
 
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -24,25 +25,34 @@ void GeoJSONProcessor::read(class LayerDef &layer, uint layerNum) {
 void GeoJSONProcessor::readFeatureCollection(class LayerDef &layer, uint layerNum) {
 	// Read a JSON file containing a single GeoJSON FeatureCollection object.
 	rapidjson::Document doc;
-	FILE* fp = fopen(layer.source.c_str(), "r");
+	FilePtr fp = openFile(layer.source, "r");
 	char readBuffer[65536];
-	rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
+	rapidjson::FileReadStream is(fp.get(), readBuffer, sizeof(readBuffer));
 	doc.ParseStream(is);
 	if (doc.HasParseError()) { throw std::runtime_error("Invalid JSON file."); }
-	fclose(fp);
 
 	if (strcmp(doc["type"].GetString(), "FeatureCollection") != 0) { 
 		throw std::runtime_error("Top-level GeoJSON object must be a FeatureCollection.");
 	}
 
 	// Process each feature
+	std::exception_ptr error;
+	std::mutex errorMutex;
 	boost::asio::thread_pool pool(threadNum);
 	for (auto &feature : doc["features"].GetArray()) { 
 		boost::asio::post(pool, [&]() {
-			processFeature(std::move(feature.GetObject()), layer, layerNum);
+			try {
+				processFeature(std::move(feature.GetObject()), layer, layerNum);
+			} catch (...) {
+				std::lock_guard<std::mutex> lock(errorMutex);
+				if (!error)
+					error = std::current_exception();
+			}
 		});
 	}
 	pool.join();
+	if (error)
+		std::rethrow_exception(error);
 }
 
 void GeoJSONProcessor::readFeatureLines(class LayerDef &layer, uint layerNum) {
@@ -50,30 +60,39 @@ void GeoJSONProcessor::readFeatureLines(class LayerDef &layer, uint layerNum) {
 	std::vector<OffsetAndLength> chunks = getNewlineChunks(layer.source, threadNum * 4);
 
 	// Process each feature
+	std::exception_ptr error;
+	std::mutex errorMutex;
 	boost::asio::thread_pool pool(threadNum);
 	for (auto &chunk : chunks) { 
 		boost::asio::post(pool, [&]() {
-			FILE* fp = fopen(layer.source.c_str(), "r");
-			if (fseek(fp, chunk.offset, SEEK_SET) != 0) throw std::runtime_error("unable to seek to " + std::to_string(chunk.offset) + " in " + layer.source);
-			char readBuffer[65536];
-			rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
+			try {
+				FilePtr fp = openFile(layer.source, "r");
+				if (fseek(fp.get(), chunk.offset, SEEK_SET) != 0) throw std::runtime_error("unable to seek to " + std::to_string(chunk.offset) + " in " + layer.source);
+				char readBuffer[65536];
+				rapidjson::FileReadStream is(fp.get(), readBuffer, sizeof(readBuffer));
 
-			// Skip leading whitespace.
-			while(is.Tell() < chunk.length && isspace(is.Peek())) is.Take();
-
-			while(is.Tell() < chunk.length) {
-				auto doc = rapidjson::Document();
-				doc.ParseStream<rapidjson::kParseStopWhenDoneFlag>(is);
-				if (doc.HasParseError()) { throw std::runtime_error("Invalid JSON file."); }
-				processFeature(std::move(doc.GetObject()), layer, layerNum);
-
-				// Skip trailing whitespace.
+				// Skip leading whitespace.
 				while(is.Tell() < chunk.length && isspace(is.Peek())) is.Take();
+
+				while(is.Tell() < chunk.length) {
+					auto doc = rapidjson::Document();
+					doc.ParseStream<rapidjson::kParseStopWhenDoneFlag>(is);
+					if (doc.HasParseError()) { throw std::runtime_error("Invalid JSON file."); }
+					processFeature(std::move(doc.GetObject()), layer, layerNum);
+
+					// Skip trailing whitespace.
+					while(is.Tell() < chunk.length && isspace(is.Peek())) is.Take();
+				}
+			} catch (...) {
+				std::lock_guard<std::mutex> lock(errorMutex);
+				if (!error)
+					error = std::current_exception();
 			}
-			fclose(fp);
 		});
 	}
 	pool.join();
+	if (error)
+		std::rethrow_exception(error);
 }
 
 template <bool Flag, typename T>

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -203,6 +203,13 @@ uint64_t getFileSize(std::string filename) {
 	throw std::runtime_error("unable to stat " + filename);
 }
 
+FilePtr openFile(const std::string &filename, const char *mode) {
+	FilePtr fp(fopen(filename.c_str(), mode));
+	if (fp == nullptr)
+		throw std::runtime_error("unable to open " + filename);
+	return fp;
+}
+
 // Given a file, attempt to divide it into N chunks, with each chunk separated
 // by a newline.
 //
@@ -212,7 +219,7 @@ std::vector<OffsetAndLength> getNewlineChunks(const std::string &filename, uint6
 
 	const uint64_t size = getFileSize(filename);
 	const uint64_t chunkSize = std::max<uint64_t>(size / chunks, 1ul);
-	FILE* fp = fopen(filename.c_str(), "r");
+	FilePtr fp = openFile(filename, "r");
 
 	// Our approach is naive: skip chunkSize bytes, scan for a newline, repeat.
 	//
@@ -226,12 +233,12 @@ std::vector<OffsetAndLength> getNewlineChunks(const std::string &filename, uint6
 		// The last chunk will not be a full `chunkSize`.
 		length = std::min(chunkSize, size - offset);
 
-		if (fseek(fp, offset + length, SEEK_SET) != 0) throw std::runtime_error("unable to seek to " + std::to_string(offset) + " in " + filename);
+		if (fseek(fp.get(), offset + length, SEEK_SET) != 0) throw std::runtime_error("unable to seek to " + std::to_string(offset) + " in " + filename);
 
 		bool foundNewline = false;
 
 		while(!foundNewline) {
-			size_t read = fread(buffer, 1, sizeof(buffer), fp);
+			size_t read = fread(buffer, 1, sizeof(buffer), fp.get());
 			if (read == 0) break;
 			for (int i = 0; i < read; i++) {
 				if (buffer[i] == '\n') {
@@ -248,6 +255,5 @@ std::vector<OffsetAndLength> getNewlineChunks(const std::string &filename, uint6
 		offset += length;
 	}
 
-	fclose(fp);
 	return rv;
 }

--- a/src/pooled_string.cpp
+++ b/src/pooled_string.cpp
@@ -2,10 +2,18 @@
 #include <stdexcept>
 #include <mutex>
 #include <cstring>
+#include <cstdlib>
 #include <deque>
+#include <memory>
 
 namespace PooledStringNS {
-	std::deque<char*> tables;
+	struct TableDeleter {
+		void operator()(char* table) const {
+			std::free(table);
+		}
+	};
+
+	std::deque<std::unique_ptr<char, TableDeleter>> tables;
 	std::mutex mutex;
 
 	const uint8_t ShortString = 0b00;
@@ -33,10 +41,10 @@ PooledString::PooledString(const std::string& str) {
 		if (spaceLeft < 0 || spaceLeft < str.size()) {
 			std::lock_guard<std::mutex> lock(mutex);
 			spaceLeft = 65536;
-			char* buffer = (char*)malloc(spaceLeft);
-			if (buffer == 0)
+			std::unique_ptr<char, TableDeleter> buffer(static_cast<char*>(std::malloc(spaceLeft)));
+			if (!buffer)
 				throw std::runtime_error("PooledString could not malloc");
-			tables.push_back(buffer);
+			tables.emplace_back(std::move(buffer));
 			tableIndex = tables.size() - 1;
 		}
 
@@ -52,7 +60,7 @@ PooledString::PooledString(const std::string& str) {
 		storage[6] = length >> 8;
 		storage[7] = length;
 
-		memcpy(tables[tableIndex] + offset, str.data(), str.size());
+		memcpy(tables[tableIndex].get() + offset, str.data(), str.size());
 
 		spaceLeft -= str.size();
 	}
@@ -106,7 +114,7 @@ const char* PooledStringNS::PooledString::data() const {
 	uint32_t tableIndex = (storage[1] << 16) + (storage[2] << 8) + storage[3];
 	uint16_t offset = (storage[4] << 8) + storage[5];
 
-	const char* data = tables[tableIndex] + offset;
+	const char* data = tables[tableIndex].get() + offset;
 	return data;
 }
 
@@ -136,7 +144,7 @@ std::string PooledStringNS::PooledString::toString() const {
 		uint32_t tableIndex = (storage[1] << 16) + (storage[2] << 8) + storage[3];
 		uint16_t offset = (storage[4] << 8) + storage[5];
 
-		char* data = tables[tableIndex] + offset;
+		char* data = tables[tableIndex].get() + offset;
 		rv.append(data, size());
 		return rv;
 	}
@@ -169,4 +177,3 @@ bool PooledStringNS::PooledString::operator<(const PooledString& other) const {
 
 	return memcmp(data(), other.data(), mySize) < 0;
 }
-

--- a/src/shp_processor.cpp
+++ b/src/shp_processor.cpp
@@ -2,11 +2,31 @@
 
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/post.hpp>
+#include <exception>
+#include <memory>
+#include <type_traits>
 
 extern bool verbose;
 
 using namespace std;
 namespace geom = boost::geometry;
+
+namespace {
+	struct ShpHandleCloser {
+		void operator()(SHPHandle shp) const {
+			SHPClose(shp);
+		}
+	};
+
+	struct DbfHandleCloser {
+		void operator()(DBFHandle dbf) const {
+			DBFClose(dbf);
+		}
+	};
+
+	using ShpHandlePtr = std::unique_ptr<std::remove_pointer<SHPHandle>::type, ShpHandleCloser>;
+	using DbfHandlePtr = std::unique_ptr<std::remove_pointer<DBFHandle>::type, DbfHandleCloser>;
+}
 
 /*
 	Read shapefiles into Boost geometries
@@ -36,7 +56,7 @@ void ShpProcessor::fillPointArrayFromShapefile(vector<Point> *points, SHPObject 
 // Read requested attributes from a shapefile, and encode into an OutputObject
 // columnTypeMap: 0 string, 1 int, 2 double, 3 boolean
 AttributeIndex ShpProcessor::readShapefileAttributes(
-		DBFHandle &dbf,
+		DBFHandle dbf,
 		int recordNum, unordered_map<int,string> &columnMap, unordered_map<int,int> &columnTypeMap,
 		LayerDef &layer, uint &minzoom) {
 
@@ -113,39 +133,42 @@ void ShpProcessor::read(class LayerDef &layer, uint layerNum)
 	const string &indexName = layer.indexName;
 
 	// open shapefile
-	SHPHandle shp = SHPOpen(filename.c_str(), "rb");
-	DBFHandle dbf = DBFOpen(filename.c_str(), "rb");
+	ShpHandlePtr shp(SHPOpen(filename.c_str(), "rb"));
+	DbfHandlePtr dbf(DBFOpen(filename.c_str(), "rb"));
 	if(shp == nullptr || dbf == nullptr)
 		return;
 	int numEntities=0, shpType=0;
 	double adfMinBound[4], adfMaxBound[4];
-	SHPGetInfo(shp, &numEntities, &shpType, adfMinBound, adfMaxBound);
+	SHPGetInfo(shp.get(), &numEntities, &shpType, adfMinBound, adfMaxBound);
 	
 	// prepare columns
 	unordered_map<int,string> columnMap;
 	unordered_map<int,int> columnTypeMap;
 	if (layer.allSourceColumns) {
-		for (size_t i=0; i<DBFGetFieldCount(dbf); i++) {
+		for (size_t i=0; i<DBFGetFieldCount(dbf.get()); i++) {
 			char name[12];
-			columnTypeMap[i] = DBFGetFieldInfo(dbf,i,name,NULL,NULL);
+			columnTypeMap[i] = DBFGetFieldInfo(dbf.get(),i,name,NULL,NULL);
 			columnMap[i] = string(name);
 		}
 	} else {
 		for (size_t i=0; i<columns.size(); i++) {
-			int dbfLoc = DBFGetFieldIndex(dbf,columns[i].c_str());
+			int dbfLoc = DBFGetFieldIndex(dbf.get(),columns[i].c_str());
 			if (dbfLoc>-1) { 
 				columnMap[dbfLoc]=columns[i];
-				columnTypeMap[dbfLoc]=DBFGetFieldInfo(dbf,dbfLoc,NULL,NULL,NULL);
+				columnTypeMap[dbfLoc]=DBFGetFieldInfo(dbf.get(),dbfLoc,NULL,NULL,NULL);
 			}
 		}
 	}
 	int indexField=-1;
-	if (indexName!="") { indexField = DBFGetFieldIndex(dbf,indexName.c_str()); }
+	if (indexName!="") { indexField = DBFGetFieldIndex(dbf.get(),indexName.c_str()); }
 
+	std::exception_ptr error;
+	std::mutex errorMutex;
 	boost::asio::thread_pool pool(threadNum);
 	for (int i=0; i<numEntities; i++) {
-		SHPObject* shape = SHPReadObject(shp, i);
-		if(shape == nullptr) { cerr << "Error loading shape from shapefile" << endl; continue; }
+		SHPObject* rawShape = SHPReadObject(shp.get(), i);
+		if(rawShape == nullptr) { cerr << "Error loading shape from shapefile" << endl; continue; }
+		std::shared_ptr<SHPObject> shape(rawShape, SHPDestroyObject);
 
 		// Check shape is in clippingBox
 		Box shapeBox(Point(shape->dfXMin, lat2latp(shape->dfYMin)), Point(shape->dfXMax, lat2latp(shape->dfYMax)));
@@ -153,27 +176,31 @@ void ShpProcessor::read(class LayerDef &layer, uint layerNum)
 		    shapeBox.max_corner().get<0>() < clippingBox.min_corner().get<0>() ||
 		    shapeBox.min_corner().get<1>() > clippingBox.max_corner().get<1>() ||
 		    shapeBox.max_corner().get<1>() < clippingBox.min_corner().get<1>()) {
-			SHPDestroyObject(shape);
 			continue;
 		}
 
 		boost::asio::post(pool, [&, i, shape]() {
-			// process attributes
-			string name;
-			bool hasName = false;
-			if (indexField>-1) { 
-				std::lock_guard<std::mutex> lock(attributeMutex);
-				name=DBFReadStringAttribute(dbf, i, indexField); hasName = true;
+			try {
+				// process attributes
+				string name;
+				bool hasName = false;
+				if (indexField>-1) {
+					std::lock_guard<std::mutex> lock(attributeMutex);
+					name=DBFReadStringAttribute(dbf.get(), i, indexField); hasName = true;
+				}
+				AttributeIndex attrIdx = readShapefileAttributes(dbf.get(), i, columnMap, columnTypeMap, layer, layer.minzoom);
+				// process geometry
+				processShapeGeometry(shape.get(), attrIdx, layer, layerNum, hasName, name);
+			} catch (...) {
+				std::lock_guard<std::mutex> lock(errorMutex);
+				if (!error)
+					error = std::current_exception();
 			}
-			AttributeIndex attrIdx = readShapefileAttributes(dbf, i, columnMap, columnTypeMap, layer, layer.minzoom);
-			// process geometry
-			processShapeGeometry(shape, attrIdx, layer, layerNum, hasName, name);
-			SHPDestroyObject(shape);
 		});
 	}
 	pool.join();
-	SHPClose(shp);
-	DBFClose(dbf);
+	if (error)
+		std::rethrow_exception(error);
 }
 
 void ShpProcessor::processShapeGeometry(SHPObject* shape, AttributeIndex attrIdx,

--- a/src/tilemaker.cpp
+++ b/src/tilemaker.cpp
@@ -169,12 +169,11 @@ int main(const int argc, const char* argv[]) {
 	rapidjson::Document jsonConfig;
 	class Config config;
 	try {
-		FILE* fp = fopen(options.jsonFile.c_str(), "r");
+		FilePtr fp = openFile(options.jsonFile, "r");
 		char readBuffer[65536];
-		rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
+		rapidjson::FileReadStream is(fp.get(), readBuffer, sizeof(readBuffer));
 		jsonConfig.ParseStream(is);
 		if (jsonConfig.HasParseError()) { cerr << "Invalid JSON file." << endl; return -1; }
-		fclose(fp);
 
 		config.readConfig(jsonConfig, hasClippingBox, clippingBox);
 	} catch (...) {
@@ -272,12 +271,22 @@ int main(const int argc, const char* argv[]) {
 				if (!hasClippingBox) {
 					cerr << "Can't read shapefiles unless a bounding box is provided." << endl;
 					exit(EXIT_FAILURE);
-				} else if (ends_with(layer.source, "json") || ends_with(layer.source, "jsonl") || ends_with(layer.source, "JSON") || ends_with(layer.source, "JSONL") || ends_with(layer.source, "jsonseq") || ends_with(layer.source, "JSONSEQ")) {
-					cout << "Reading GeoJSON " << layer.name << endl;
-					geoJSONProcessor.read(layers.layers[layerNum], layerNum);
 				} else {
-					cout << "Reading shapefile " << layer.name << endl;
-					shpProcessor.read(layers.layers[layerNum], layerNum);
+					try {
+						if (ends_with(layer.source, "json") || ends_with(layer.source, "jsonl") || ends_with(layer.source, "JSON") || ends_with(layer.source, "JSONL") || ends_with(layer.source, "jsonseq") || ends_with(layer.source, "JSONSEQ")) {
+							cout << "Reading GeoJSON " << layer.name << endl;
+							geoJSONProcessor.read(layers.layers[layerNum], layerNum);
+						} else {
+							cout << "Reading shapefile " << layer.name << endl;
+							shpProcessor.read(layers.layers[layerNum], layerNum);
+						}
+					} catch (const std::exception& e) {
+						cerr << "Error reading external source " << layer.source << ": " << e.what() << endl;
+						return -1;
+					} catch (...) {
+						cerr << "Unknown error reading external source " << layer.source << endl;
+						return -1;
+					}
 				}
 			}
 		}
@@ -564,4 +573,3 @@ int main(const int argc, const char* argv[]) {
 
 	cout << endl << "Filled the tileset with good things at " << sharedData.outputFile << endl;
 }
-

--- a/test/attribute_store.test.cpp
+++ b/test/attribute_store.test.cpp
@@ -122,7 +122,7 @@ MU_TEST(test_attribute_store_capacity) {
 
 	try {
 		keys.key2index("key512");
-	} catch (std::out_of_range) {
+	} catch (const std::out_of_range&) {
 		caughtException = true;
 	}
 

--- a/test/helpers.test.cpp
+++ b/test/helpers.test.cpp
@@ -1,6 +1,21 @@
 #include <iostream>
+#include <stdexcept>
 #include "external/minunit.h"
 #include "helpers.h"
+
+MU_TEST(test_open_file) {
+	FilePtr fp = openFile("test/test.jsonl", "r");
+	mu_check(fp != nullptr);
+	mu_check(fgetc(fp.get()) == '{');
+
+	bool caughtException = false;
+	try {
+		openFile("test/this-file-does-not-exist", "r");
+	} catch (const std::runtime_error&) {
+		caughtException = true;
+	}
+	mu_check(caughtException);
+}
 
 MU_TEST(test_get_chunks) {
 	{
@@ -83,6 +98,7 @@ MU_TEST(test_compression_zlib) {
 
 
 MU_TEST_SUITE(test_suite_helpers) {
+	MU_RUN_TEST(test_open_file);
 	MU_RUN_TEST(test_get_chunks);
 	MU_RUN_TEST(test_compression_gzip);
 	MU_RUN_TEST(test_compression_zlib);

--- a/test/pooled_string.test.cpp
+++ b/test/pooled_string.test.cpp
@@ -1,4 +1,8 @@
 #include <iostream>
+#include <atomic>
+#include <stdexcept>
+#include <thread>
+#include <vector>
 #include "external/minunit.h"
 #include "pooled_string.h"
 
@@ -46,8 +50,89 @@ MU_TEST(test_pooled_string) {
 	mu_check(stdShortString != stdLongString);
 }
 
+MU_TEST(test_pooled_string_boundaries) {
+	const std::string shortBoundary(15, 'a');
+	const std::string pooledBoundary(16, 'b');
+	const std::string largest(65535, 'c');
+
+	PooledString shortString(shortBoundary);
+	PooledString pooledString(pooledBoundary);
+	PooledString largestString(largest);
+
+	mu_check(shortString.size() == shortBoundary.size());
+	mu_check(shortString.toString() == shortBoundary);
+	mu_check(pooledString.size() == pooledBoundary.size());
+	mu_check(pooledString.toString() == pooledBoundary);
+	mu_check(largestString.size() == largest.size());
+	mu_check(largestString.toString() == largest);
+
+	bool caughtException = false;
+	try {
+		PooledString tooLarge(std::string(65536, 'd'));
+	} catch (const std::runtime_error&) {
+		caughtException = true;
+	}
+	mu_check(caughtException);
+
+	// The largest string leaves a one-byte tail. Allocating another pooled
+	// string must not invalidate the preceding table.
+	PooledString nextTable(std::string(16, 'e'));
+	mu_check(largestString.toString() == largest);
+	mu_check(nextTable.toString() == std::string(16, 'e'));
+}
+
+MU_TEST(test_pooled_string_multiple_tables) {
+	std::vector<std::string> originals;
+	std::vector<PooledString> pooled;
+	for (int i = 0; i < 2048; i++) {
+		originals.emplace_back("pooled string " + std::to_string(i) +
+		                       std::string(48, char('a' + i % 26)));
+		pooled.emplace_back(originals.back());
+	}
+
+	for (size_t i = 0; i < pooled.size(); i++)
+		mu_check(pooled[i].toString() == originals[i]);
+}
+
+MU_TEST(test_pooled_string_threaded) {
+	const int threadCount = 8;
+	const int stringsPerThread = 256;
+	std::atomic<bool> start(false);
+	std::atomic<bool> failed(false);
+	std::vector<std::thread> threads;
+
+	for (int thread = 0; thread < threadCount; thread++) {
+		threads.emplace_back([&, thread]() {
+			std::vector<std::string> originals;
+			std::vector<PooledString> pooled;
+			for (int i = 0; i < stringsPerThread; i++)
+				originals.emplace_back("thread " + std::to_string(thread) +
+				                       " string " + std::to_string(i) +
+				                       std::string(48, char('a' + thread)));
+
+			while (!start.load(std::memory_order_acquire)) {}
+			for (const std::string& value : originals)
+				pooled.emplace_back(value);
+
+			for (size_t i = 0; i < pooled.size(); i++) {
+				if (pooled[i].toString() != originals[i])
+					failed.store(true, std::memory_order_release);
+			}
+		});
+	}
+
+	start.store(true, std::memory_order_release);
+	for (std::thread& thread : threads)
+		thread.join();
+
+	mu_check(failed.load(std::memory_order_acquire) == false);
+}
+
 MU_TEST_SUITE(test_suite_pooled_string) {
 	MU_RUN_TEST(test_pooled_string);
+	MU_RUN_TEST(test_pooled_string_boundaries);
+	MU_RUN_TEST(test_pooled_string_multiple_tables);
+	MU_RUN_TEST(test_pooled_string_threaded);
 }
 
 int main() {


### PR DESCRIPTION
## Problem

Valgrind reports every 64 KiB `PooledString` slab as definitely lost at exit.
The sampled Monaco run loses 196,608 bytes in three blocks. Several frontend
error paths also leave `FILE*`, SHP/DBF handles, or admitted `SHPObject`s without
an exception-safe owner. Worker exceptions can escape Asio handlers and call
`terminate`, preventing scoped cleanup and obscuring the source of the error.

`AttributePair::hash()` also throws a heap-allocated exception pointer, which
would leak and bypass ordinary `std::out_of_range` catches.

## Changes

- Own stable `PooledString` slabs with `unique_ptr` plus a `free` deleter,
  preserving table indexes, stored pointers, and string equality semantics.
- Throw `std::out_of_range` by value.
- Add scoped `FILE*` ownership for main config, GeoJSON/JSONL, and newline-chunk
  parsing, including a checked open with a local error.
- Own SHP and DBF handles independently so half-open pairs are cleaned up.
- Keep each posted `SHPObject` under shared exception-safe ownership compatible
  with the supported Boost/Asio handler requirements.
- Capture worker exceptions, join the pool, and report them from the main
  thread so cleanup runs and the failing external source is identified.
- Extend `PooledString` coverage across inline/pooled and maximum-length
  boundaries, multiple slabs, and concurrent allocation.

## Validation

- `make test` (C++14): all 13 test targets pass.
- CMake RelWithDebInfo (C++17), parallel 8: passes.
- Windows VS 2022/MSVC 19.44 RelWithDebInfo with vcpkg
  `x64-windows-static-md`, static dependencies, parallel 8: both executables
  link; `tilemaker.exe --help` passes.
- `git diff --check`: passes on Linux and Windows.

Matched Monaco Memcheck (`--threads 1`, PMTiles, example profile, no store):

| | Upstream | This branch |
|---|---:|---:|
| Allocations / frees | 563,412 / 563,409 | 563,407 / 563,407 |
| Bytes in use at exit | 196,608 | 0 |
| Definitely lost | 196,608 B / 3 blocks | 0 |
| Errors | 3 | 0 |

The generated PMTiles files are byte-identical.

Targeted `--track-fds=yes` checks also go clean for:

- invalid main config (previously one open descriptor and 472 reachable bytes);
- invalid GeoJSON (previously aborting with the source descriptor open);
- an SHP/DBF half-pair (previously one open descriptor, 248 definitely lost
  bytes, and 1,272 indirectly lost bytes).

## Scope

This intentionally does not reuse partially filled TLS string tails, bound SHP
or output queues, change mmap arenas, or alter geometry/cache storage. Those are
separate peak-memory changes with different concurrency and performance risks.
The direct invalid `AttributePairType` branch is not constructible through its
two-bit field without adding a test-only production hook, so the throw-by-value
change is covered by source review and both compiler modes.
