### PR TITLE
Skip empty multipolygons in union_many() to avoid invalid R-tree box

### DIFF
--- a/src/geom.cpp
+++ b/src/geom.cpp
@@ -250,6 +250,7 @@ void union_many(std::vector<MultiPolygon> &to_unify) {
 	// whose bboxes intersect (transitivity is handled by union-find)
 	bgi::rtree<BoxIdx, bgi::quadratic<16>> rtree;
 	for (size_t i = 0; i < to_unify.size(); i++) {
+		if (boost::geometry::is_empty(to_unify[i])) continue;
 		for (auto const &v : rtree | bgi::adaptors::queried(bgi::intersects(boxes[i]))) {
 			size_t ri = find(i), rj = find(v.second);
 			if (ri != rj) parent[ri] = rj;


### PR DESCRIPTION
Generating planet tiles crashes during the mbtile write phase with a
Boost.Geometry assertion:

boost/geometry/index/rtree.hpp:1661:
Assertion `(detail::is_valid(m_members.translator()(value)))
&& ("Indexable is invalid")' failed.
Aborted

### Environment
Debian 13.6
libboost-dev 1.83.0.2+b2
git pull master to update my version with the commits of the last 3 months
make clean
make => NDEBUG not set so an assert causes abort() which results in the crash (while with NDEBUG this error is silently ignored)
planet dump of this week (Aug. 27), problematic tile extract attached


### Cause

`boost::geometry::envelope()` of an *empty* multipolygon returns Boost's inverse
initialisation box — `min = +DBL_MAX`, `max = -DBL_MAX` — which fails
the indexable validity check on insert.

Clipping a polygon against a tile boundary can legitimately produce an
empty result, so `ProcessObjects()` (tile_worker.cpp:402) can hand
`union_many()` a vector containing empty entries.

Backtrace at the point of failure:

#4 ...rtree<...>::raw_insert (...) at boost/geometry/index/rtree.hpp:1661
#6 union_many (to_unify=std::vector of length 2) at src/geom.cpp:257
#7 ProcessObjects (...) at src/tile_worker.cpp:402
#8 ProcessLayer (..., zoom=13, ...) at src/tile_worker.cpp:496


with `to_unify[0].empty() == true` and the box printing as
`±1.7976931348623157e+308`.

### Fix

Skip empty multipolygons before the R-tree query and insert. An empty
multipolygon cannot intersect anything and contributes nothing to the
union, so skipping it is semantically correct rather than just
silencing the assertion.

### Why this matters for release builds

Builds that define `NDEBUG` — including CMake `Release` and most
distribution packages — compile the assertion out. They do not abort,
but they do store the invalid box in the R-tree, which makes
subsequent `intersects()` queries unreliable for that tile. Polygons
may then be merged that should not be, or vice versa. The result is
silently incorrect output rather than a crash.

The Makefile build does not define `NDEBUG`, which is why the problem
surfaces there.

### Reproduction

Planet dump, z13 within `z6/0/14` (north-west Alaska). A cut-down
extract is enough (attached)

```bash
osmium extract -b -180,67.5,-172,71.5 planet-latest.osm.pbf -o problem.osm.pbf
tilemaker --input problem.osm.pbf --output problem.mbtiles \
  --config config.json --process process.lua
```
