### PR TITLE
Fix residential area filtering by size

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -742,8 +742,8 @@ function way_function()
 			Layer("landuse", true)
 			Attribute("class", l)
 			if l=="residential" then
-				if Area()<ZRES8^2 then MinZoom(8)
-				else SetMinZoomByArea() end
+				if Area()>ZRES6^2 then SetMinZoomByArea()
+				else MinZoom(8) end
 			else MinZoom(11) end
 			write_name = true
 		end


### PR DESCRIPTION
The intent was to display all residential areas at zoom level 8 but features that SetMinZoomByArea puts into zoom level 9 were not displayed because of the wrong constant used for the comparison. An area slightly larger than ZRES7^2 results in zoom level 8. Only area>ZRES6^2 results in a zoom level smaller than 8.

https://github.com/systemed/tilemaker/blob/facdf933f4f5ac2944a9d65c27970270583d68fa/resources/process-openmaptiles.lua#L887-L889